### PR TITLE
fix rom_table_lookup

### DIFF
--- a/rp2040-hal/src/rom_data.rs
+++ b/rp2040-hal/src/rom_data.rs
@@ -144,9 +144,9 @@ pub fn copyright_string() -> &'static str {
 }
 
 /// The 8 most significant hex digits of the Bootrom git revision.
-pub fn git_revision() -> &'static str {
-    let s: *const u8 = rom_table_lookup(DATA_TABLE, *b"GR");
-    unsafe { convert_str(s) }
+pub fn git_revision() -> u32 {
+    let s: *const u32 = rom_table_lookup(DATA_TABLE, *b"GR");
+    unsafe { *s }
 }
 
 /// The start address of the floating point library code and data. This and fplib_end along with the individual

--- a/rp2040-hal/src/rom_data.rs
+++ b/rp2040-hal/src/rom_data.rs
@@ -11,17 +11,23 @@ type RomTableLookupFn<T> = unsafe extern "C" fn(*const u16, u32) -> T;
 const ROM_TABLE_LOOKUP_PTR: *const u16 = 0x18 as _;
 
 /// Pointer to helper functions lookup table.
-const FUNC_TABLE: *const *const u16 = 0x14 as _;
+const FUNC_TABLE: *const u16 = 0x14 as _;
 
 /// Pointer to the public data lookup table.
-const DATA_TABLE: *const *const u16 = 0x16 as _;
+const DATA_TABLE: *const u16 = 0x16 as _;
 
 /// Retrive rom content from a table using a code.
-fn rom_table_lookup<T>(table: *const *const u16, tag: RomFnTableCode) -> T {
+fn rom_table_lookup<T>(table: *const u16, tag: RomFnTableCode) -> T {
     unsafe {
-        let rom_table_lookup: RomTableLookupFn<T> = core::mem::transmute(ROM_TABLE_LOOKUP_PTR);
-        rom_table_lookup(*table, u16::from_le_bytes(tag) as u32)
+        let rom_table_lookup_ptr: *const u32 = rom_hword_as_ptr(ROM_TABLE_LOOKUP_PTR);
+        let rom_table_lookup: RomTableLookupFn<T> = core::mem::transmute(rom_table_lookup_ptr);
+        rom_table_lookup(rom_hword_as_ptr(table) as *const u16, u16::from_le_bytes(tag) as u32)
     }
+}
+
+unsafe fn rom_hword_as_ptr(rom_address: *const u16) -> *const u32 {
+    let ptr: u16 = *rom_address;
+    ptr as *const u32
 }
 
 macro_rules! rom_funcs {


### PR DESCRIPTION
It seems like the rom_table_lookup missed one level of
pointer dereferencing.

After comparing it to the working call to reset_usb_boot() in
https://github.com/jannic/rp-microcontroller-rs/blob/master/util/rp2040-panic-usb-boot/src/lib.rs,
I changed the code until it generated basically the same assembly.

With that change, I was able to successfully call rom_data::reset_to_usb_boot()

I still don't like the type RomTableLookupFn, which just returns
some generic T without any checks, and I think rom_table_lookup
should be unsafe. But as none of those are pub, it doesn't matter too
much. So I just made the changes necessary to make the code work.