### PR TITLE
Implement a wrapper for the xosc peripheral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+target/
 Cargo.lock

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -12,5 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cortex-m = "0.7.1"
 embedded-hal = "0.2.4"
+embedded-time = "0.10.1"
 nb = "1.0.0"
+num = { version = "0.3.0", default-features = false }
 rp2040-pac = "0.1.1"

--- a/rp2040-hal/src/clocks/generators.rs
+++ b/rp2040-hal/src/clocks/generators.rs
@@ -1,18 +1,46 @@
+//! The clocks block, containing all clock generators
+
 use pac::CLOCKS;
 use sharing::SharedClocksBlock;
 
+/// Split up of the clocks block
+///
+/// This allows to use the different clock generators and devices independently.
 pub struct SplitClocks {
+    /// Clock output to GPIO 0
     pub gp_out0: ClkGPOut0,
+
+    /// Clock output to GPIO 1
     pub gp_out1: ClkGPOut1,
+
+    /// Clock output to GPIO 2
     pub gp_out2: ClkGPOut2,
+
+    /// Clock output to GPIO 3
     pub gp_out3: ClkGPOut3,
+
+    /// Clock output to UART and SPI
     pub peri: ClkPeri,
+
+    /// Clock output to USB
     pub usb: ClkUsb,
+
+    /// Clock output to ADC
     pub adc: ClkAdc,
+
+    /// Clock output to RTC
     pub rtc: ClkRtc,
+
+    /// Frequency counter (see Type description for details)
     pub frq_cnt: FrequencyCounter,
+
+    /// Resus (see Type description for details)
     pub resus: Resus,
+
+    /// Clock gates (see Type description for details)
     pub gates: ClkGates,
+
+    /// Register block handle (see Type description for details)
     pub _dev: ClockHandle,
 }
 
@@ -59,34 +87,53 @@ impl SplitClocks {
     }
 
     /// Return the PAC register block
+    ///
+    /// Since this function can only be called with a complete set of parts it should be save to
+    /// get the register block back.
     pub fn free(self) -> CLOCKS {
-        // Safety: free() can only be called if all parts have been placed back thus we can release
-        //         the device
         self._dev._private
     }
 }
 
+/// Clock gates used to enable or disable peripherals. See section 2.15.3.5 of the datasheet.
+#[allow(dead_code)] // ToDo: Implement clock gating
 pub struct ClkGates {
     share: SharedClocksBlock,
 }
 
+/// See section 2.15.4 of the datasheet
+#[allow(dead_code)] // ToDo: Implement frequency counting
 pub struct FrequencyCounter {
     share: SharedClocksBlock,
 }
 
+/// See section 2.15.5 of the datasheet
+#[allow(dead_code)] // ToDo: Implement resus device
 pub struct Resus {
     share: SharedClocksBlock,
 }
 
+/// Helper struct to hold the register block so it could be freed again. Does not give any
+/// access to anything, since that should only be possible via the different structs like
+/// `ClkGates`, `ClkSys` or `FrequencyCounter`.
 pub struct ClockHandle {
     _private: CLOCKS,
 }
 
+/// A generator that can be switched only glitching
+///
+/// Provides the method provided in the datasheet to switch glitchless even with these generators.
 pub trait GlitchingClockSwitch<Src> {
+    /// Disable the clock source cleanly
     fn disable(&mut self);
+
+    /// Enable the clock source cleanly
     fn enable(&mut self);
+
+    /// Select the AUX source (glitching allowed)
     fn set_aux_src(&mut self, src: Src);
 
+    /// Switch the clock according to the datasheet, avoiding glitches
     fn switch_glitchless(&mut self, src: Src) {
         self.disable();
 
@@ -99,13 +146,15 @@ pub trait GlitchingClockSwitch<Src> {
     }
 }
 
+/// Parameters for a fractional clock divisor. See datasheet section 2.15.3.3 for details.
 pub struct FractionalDivisor {
     int: u32,
     frac: u8,
 }
 
 impl FractionalDivisor {
-    pub fn new(int: u32, frac: u8) -> Option<Self> {
+    /// Create a new divisor, making sure the integral part fits into the register.
+    pub const fn new(int: u32, frac: u8) -> Option<Self> {
         if int > 0x00_ff_ff_ff {
             return None;
         }
@@ -114,23 +163,35 @@ impl FractionalDivisor {
     }
 }
 
+/// A clock source that can be divided with a fractional value
 pub trait FractionalDiv {
+    /// Get current divider value
     fn div(&self) -> FractionalDivisor;
+    /// Set divider
     fn set_div(&mut self, div: FractionalDivisor);
 }
 
+/// A clock source with an integer divider
 pub trait IntDiv {
+    /// Get current divider value
     fn div(&self) -> u8;
+    /// Set divider
     fn set_div(&mut self, div: u8);
 }
 
+/// A clock generator that has duty cycle correction. See section 2.15.3.4 for details
 pub trait DutyCycleCorrect {
+    /// Returns `true` if the correction is active.
     fn dc50(&self) -> bool;
+    /// Set the correction (`true` => enabled)
     fn set_dc50(&mut self, correct: bool);
 }
 
 macro_rules! clock_generator {
     ($name:ident, $ctrl:ident) => {
+        /// Clock generator for $name
+        ///
+        /// ToDo: Find a good way to add doc comments for all the generators
         pub struct $name {
             share: SharedClocksBlock,
         }

--- a/rp2040-hal/src/clocks/generators.rs
+++ b/rp2040-hal/src/clocks/generators.rs
@@ -1,0 +1,251 @@
+use pac::CLOCKS;
+use sharing::SharedClocksBlock;
+
+pub struct SplitClocks {
+    pub gp_out0: ClkGPOut0,
+    pub gp_out1: ClkGPOut1,
+    pub gp_out2: ClkGPOut2,
+    pub gp_out3: ClkGPOut3,
+    pub peri: ClkPeri,
+    pub usb: ClkUsb,
+    pub adc: ClkAdc,
+    pub rtc: ClkRtc,
+    pub frq_cnt: FrequencyCounter,
+    pub resus: Resus,
+    pub gates: ClkGates,
+    pub _dev: ClockHandle,
+}
+
+impl SplitClocks {
+    /// Split the clocks block into its parts
+    pub fn split(mut dev: CLOCKS) -> Self {
+        let share = SharedClocksBlock::new(&mut dev);
+        SplitClocks {
+            gp_out0: ClkGPOut0 {
+                share: share.copy(),
+            },
+            gp_out1: ClkGPOut1 {
+                share: share.copy(),
+            },
+            gp_out2: ClkGPOut2 {
+                share: share.copy(),
+            },
+            gp_out3: ClkGPOut3 {
+                share: share.copy(),
+            },
+            peri: ClkPeri {
+                share: share.copy(),
+            },
+            usb: ClkUsb {
+                share: share.copy(),
+            },
+            adc: ClkAdc {
+                share: share.copy(),
+            },
+            rtc: ClkRtc {
+                share: share.copy(),
+            },
+            frq_cnt: FrequencyCounter {
+                share: share.copy(),
+            },
+            resus: Resus {
+                share: share.copy(),
+            },
+            gates: ClkGates {
+                share: share.copy(),
+            },
+            _dev: ClockHandle { _private: dev },
+        }
+    }
+
+    /// Return the PAC register block
+    pub fn free(self) -> CLOCKS {
+        // Safety: free() can only be called if all parts have been placed back thus we can release
+        //         the device
+        self._dev._private
+    }
+}
+
+pub struct ClkGates {
+    share: SharedClocksBlock,
+}
+
+pub struct FrequencyCounter {
+    share: SharedClocksBlock,
+}
+
+pub struct Resus {
+    share: SharedClocksBlock,
+}
+
+pub struct ClockHandle {
+    _private: CLOCKS,
+}
+
+pub trait GlitchingClockSwitch<Src> {
+    fn disable(&mut self);
+    fn enable(&mut self);
+    fn set_aux_src(&mut self, src: Src);
+
+    fn switch_glitchless(&mut self, src: Src) {
+        self.disable();
+
+        // ToDo: Wait 2 cycles
+
+        self.set_aux_src(src);
+        self.enable();
+
+        // ToDo: Wait 2 cycles
+    }
+}
+
+pub struct FractionalDivisor {
+    int: u32,
+    frac: u8,
+}
+
+impl FractionalDivisor {
+    pub fn new(int: u32, frac: u8) -> Option<Self> {
+        if int > 0x00_ff_ff_ff {
+            return None;
+        }
+
+        Some(FractionalDivisor { int, frac })
+    }
+}
+
+pub trait FractionalDiv {
+    fn div(&self) -> FractionalDivisor;
+    fn set_div(&mut self, div: FractionalDivisor);
+}
+
+pub trait IntDiv {
+    fn div(&self) -> u8;
+    fn set_div(&mut self, div: u8);
+}
+
+pub trait DutyCycleCorrect {
+    fn dc50(&self) -> bool;
+    fn set_dc50(&mut self, correct: bool);
+}
+
+macro_rules! clock_generator {
+    ($name:ident, $ctrl:ident) => {
+        pub struct $name {
+            share: SharedClocksBlock,
+        }
+
+        impl GlitchingClockSwitch<$crate::pac::clocks::$ctrl::AUXSRC_A> for $name {
+            fn disable(&mut self) {
+                unsafe { &self.share.get().$ctrl }.modify(|_, w| w.enable().clear_bit());
+            }
+
+            fn enable(&mut self) {
+                unsafe { &self.share.get().$ctrl }.modify(|_, w| w.enable().set_bit());
+            }
+
+            fn set_aux_src(&mut self, src: $crate::pac::clocks::$ctrl::AUXSRC_A) {
+                unsafe { &self.share.get().$ctrl }.modify(|_, w| w.auxsrc().variant(src));
+            }
+        }
+    };
+}
+
+macro_rules! dc_correct {
+    ($name:ident, $ctrl:ident) => {
+        impl DutyCycleCorrect for $name {
+            fn dc50(&self) -> bool {
+                unsafe { &self.share.get().$ctrl }
+                    .read()
+                    .dc50()
+                    .bit_is_set()
+            }
+
+            fn set_dc50(&mut self, correct: bool) {
+                unsafe { &self.share.get().$ctrl }.modify(|_, w| w.dc50().bit(correct));
+            }
+        }
+    };
+}
+
+macro_rules! frac_div {
+    ($name:ident, $div:ident) => {
+        impl FractionalDiv for $name {
+            fn div(&self) -> FractionalDivisor {
+                let reg = unsafe { &self.share.get().$div }.read();
+                FractionalDivisor {
+                    int: reg.int().bits(),
+                    frac: reg.frac().bits(),
+                }
+            }
+
+            fn set_div(&mut self, div: FractionalDivisor) {
+                unsafe { &self.share.get() }
+                    .$div
+                    .write(|w| unsafe { w.int().bits(div.int).frac().bits(div.frac) });
+            }
+        }
+    };
+}
+
+macro_rules! int_div {
+    ($name:ident, $div:ident) => {
+        impl IntDiv for $name {
+            fn div(&self) -> u8 {
+                unsafe { &self.share.get().$div }.read().int().bits()
+            }
+
+            fn set_div(&mut self, div: u8) {
+                unsafe { &self.share.get() }
+                    .$div
+                    .write(|w| unsafe { w.int().bits(div) });
+            }
+        }
+    };
+}
+
+macro_rules! gp_out {
+    ($name:ident, $ctrl:ident, $div:ident) => {
+        clock_generator! {$name, $ctrl}
+        dc_correct! {$name, $ctrl}
+        frac_div! {$name, $div}
+    };
+}
+
+gp_out! {ClkGPOut0, clk_gpout0_ctrl, clk_gpout0_div}
+gp_out! {ClkGPOut1, clk_gpout1_ctrl, clk_gpout1_div}
+gp_out! {ClkGPOut2, clk_gpout2_ctrl, clk_gpout2_div}
+gp_out! {ClkGPOut3, clk_gpout3_ctrl, clk_gpout3_div}
+
+clock_generator! {ClkPeri, clk_peri_ctrl}
+
+clock_generator! {ClkUsb, clk_usb_ctrl}
+int_div! {ClkUsb, clk_usb_div}
+
+clock_generator! {ClkAdc, clk_adc_ctrl}
+int_div! {ClkAdc, clk_adc_div}
+
+clock_generator! {ClkRtc, clk_rtc_ctrl}
+frac_div! {ClkRtc, clk_rtc_div}
+
+mod sharing {
+    use pac::clocks::RegisterBlock;
+    use pac::CLOCKS;
+
+    pub struct SharedClocksBlock {}
+
+    impl SharedClocksBlock {
+        pub fn new(_dev: &mut CLOCKS) -> SharedClocksBlock {
+            SharedClocksBlock {}
+        }
+
+        /// Safety: Each of the clock generators may only use its matching registers (CLK_*_(CTRL|DIV|SELECTED))
+        pub unsafe fn get(&self) -> &RegisterBlock {
+            &*CLOCKS::ptr()
+        }
+
+        pub fn copy(&self) -> Self {
+            SharedClocksBlock {}
+        }
+    }
+}

--- a/rp2040-hal/src/clocks/generators.rs
+++ b/rp2040-hal/src/clocks/generators.rs
@@ -232,11 +232,13 @@ mod sharing {
     use pac::clocks::RegisterBlock;
     use pac::CLOCKS;
 
-    pub struct SharedClocksBlock {}
+    pub struct SharedClocksBlock {
+        _private: (),
+    }
 
     impl SharedClocksBlock {
         pub fn new(_dev: &mut CLOCKS) -> SharedClocksBlock {
-            SharedClocksBlock {}
+            SharedClocksBlock { _private: () }
         }
 
         /// Safety: Each of the clock generators may only use its matching registers (CLK_*_(CTRL|DIV|SELECTED))
@@ -245,7 +247,7 @@ mod sharing {
         }
 
         pub fn copy(&self) -> Self {
-            SharedClocksBlock {}
+            SharedClocksBlock { _private: () }
         }
     }
 }

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -1,28 +1,98 @@
 //! Clock tree configuration
 //!
 //! # Example
-/// ```rust no_run
-/// use embedded_time::rate::Extensions as _;
-///
-/// use rp2040_pac::Peripherals;
-/// use rp2040_hal::clocks::{XOsc, SplitClocks};
-/// use rp2040_hal::clocks::pll::Pll;
-///
-/// let p = Peripherals::take().unwrap();
-///
-/// // Setup the clock sources
-/// let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap();
-/// let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, &xosc, 125.MHz().into()).unwrap();
-/// let pll_usb = Pll::new_stable_blocking(p.PLL_USB, &xosc, 48.MHz().into()).unwrap();
-///
-/// // Derive the clocks for the different domains
-/// let clocks = SplitClocks::split(p.CLOCKS);
-///
-/// let clk_peri = clocks.peri;
-/// // clk_peri.switch_to(&pll_sys);
-///
-/// // ToDo: Use UART
-/// ```
+//! The idea behind this design is that you can use the blocks of the clock as similar to normal
+//! Rust as possible. This basically means you can use a clock by value, by reference, with shared
+//! ownership or you can leak them (and thus freeze their state forever).
+//!
+//! ## Borrowed clocks
+//! ```rust no_run
+//! use embedded_time::rate::Extensions as _;
+//!
+//! use rp2040_pac::Peripherals;
+//! use rp2040_hal::clocks::{XOsc, SplitClocks};
+//! use rp2040_hal::clocks::pll::Pll;
+//!
+//! let p = Peripherals::take().unwrap();
+//!
+//! // Setup the clock sources
+//! let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap();
+//! let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, &xosc, 125.MHz().into()).unwrap();
+//! let pll_usb = Pll::new_stable_blocking(p.PLL_USB, &xosc, 48.MHz().into()).unwrap();
+//!
+//! // Derive the clocks for the different domains
+//! let clocks = SplitClocks::split(p.CLOCKS);
+//!
+//! let clk_peri = clocks.peri;
+//! // clk_peri.switch_to(&pll_sys);
+//!
+//! // ToDo: Use UART
+//! ```
+//!
+//!! ## Leaked clocks
+//! ```rust no_run
+//! use embedded_time::rate::Extensions as _;
+//!
+//! use rp2040_pac::Peripherals;
+//! use rp2040_hal::clocks::{XOsc, SplitClocks};
+//! use rp2040_hal::clocks::pll::Pll;
+//!
+//! let p = Peripherals::take().unwrap();
+//!
+//! // Setup the clock sources
+//! let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap().leak();
+//! let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, xosc, 125.MHz().into()).unwrap().leak();
+//! let pll_usb = Pll::new_stable_blocking(p.PLL_USB, xosc, 48.MHz().into()).unwrap().leak();
+//!
+//! // XOsc can now go out of scope, since the PLL have leaked copies
+//! drop(xosc);
+//!
+//! let _ = pll_usb;
+//!
+//! // Derive the clocks for the different domains
+//! let clocks = SplitClocks::split(p.CLOCKS);
+//!
+//! let clk_peri = clocks.peri;
+//! // clk_peri.switch_to(pll_sys);
+//!
+//! // ToDo: Use UART
+//! ```
+//!
+//!! ## Shared clocks
+//! ```rust no_run
+//! use embedded_time::rate::Extensions as _;
+//!
+//! use rp2040_pac::Peripherals;
+//! use rp2040_hal::clocks::{XOsc, SplitClocks};
+//! use rp2040_hal::clocks::pll::Pll;
+//!
+//! let p = Peripherals::take().unwrap();
+//!
+//! // Setup the clock sources
+//! let mut xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap().share();
+//! let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, xosc.take_share(), 125.MHz().into()).unwrap().share();
+//! let pll_usb = Pll::new_stable_blocking(p.PLL_USB, xosc.take_share(), 48.MHz().into()).unwrap().share();
+//!
+//! // ToDo: Use shared pll with device
+//!
+//! // Go to power down -> Shutdown PLLs and XOsc
+//! let (pll_sys_dev, src) = pll_sys.un_share().disable().free();
+//! xosc.return_share(src);
+//! let (pll_usb_dev, src) = pll_usb.un_share().disable().free();
+//! xosc.return_share(src);
+//!
+//! assert!(!xosc.has_outstanding_shares());
+//! let disabled_xosc = xosc.un_share().disable();
+//!
+//! // Derive the clocks for the different domains
+//! let clocks = SplitClocks::split(p.CLOCKS);
+//!
+//! let clk_peri = clocks.peri;
+//! // clk_peri.switch_to(pll_sys);
+//!
+//! // ToDo: Use UART
+//! ```
+
 pub mod generators;
 pub mod pll;
 mod xosc;
@@ -36,6 +106,7 @@ use embedded_time::fixed_point::FixedPoint;
 use embedded_time::rate;
 use embedded_time::rate::*;
 
+/// Type used to represent rates internally to avoid spamming generic type parameters.
 pub type Rate = rate::Generic<u32>;
 
 /// Trait to make it easier to express a simple rate
@@ -69,6 +140,7 @@ pub trait ClkDevice {}
 
 /// Trait for wrappers around clock sources
 pub trait ClkSource {
+    /// The device this source is referring to. (e.g. `pac::XOSC`)
     type DeviceName;
 
     /// Returns the clock rate of the wrapped device.

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -1,5 +1,28 @@
 //! Clock tree configuration
-
+//!
+//! # Example
+/// ```rust no_run
+/// use embedded_time::rate::Extensions as _;
+///
+/// use rp2040_pac::Peripherals;
+/// use rp2040_hal::clocks::{XOsc, SplitClocks};
+/// use rp2040_hal::clocks::pll::Pll;
+///
+/// let p = Peripherals::take().unwrap();
+///
+/// // Setup the clock sources
+/// let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap();
+/// let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, &xosc, 125.MHz().into()).unwrap();
+/// let pll_usb = Pll::new_stable_blocking(p.PLL_USB, &xosc, 48.MHz().into()).unwrap();
+///
+/// // Derive the clocks for the different domains
+/// let clocks = SplitClocks::split(p.CLOCKS);
+///
+/// let clk_peri = clocks.peri;
+/// // clk_peri.switch_to(&pll_sys);
+///
+/// // ToDo: Use UART
+/// ```
 pub mod generators;
 pub mod pll;
 mod xosc;
@@ -10,10 +33,15 @@ pub use xosc::XOsc;
 
 use core::convert::TryFrom;
 use embedded_time::fixed_point::FixedPoint;
+use embedded_time::rate;
 use embedded_time::rate::*;
 
+pub type Rate = rate::Generic<u32>;
+
 /// Trait to make it easier to express a simple rate
-pub trait ClkRate: Rate + FixedPoint<T = u32> + Copy + PartialOrd<Megahertz> + From<Hertz> {
+pub trait ClkRate:
+    embedded_time::rate::Rate + FixedPoint<T = u32> + Copy + PartialOrd<Megahertz> + From<Hertz>
+{
     /// Return the rate converted to Hz if possible
     fn as_hz(&self) -> Option<Hertz>;
 }
@@ -40,7 +68,9 @@ impl ClkRate for Hertz {
 pub trait ClkDevice {}
 
 /// Trait for wrappers around clock sources
-pub trait ClkSource<Dev: ClkDevice, R: ClkRate> {
+pub trait ClkSource {
+    type DeviceName;
+
     /// Returns the clock rate of the wrapped device.
-    fn rate(&self) -> R;
+    fn rate(&self) -> rate::Generic<u32>;
 }

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -1,0 +1,4 @@
+//! Clock tree configuration
+
+mod xosc;
+pub use xosc::XOsc;

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -1,4 +1,44 @@
 //! Clock tree configuration
 
+pub mod pll;
 mod xosc;
+
+pub use pll::Pll;
 pub use xosc::XOsc;
+
+use core::convert::TryFrom;
+use embedded_time::fixed_point::FixedPoint;
+use embedded_time::rate::*;
+
+/// Trait to make it easier to express a simple rate
+pub trait ClkRate: Rate + FixedPoint<T = u32> + Copy + PartialOrd<Megahertz> + From<Hertz> {
+    /// Return the rate converted to Hz if possible
+    fn as_hz(&self) -> Option<Hertz>;
+}
+
+impl ClkRate for Megahertz {
+    fn as_hz(&self) -> Option<Hertz> {
+        Hertz::try_from(*self).ok()
+    }
+}
+
+impl ClkRate for Kilohertz {
+    fn as_hz(&self) -> Option<Hertz> {
+        Hertz::try_from(*self).ok()
+    }
+}
+
+impl ClkRate for Hertz {
+    fn as_hz(&self) -> Option<Hertz> {
+        Some(*self)
+    }
+}
+
+/// Marker Trait for Clock sourcing devices
+pub trait ClkDevice {}
+
+/// Trait for wrappers around clock sources
+pub trait ClkSource<Dev: ClkDevice, R: ClkRate> {
+    /// Returns the clock rate of the wrapped device.
+    fn rate(&self) -> R;
+}

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -1,8 +1,10 @@
 //! Clock tree configuration
 
+pub mod generators;
 pub mod pll;
 mod xosc;
 
+pub use generators::SplitClocks;
 pub use pll::Pll;
 pub use xosc::XOsc;
 

--- a/rp2040-hal/src/clocks/pll.rs
+++ b/rp2040-hal/src/clocks/pll.rs
@@ -1,9 +1,7 @@
 //! PLL wrapper
 //!
 
-use super::ClkSource;
-use super::Rate;
-use crate::clocks::ClkDevice;
+use super::unstable::{ClkDevice, ClkSource, Rate};
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -88,7 +86,7 @@ pub struct StableToken<P: PllDev> {
 /// use embedded_time::rate::Extensions as _;
 ///
 /// use rp2040_pac::Peripherals;
-/// use rp2040_hal::clocks::XOsc;
+/// use rp2040_hal::clocks::xosc::XOsc;
 /// use rp2040_hal::clocks::pll::Pll;
 ///
 /// let p = Peripherals::take().unwrap();
@@ -105,7 +103,7 @@ pub struct StableToken<P: PllDev> {
 /// use embedded_time::rate::Extensions as _;
 ///
 /// use rp2040_pac::Peripherals;
-/// use rp2040_hal::clocks::XOsc;
+/// use rp2040_hal::clocks::xosc::XOsc;
 /// use rp2040_hal::clocks::pll::Pll;
 ///
 /// let p = Peripherals::take().unwrap();

--- a/rp2040-hal/src/clocks/pll.rs
+++ b/rp2040-hal/src/clocks/pll.rs
@@ -1,0 +1,499 @@
+//! PLL wrapper
+//!
+
+use super::xosc::StableXOsc;
+use super::{ClkRate, ClkSource};
+use crate::clocks::ClkDevice;
+use core::marker::PhantomData;
+use core::ops::Deref;
+use embedded_time::rate::*;
+use nb::Error::{Other, WouldBlock};
+use pac::pll_sys::RegisterBlock;
+use state::*;
+
+mod state {
+    use crate::clocks::pll::PllDev;
+
+    pub trait State {}
+
+    pub struct Disabled(pub(super) super::PllParams);
+    pub struct Enabled<P: PllDev> {
+        pub(super) token: Option<super::StableToken<P>>,
+    }
+    pub struct Stable;
+
+    impl State for Disabled {}
+    impl<P: PllDev> State for Enabled<P> {}
+    impl State for Stable {}
+}
+
+/// All the devices that can be used with this implementation have to implement this marker trait;
+pub trait PllDev: Deref<Target = RegisterBlock> {
+    /// The maximum rate this PLL can output according to the datasheet.
+    const MAX_OUT_RATE: Megahertz<u32>;
+}
+
+impl PllDev for pac::PLL_SYS {
+    const MAX_OUT_RATE: Megahertz<u32> = Megahertz(133);
+}
+
+impl PllDev for pac::PLL_USB {
+    const MAX_OUT_RATE: Megahertz<u32> = Megahertz(48);
+}
+
+/// A list of contraints for the PLL according to datasheet section 2.18.2
+pub mod constraints {
+    use core::ops::RangeInclusive;
+    use embedded_time::rate::Hertz;
+    use embedded_time::rate::Megahertz;
+
+    /// Minimum reference clock after reference divider
+    pub const MIN_REF_CLK: Megahertz<u32> = Megahertz(5);
+
+    /// Allowed range for the voltage controlled oscillator (VCO)
+    pub const F_OUT_VCO_RANGE: RangeInclusive<Hertz<u32>> =
+        Hertz(400_000_000)..=Hertz(1_600_000_000);
+
+    /// Allowed range for the feedback divider
+    pub const FB_DIV_RANGE: RangeInclusive<u16> = 16..=320;
+
+    /// Allowed range for both of the post dividers
+    pub const POST_DIV_RANGE: RangeInclusive<u8> = 1..=7;
+}
+
+/// Returned if the requested rate exceeds the ratings given in the datasheet.
+#[derive(Debug)]
+pub struct ParameterOutOfRangeError;
+
+/// Error returned if the device should be disabled but the token is already gone.
+/// This way it is not possible to have more than one token at any point in time.
+#[derive(Debug)]
+pub struct ErrorTokenAlreadyTaken;
+
+/// A token that represents that the Pll has locked.
+pub struct StableToken<P: PllDev> {
+    _dev: PhantomData<P>,
+}
+
+/// Pll wrapper
+///
+/// # Example
+/// # Blocking
+/// ```rust no_run
+/// use embedded_time::rate::Extensions as _;
+///
+/// use rp2040_pac::Peripherals;
+/// use rp2040_hal::clocks::XOsc;
+/// use rp2040_hal::clocks::pll::Pll;
+///
+/// let p = Peripherals::take().unwrap();
+///
+/// let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz()).unwrap();
+///
+/// let pll = Pll::new_stable_blocking(p.PLL_SYS, &xosc, 125.MHz()).unwrap();
+///
+/// // Do things with the clock source
+/// ```
+///
+/// ## Non-Blocking
+/// ```rust no_run
+/// use embedded_time::rate::Extensions as _;
+///
+/// use rp2040_pac::Peripherals;
+/// use rp2040_hal::clocks::XOsc;
+/// use rp2040_hal::clocks::pll::Pll;
+///
+/// let p = Peripherals::take().unwrap();
+///
+/// let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz()).unwrap();
+///
+/// let pll = Pll::new(p.PLL_SYS, &xosc, 125.MHz()).unwrap();
+///
+/// let mut pll = pll.enable();
+/// let token = nb::block!(pll.await_stable()).unwrap();
+/// let pll = pll.stable(token);
+///
+/// // Do things with the clock source
+/// ```
+///
+pub struct Pll<Dev: PllDev, Src: ClkSource<StableXOsc<R>, R>, S: State, R: ClkRate> {
+    dev: Dev,
+    src: Src,
+    state: S,
+    _rate: PhantomData<R>,
+}
+
+/// Convenience type for a stable PLL
+pub type StablePll<Dev, Src, R> = Pll<Dev, Src, Stable, R>;
+
+impl<R: ClkRate, Dev: PllDev, Src: ClkSource<StableXOsc<R>, R>> ClkDevice
+    for Pll<Dev, Src, Stable, R>
+{
+}
+impl<R: ClkRate, Dev: PllDev, Src: ClkSource<StableXOsc<R>, R>>
+    ClkSource<Pll<Dev, Src, Stable, R>, R> for Pll<Dev, Src, Stable, R>
+{
+    fn rate(&self) -> R {
+        self.params()
+            .resulting_rate(self.src.rate().as_hz().unwrap())
+            .into()
+    }
+}
+
+impl<Dev: PllDev, Src: ClkSource<StableXOsc<R>, R>, R: ClkRate> Pll<Dev, Src, Disabled, R> {
+    /// Create a new Pll
+    pub fn new(dev: Dev, src: Src, output: R) -> Result<Self, ParameterOutOfRangeError> {
+        let input = src.rate().as_hz().ok_or(ParameterOutOfRangeError {})?;
+        let output = output.as_hz().ok_or(ParameterOutOfRangeError {})?;
+
+        let params = PllParams::find(input, output, None, OptimizeFor::LowJitter)
+            .ok_or(ParameterOutOfRangeError {})?;
+
+        if params.resulting_rate(input) > Dev::MAX_OUT_RATE {
+            return Err(ParameterOutOfRangeError {});
+        }
+
+        Ok(Pll {
+            dev,
+            src,
+            state: Disabled(params),
+            _rate: PhantomData,
+        })
+    }
+
+    /// Convenience method for getting a running PLL without needing to worry about the state
+    /// machine.
+    pub fn new_stable_blocking(
+        dev: Dev,
+        src: Src,
+        output: R,
+    ) -> Result<Pll<Dev, Src, Stable, R>, ParameterOutOfRangeError> {
+        let mut pll = Self::new(dev, src, output)?.enable();
+        let token = nb::block!(pll.await_stable()).unwrap();
+        Ok(pll.stable(token))
+    }
+
+    /// Set all the dividers based of the struct
+    fn set_params(&mut self, params: PllParams) {
+        // Safety: PllParams can only contain valid values for these parameters
+        unsafe {
+            self.dev.cs.write(|w| w.refdiv().bits(params.ref_div));
+            self.dev
+                .fbdiv_int
+                .write(|w| w.fbdiv_int().bits(params.fb_div));
+            self.dev.prim.write(|w| {
+                w.postdiv1()
+                    .bits(params.post_div1)
+                    .postdiv2()
+                    .bits(params.post_div2)
+            });
+        }
+    }
+
+    /// Set the requested and enable the PLL. Before the PLL can be used for anything is needs to
+    /// be stable.
+    pub fn enable(mut self) -> Pll<Dev, Src, Enabled<Dev>, R> {
+        // Turn of the power, it it may have been enabled before
+        self.raw_disable_pwr();
+
+        self.set_params(self.state.0);
+
+        // Enable power
+        self.dev
+            .pwr
+            .write(|w| w.pd().clear_bit().vcopd().clear_bit());
+
+        // The VCO is now running and we need to wait until the Pll is locked, to call is stable
+        self.transition(Enabled {
+            token: Some(StableToken { _dev: PhantomData }),
+        })
+    }
+
+    /// Destructure the PLL back into its parts
+    pub fn free(self) -> (Dev, Src) {
+        (self.dev, self.src)
+    }
+}
+
+impl<Dev: PllDev, Src: ClkSource<StableXOsc<R>, R>, R: ClkRate> Pll<Dev, Src, Enabled<Dev>, R> {
+    /// Transition to the stable state. Obtain a token by calling `await_stable`.
+    pub fn stable(self, _: StableToken<Dev>) -> Pll<Dev, Src, Stable, R> {
+        // Enable power to the post dividers
+        self.dev.pwr.write(|w| w.postdivpd().clear_bit());
+
+        self.transition(Stable {})
+    }
+
+    /// Check if the PLL is stable. Meaning the `locked` flag is set in the `CS` register.
+    pub fn await_stable(&mut self) -> nb::Result<StableToken<Dev>, ErrorTokenAlreadyTaken> {
+        let is_stable = self.dev.cs.read().lock().bit_is_set();
+        if !is_stable {
+            return Err(WouldBlock);
+        }
+
+        match self.state.token.take() {
+            None => Err(Other(ErrorTokenAlreadyTaken {})),
+            Some(token) => Ok(token),
+        }
+    }
+
+    /// Disable the PLL, this can be useful if you can not get the PLL to lock and want to change
+    /// settings to try again.
+    pub fn disable(mut self) -> Result<Pll<Dev, Src, Disabled, R>, Self> {
+        if self.state.token.is_none() {
+            return Err(self);
+        }
+
+        self.raw_disable_pwr();
+        let next = Disabled(self.params());
+        Ok(self.transition(next))
+    }
+}
+
+impl<Dev: PllDev, Src: ClkSource<StableXOsc<R>, R>, R: ClkRate> Pll<Dev, Src, Stable, R> {
+    /// Disables the PLL without checking if the output clock is still in use.
+    pub fn disable_unchecked(mut self) -> Result<Pll<Dev, Src, Disabled, R>, Self> {
+        self.raw_disable_pwr();
+        let next = Disabled(self.params());
+        Ok(self.transition(next))
+    }
+}
+
+impl<D: PllDev, Sr: ClkSource<StableXOsc<R>, R>, St: State, R: ClkRate> Pll<D, Sr, St, R> {
+    fn transition<To: State>(self, to: To) -> Pll<D, Sr, To, R> {
+        Pll {
+            dev: self.dev,
+            src: self.src,
+            state: to,
+            _rate: self._rate,
+        }
+    }
+
+    fn raw_disable_pwr(&mut self) {
+        self.dev.pwr.write(|w| {
+            w.pd()
+                .set_bit()
+                .dsmpd()
+                .set_bit()
+                .postdivpd()
+                .set_bit()
+                .vcopd()
+                .set_bit()
+        });
+    }
+
+    fn params(&self) -> PllParams {
+        PllParams {
+            ref_div: self.dev.cs.read().refdiv().bits(),
+            fb_div: self.dev.fbdiv_int.read().fbdiv_int().bits(),
+            post_div1: self.dev.prim.read().postdiv1().bits(),
+            post_div2: self.dev.prim.read().postdiv2().bits(),
+        }
+    }
+}
+
+/// What to aim for when choosing PLL parameters.
+pub enum OptimizeFor {
+    /// Tries to use a low VCO rate in order to use as little power as possible.
+    LowPower,
+
+    /// Tries to use a high VCO rate in order to have as little clock jitter as possible.
+    LowJitter,
+}
+
+/// A set of parameters to set up the PLL
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub struct PllParams {
+    ref_div: u8,
+    fb_div: u16,
+    post_div1: u8,
+    post_div2: u8,
+}
+
+impl PllParams {
+    /// Calculate the output rate for a pll configured with this set of parameters and the given
+    /// `input` as reference clock.
+    pub fn resulting_rate(&self, input: Hertz) -> Hertz {
+        input * (self.fb_div as u32)
+            / (self.ref_div as u32)
+            / (self.post_div1 as u32)
+            / (self.post_div2 as u32)
+    }
+
+    /// Find a set of settings for the PLL to match the given output.
+    ///
+    /// The calculation is based on [the script given in the datasheet](https://github.com/raspberrypi/pico-sdk/tree/master/src/rp2_common/hardware_clocks/scripts/vcocalc.py#L1-L37)
+    /// (section 2.18.2).
+    ///
+    /// - If `low_vco` is true a more power efficient set is chosen, but the output jitter might be higher.
+    /// - If `vco_max` is Some() then no VCO higher than that will be used.
+    ///
+    /// # TODO
+    /// This function could be `const` since we only loop and do basic arithmatic. But it does get
+    /// more difficult to read if written without iterators.
+    ///
+    /// # Example
+    /// ```
+    /// use rp2040_hal::clocks::pll::{PllParams, OptimizeFor};
+    /// use embedded_time::rate::Extensions;
+    ///
+    /// // Get a low power set of setting for about 125 MHz
+    /// let params = PllParams::find(12_000_000.Hz(), 125_000_000.Hz(), Some(600_000_000.Hz()), OptimizeFor::LowPower).unwrap();
+    /// assert_eq!(params.ref_div(), 1);
+    /// assert_eq!(params.fb_div(), 42);
+    /// assert_eq!(params.post_div1(), 4);
+    /// assert_eq!(params.post_div2(), 1);
+    ///
+    /// assert_eq!(params.resulting_rate(12_000_000.Hz()), 126_000_000u32.Hz());
+    /// ```
+    pub fn find(
+        input: Hertz,
+        output: Hertz,
+        vco_max: Option<Hertz>,
+        target: OptimizeFor,
+    ) -> Option<Self> {
+        use constraints::*;
+        let post_divs = POST_DIV_RANGE
+            .into_iter()
+            .flat_map(|pd2| POST_DIV_RANGE.into_iter().map(move |pd1| (pd2, pd1)));
+
+        let mut fb_iter = FB_DIV_RANGE;
+        let fb_divs = core::iter::from_fn(|| match target {
+            OptimizeFor::LowPower => fb_iter.next(),
+            OptimizeFor::LowJitter => fb_iter.next_back(),
+        });
+
+        let vco_range = *F_OUT_VCO_RANGE.start()..=vco_max.unwrap_or(*F_OUT_VCO_RANGE.end());
+
+        let (_margin, (_vco, fb_div, post_div2, post_div1)) = fb_divs
+            .map(|fb_div| (input * (fb_div as u32), fb_div))
+            .filter(|(vco, _fb_div)| vco_range.contains(vco))
+            .flat_map(|(vco, fb_div)| {
+                post_divs
+                    .clone()
+                    .map(move |(pd2, pd1)| (vco, fb_div, pd2, pd1))
+            })
+            .map(|params| {
+                let (vco, _fb_div, pd2, pd1) = params;
+                let out = vco / pd1 as u32 / pd2 as u32;
+                let margin = if output > out {
+                    output - out
+                } else {
+                    out - output
+                };
+                (margin, params)
+            })
+            .min_by_key(|(margin, _)| *margin)?;
+
+        Some(PllParams {
+            ref_div: 1,
+            fb_div,
+            post_div1,
+            post_div2,
+        })
+    }
+
+    /// Get the value for the reference divider
+    pub fn ref_div(&self) -> u8 {
+        self.ref_div
+    }
+
+    /// Get the value for the feedback divider
+    pub fn fb_div(&self) -> u16 {
+        self.fb_div
+    }
+
+    /// Get the value of the first post divider
+    pub fn post_div1(&self) -> u8 {
+        self.post_div1
+    }
+
+    /// Get the value od the second post divider
+    pub fn post_div2(&self) -> u8 {
+        self.post_div2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datsheet_example() {
+        assert_eq!(
+            PllParams::find(
+                12_000_000.Hz(),
+                48_000_000.Hz(),
+                None,
+                OptimizeFor::LowJitter
+            )
+            .unwrap(),
+            PllParams {
+                ref_div: 1,
+                fb_div: 120,
+                post_div1: 6,
+                post_div2: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn datsheet_example_low_vco() {
+        assert_eq!(
+            PllParams::find(
+                12_000_000.Hz(),
+                48_000_000.Hz(),
+                None,
+                OptimizeFor::LowPower
+            )
+            .unwrap(),
+            PllParams {
+                ref_div: 1,
+                fb_div: 36,
+                post_div1: 3,
+                post_div2: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn datsheet_example_limited_vco() {
+        assert_eq!(
+            PllParams::find(
+                12_000_000.Hz(),
+                125_000_000.Hz(),
+                None,
+                OptimizeFor::LowPower
+            )
+            .unwrap(),
+            PllParams {
+                ref_div: 1,
+                fb_div: 125,
+                post_div1: 6,
+                post_div2: 2,
+            }
+        );
+
+        let expected = PllParams {
+            ref_div: 1,
+            fb_div: 42,
+            post_div1: 4,
+            post_div2: 1,
+        };
+        assert_eq!(
+            PllParams::find(
+                12_000_000.Hz(),
+                125_000_000.Hz(),
+                Some(600_000_000.Hz()),
+                OptimizeFor::LowPower
+            )
+            .unwrap(),
+            expected
+        );
+
+        assert_eq!(
+            expected.resulting_rate(12_000_000.Hz()),
+            126_000_000u32.Hz()
+        )
+    }
+}

--- a/rp2040-hal/src/clocks/unstable/generators.rs
+++ b/rp2040-hal/src/clocks/unstable/generators.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // ToDo: Use this instead of directly writing registers
+
 //! The clocks block, containing all clock generators
 
 use pac::CLOCKS;
@@ -18,6 +20,12 @@ pub struct SplitClocks {
 
     /// Clock output to GPIO 3
     pub gp_out3: ClkGPOut3,
+
+    /// Clock output to Watchdog and timers
+    pub c_ref: ClkRef,
+
+    /// Clock output to Processor, bus-fabric, memories and memory mapped registers
+    pub sys: ClkSys,
 
     /// Clock output to UART and SPI
     pub peri: ClkPeri,
@@ -59,6 +67,12 @@ impl SplitClocks {
                 share: share.copy(),
             },
             gp_out3: ClkGPOut3 {
+                share: share.copy(),
+            },
+            c_ref: ClkRef {
+                share: share.copy(),
+            },
+            sys: ClkSys {
                 share: share.copy(),
             },
             peri: ClkPeri {
@@ -277,6 +291,14 @@ gp_out! {ClkGPOut0, clk_gpout0_ctrl, clk_gpout0_div}
 gp_out! {ClkGPOut1, clk_gpout1_ctrl, clk_gpout1_div}
 gp_out! {ClkGPOut2, clk_gpout2_ctrl, clk_gpout2_div}
 gp_out! {ClkGPOut3, clk_gpout3_ctrl, clk_gpout3_div}
+
+pub struct ClkRef {
+    share: SharedClocksBlock,
+}
+
+pub struct ClkSys {
+    share: SharedClocksBlock,
+}
 
 clock_generator! {ClkPeri, clk_peri_ctrl}
 

--- a/rp2040-hal/src/clocks/unstable/mod.rs
+++ b/rp2040-hal/src/clocks/unstable/mod.rs
@@ -1,0 +1,116 @@
+//! Clock tree configuration
+//!
+//! This was my first idea on how to make a dynamic clock tree, it turned out to be quite
+//! complicated. Maybe at some point we could take another look at this.
+//!
+//! # Example
+//! The idea behind this design is that you can use the blocks of the clock as similar to normal
+//! Rust as possible. This basically means you can use a clock by value, by reference, with shared
+//! ownership or you can leak them (and thus freeze their state forever).
+//!
+//! ## Borrowed clocks
+//! ```rust no_run ignore
+//! use embedded_time::rate::Extensions as _;
+//!
+//! use rp2040_pac::Peripherals;
+//! use rp2040_hal::clocks::{xosc::XOsc, unstable::SplitClocks, pll::Pll};
+//!
+//! let p = Peripherals::take().unwrap();
+//!
+//! // Setup the clock sources
+//! let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap();
+//! let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, &xosc, 125.MHz().into()).unwrap();
+//! let pll_usb = Pll::new_stable_blocking(p.PLL_USB, &xosc, 48.MHz().into()).unwrap();
+//!
+//! // Derive the clocks for the different domains
+//! let clocks = SplitClocks::split(p.CLOCKS);
+//!
+//! let clk_peri = clocks.peri;
+//! // clk_peri.switch_to(&pll_sys);
+//!
+//! // ToDo: Use UART
+//! ```
+//!
+//!! ## Leaked clocks
+//! ```rust no_run ignore
+//! use embedded_time::rate::Extensions as _;
+//!
+//! use rp2040_pac::Peripherals;
+//! use rp2040_hal::clocks::{xosc::XOsc, SplitClocks, pll::Pll};
+//!
+//! let p = Peripherals::take().unwrap();
+//!
+//! // Setup the clock sources
+//! let xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap().leak();
+//! let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, xosc, 125.MHz().into()).unwrap().leak();
+//! let pll_usb = Pll::new_stable_blocking(p.PLL_USB, xosc, 48.MHz().into()).unwrap().leak();
+//!
+//! // XOsc can now go out of scope, since the PLL have leaked copies
+//! drop(xosc);
+//!
+//! let _ = pll_usb;
+//!
+//! // Derive the clocks for the different domains
+//! let clocks = SplitClocks::split(p.CLOCKS);
+//!
+//! let clk_peri = clocks.peri;
+//! // clk_peri.switch_to(pll_sys);
+//!
+//! // ToDo: Use UART
+//! ```
+//!
+//!! ## Shared clocks
+//! ```rust no_run ignore
+//! use embedded_time::rate::Extensions as _;
+//!
+//! use rp2040_pac::Peripherals;
+//! use rp2040_hal::clocks::{XOsc, SplitClocks};
+//! use rp2040_hal::clocks::pll::Pll;
+//!
+//! let p = Peripherals::take().unwrap();
+//!
+//! // Setup the clock sources
+//! let mut xosc = XOsc::new_stable_blocking(p.XOSC, 12.MHz().into()).unwrap().share();
+//! let pll_sys = Pll::new_stable_blocking(p.PLL_SYS, xosc.take_share(), 125.MHz().into()).unwrap().share();
+//! let pll_usb = Pll::new_stable_blocking(p.PLL_USB, xosc.take_share(), 48.MHz().into()).unwrap().share();
+//!
+//! // ToDo: Use shared pll with device
+//!
+//! // Go to power down -> Shutdown PLLs and XOsc
+//! let (pll_sys_dev, src) = pll_sys.un_share().disable().free();
+//! xosc.return_share(src);
+//! let (pll_usb_dev, src) = pll_usb.un_share().disable().free();
+//! xosc.return_share(src);
+//!
+//! assert!(!xosc.has_outstanding_shares());
+//! let disabled_xosc = xosc.un_share().disable();
+//!
+//! // Derive the clocks for the different domains
+//! let clocks = SplitClocks::split(p.CLOCKS);
+//!
+//! let clk_peri = clocks.peri;
+//! // clk_peri.switch_to(pll_sys);
+//!
+//! // ToDo: Use UART
+//! ```
+
+pub mod generators;
+
+pub use generators::SplitClocks;
+
+use embedded_time::rate;
+
+/// Type used to represent rates internally to avoid spamming generic type parameters.
+pub type Rate = rate::Generic<u32>;
+
+/// Marker Trait for Clock sourcing devices
+pub trait ClkDevice {}
+
+/// Trait for wrappers around clock sources
+pub trait ClkSource {
+    /// The device this source is referring to. (e.g. `pac::XOSC`)
+    type DeviceName;
+
+    /// Returns the clock rate of the wrapped device.
+    fn rate(&self) -> rate::Generic<u32>;
+}

--- a/rp2040-hal/src/clocks/xosc.rs
+++ b/rp2040-hal/src/clocks/xosc.rs
@@ -1,0 +1,213 @@
+use core::marker::PhantomData;
+use embedded_time::duration::*;
+use embedded_time::fixed_point::FixedPoint;
+use embedded_time::rate::*;
+use num::rational::Ratio;
+use num::{CheckedDiv, CheckedMul};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait State: sealed::Sealed {}
+pub trait EnabledOrStable: State {}
+
+pub struct Disabled;
+pub struct Enabled;
+pub struct Stable;
+
+impl State for Disabled {}
+impl State for Enabled {}
+impl State for Stable {}
+
+impl EnabledOrStable for Enabled {}
+impl EnabledOrStable for Stable {}
+
+impl sealed::Sealed for Disabled {}
+impl sealed::Sealed for Enabled {}
+impl sealed::Sealed for Stable {}
+
+#[derive(Debug)]
+pub enum Error {
+    StartUpDelayOverflows,
+    RateOutOfRange,
+}
+
+/// [Chapter 2 Section 16](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
+///
+/// # Example
+/// ```rust no_run
+/// use embedded_time::rate::Extensions as _;
+/// use embedded_time::duration::Extensions as _;
+///
+/// use rp2040_pac::Peripherals;
+/// use rp2040_hal::clocks::XOsc;
+///
+/// let p = Peripherals::take().unwrap();
+///
+/// let mut xosc = XOsc::new(p.XOSC, 12.MHz()).unwrap();
+///
+/// // Optional, defaults to 1ms
+/// xosc.set_startup_delay(&42.milliseconds()).unwrap();
+///
+/// let mut xosc = xosc.enable();
+/// let stable_xosc = loop {
+///     xosc = match xosc.stable() {
+///         Ok(x) => break x,
+///         Err(x) => x,
+///     };
+/// };
+///
+/// // Do things with the clock source
+/// ```
+pub struct XOsc<S: State, R: Rate> {
+    inner: pac::XOSC,
+    rate: R,
+    state: PhantomData<S>,
+}
+
+impl<R> XOsc<Disabled, R>
+where
+    R: Rate + FixedPoint<T = u32> + Copy + PartialOrd<Megahertz>,
+    Megahertz: PartialOrd<R>,
+{
+    /// Create a new wrapper for an oscillator with a given frequency.
+    pub fn new(peri: pac::XOSC, rate: R) -> Result<Self, Error> {
+        let mut dev = XOsc {
+            inner: peri,
+            rate,
+            state: PhantomData,
+        };
+
+        if !(1.MHz()..=15.MHz()).contains(&rate) {
+            return Err(Error::RateOutOfRange);
+        }
+        dev.inner.ctrl.write(|w| w.freq_range()._1_15mhz());
+
+        dev.set_startup_delay(&Milliseconds(1))?;
+
+        Ok(dev)
+    }
+
+    /// Sets the startup delay for the osc. Defaults to 1ms
+    pub fn set_startup_delay<D: Duration + FixedPoint<T = u32>>(
+        &mut self,
+        duration: &D,
+    ) -> Result<(), Error> {
+        let startup_delay = delay_cnt(&self.rate, duration).ok_or(Error::StartUpDelayOverflows)?;
+
+        self.inner
+            .startup
+            .write(|w| unsafe { w.delay().bits(startup_delay) });
+
+        Ok(())
+    }
+
+    /// Enable the peripheral
+    pub fn enable(self) -> XOsc<Enabled, R> {
+        self.inner.ctrl.write(|w| w.enable().enable());
+
+        XOsc {
+            inner: self.inner,
+            rate: self.rate,
+            state: PhantomData,
+        }
+    }
+
+    /// Release the inner peripheral.
+    pub fn free(self) -> pac::XOSC {
+        self.inner
+    }
+}
+
+impl<R: Rate> XOsc<Enabled, R> {
+    /// Check if the oscillator is stable and can be used. Returns the old state if is not yet stable.
+    pub fn stable(self) -> Result<XOsc<Stable, R>, Self> {
+        if !self.inner.status.read().stable().bit_is_set() {
+            return Err(self);
+        }
+
+        Ok(XOsc {
+            inner: self.inner,
+            rate: self.rate,
+            state: PhantomData,
+        })
+    }
+}
+
+impl<R: Rate, S: EnabledOrStable> XOsc<S, R> {
+    /// This disables the device without checking if the clock is still in use
+    // ToDo: Should this be `unsafe`?
+    pub fn disable_unchecked(self) -> XOsc<Disabled, R> {
+        self.inner.ctrl.write(|w| w.enable().disable());
+
+        XOsc {
+            inner: self.inner,
+            rate: self.rate,
+            state: PhantomData,
+        }
+    }
+}
+
+fn delay_cnt<R: Rate + FixedPoint<T = u32>, D: Duration + FixedPoint<T = u32>>(
+    rate: &R,
+    startup_delay: &D,
+) -> Option<u16> {
+    let f_osc = Ratio::from_integer(*rate.integer());
+    let t_stable = Ratio::from_integer(*startup_delay.integer());
+
+    let f_unit = R::SCALING_FACTOR;
+    let f_unit = Ratio::new(*f_unit.numerator(), *f_unit.denominator());
+
+    let t_unit = D::SCALING_FACTOR;
+    let t_unit = Ratio::new(*t_unit.numerator(), *t_unit.denominator());
+
+    let reg_val = f_unit
+        .checked_mul(&t_unit)?
+        .checked_mul(&f_osc)?
+        .checked_mul(&t_stable)?
+        .checked_div(&Ratio::from_integer(256))?
+        .ceil()
+        .to_integer();
+
+    if reg_val > 0x3fff {
+        // The register can only hold 14 bits
+        return None;
+    }
+
+    Some(reg_val as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_delay_of_0_should_return_0() {
+        assert_eq!(delay_cnt(&12.MHz(), &Milliseconds(0)), Some(0));
+    }
+
+    #[test]
+    fn datasheet_example_matches_impl() {
+        let delay = &Milliseconds(1);
+        assert_eq!(delay_cnt(&12.MHz(), delay), Some(47));
+        assert_eq!(delay_cnt(&12_000.kHz(), delay), Some(47));
+        assert_eq!(delay_cnt(&12_000_000.Hz(), delay), Some(47));
+
+        let delay = &Nanoseconds(1_000_000);
+        assert_eq!(delay_cnt(&12.MHz(), delay), Some(47));
+        assert_eq!(delay_cnt(&12_000.kHz(), delay), Some(47));
+        assert_eq!(delay_cnt(&12_000_000.Hz(), delay), Some(47));
+    }
+
+    #[test]
+    fn high_value_examples() {
+        assert_eq!(
+            delay_cnt(&15.MHz(), &279_603_200.nanoseconds()),
+            Some(0x3fff)
+        );
+
+        // This should overflow the available 14 bits
+        assert_eq!(delay_cnt(&15.MHz(), &279_603_201.nanoseconds()), None);
+    }
+}

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -13,6 +13,7 @@ extern crate nb;
 pub extern crate rp2040_pac as pac;
 
 pub mod adc;
+pub mod clocks;
 pub mod i2c;
 pub mod prelude;
 pub mod pwm;


### PR DESCRIPTION
This allows users to setup the clock without using any unsafe.
Also is eliminates unintentional mis-use using the type-state
pattern.