### PR TITLE
Add .cargo/config defining the build target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# Instruction set of Cortex-M0+
+target = "thumbv6m-none-eabi"


### PR DESCRIPTION
Add `.cargo/config` defining the build target so that you can build with simply `cargo build`.