### PR TITLE
Have the `pll` and `uart` HAL modules bring the hardware out of reset

### DIFF
--- a/rp2040-hal/src/gpio.rs
+++ b/rp2040-hal/src/gpio.rs
@@ -77,18 +77,15 @@ macro_rules! gpio {
             use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
             use super::*;
 
+            use crate::resets::SubsystemReset;
+
             impl GpioExt<pac::$PADSX, sio::$siotoken> for pac::$GPIOX {
                 type Parts = Parts;
 
                 fn split(self, pads: pac::$PADSX, sio: sio::$siotoken, resets: &mut pac::RESETS) -> Parts {
-                    resets.reset.modify(|_, w| w.$gpiox().clear_bit().$padsx().clear_bit());
-                    // TODO: Implement Resets in the HAL
-                    while resets.reset_done.read().$gpiox().bit_is_clear() {
-                        cortex_m::asm::delay(10);
-                    }
-                    while resets.reset_done.read().$padsx().bit_is_clear() {
-                        cortex_m::asm::delay(10);
-                    }
+                    // FIXME: bring both of these up at the same time
+                    self.reset_bring_up(resets);
+                    pads.reset_bring_up(resets);
                     Parts {
                         _pads: pads,
                         _sio: sio,

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -19,6 +19,7 @@ pub mod i2c;
 pub mod pll;
 pub mod prelude;
 pub mod pwm;
+pub mod resets;
 pub mod rom_data;
 pub mod rtc;
 pub mod sio;

--- a/rp2040-hal/src/resets.rs
+++ b/rp2040-hal/src/resets.rs
@@ -1,0 +1,49 @@
+//! Subsystem Resets
+// See [Chapter 2 Section 14](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
+use rp2040_pac as pac;
+
+mod private {
+    pub trait SubsystemReset {
+        fn reset_bring_up(&self, resets: &mut pac::RESETS);
+    }
+}
+
+pub(crate) use private::SubsystemReset;
+
+macro_rules! generate_reset {
+    ($MODULE:ident, $module:ident) => {
+        impl SubsystemReset for pac::$MODULE {
+            fn reset_bring_up(&self, resets: &mut pac::RESETS) {
+                resets.reset.modify(|_, w| w.$module().clear_bit());
+                while resets.reset_done.read().$module().bit_is_clear() {}
+            }
+        }
+    };
+}
+
+// In datasheet order
+generate_reset!(USBCTRL_REGS, usbctrl);
+generate_reset!(UART1, uart1);
+generate_reset!(UART0, uart0);
+generate_reset!(TIMER, timer);
+generate_reset!(TBMAN, tbman);
+generate_reset!(SYSINFO, sysinfo);
+generate_reset!(SYSCFG, syscfg);
+generate_reset!(SPI1, spi1);
+generate_reset!(SPI0, spi0);
+generate_reset!(RTC, rtc);
+generate_reset!(PWM, pwm);
+generate_reset!(PLL_USB, pll_usb);
+generate_reset!(PLL_SYS, pll_sys);
+generate_reset!(PIO1, pio1);
+generate_reset!(PIO0, pio0);
+generate_reset!(PADS_QSPI, pads_qspi);
+generate_reset!(PADS_BANK0, pads_bank0);
+//generate_reset!(JTAG,jtag); // This doesn't seem to have an item in the pac
+generate_reset!(IO_QSPI, io_qspi);
+generate_reset!(IO_BANK0, io_bank0);
+generate_reset!(I2C1, i2c1);
+generate_reset!(I2C0, i2c0);
+generate_reset!(DMA, dma);
+generate_reset!(BUSCTRL, busctrl);
+generate_reset!(ADC, adc);


### PR DESCRIPTION
Currently, `pll` and `uart` do not bring the module out of reset before attempting to use it.

If the module is still in reset, you cannot use it.

This PR brings the UART and PLL out of reset before attempting to use them.