### PR TITLE
Watchdog implementation

### DIFF
--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -8,15 +8,14 @@ use embedded_time::{
 use crate::pac::WATCHDOG;
 
 
-//const MAX_LOAD: u32 = 0x7FFFFF;
-
-
+///
 pub struct Watchdog {
     watchdog: WATCHDOG,
     delay_ms: u32,
 }
 
 impl Watchdog {
+    ///
     pub fn new(watchdog: WATCHDOG) -> Self {
         Self {
             watchdog,
@@ -24,6 +23,7 @@ impl Watchdog {
         }
     }
 
+    ///
     pub fn enable_tick_generation(&mut self, cycles: u8) {
         const WATCHDOG_TICK_ENABLE_BITS: u32 = 0x200;
 
@@ -57,11 +57,11 @@ impl watchdog::WatchdogEnable for Watchdog {
     /// Due to a logic error, the watchdog decrements by 2 and
     /// value must be compensated; see RP2040-E1
     fn start<T: Into<Self::Time>>(&mut self, period: T) {
-        let delay_ms = period
+        self.delay_ms = period
             .into()
             .integer() * 2;
 
-        self.load_counter(delay_ms);
+        self.load_counter(self.delay_ms);
         self.enable();
     }
 }

--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -4,14 +4,14 @@ use crate::pac::WATCHDOG;
 use embedded_hal::watchdog;
 use embedded_time::{duration, fixed_point::FixedPoint};
 
-///
+/// Watchdog peripheral
 pub struct Watchdog {
     watchdog: WATCHDOG,
     delay_ms: u32,
 }
 
 impl Watchdog {
-    ///
+    /// Create a new [`Watchdog`]
     pub fn new(watchdog: WATCHDOG) -> Self {
         Self {
             watchdog,
@@ -19,7 +19,11 @@ impl Watchdog {
         }
     }
 
+    /// Starts tick generation on clk_tick which is driven from clk_ref.
     ///
+    /// # Arguments
+    ///
+    /// * `cycles` - Total number of tick cycles before the next tick is generated.
     pub fn enable_tick_generation(&mut self, cycles: u8) {
         const WATCHDOG_TICK_ENABLE_BITS: u32 = 0x200;
 
@@ -28,7 +32,12 @@ impl Watchdog {
             .write(|w| unsafe { w.bits(WATCHDOG_TICK_ENABLE_BITS | cycles as u32) })
     }
 
+    /// Defines whether or not the watchdog timer should be paused when processor(s) are in debug mode
+    /// or when JTAG is accessing bus fabric
     ///
+    /// # Arguments
+    ///
+    /// * `pause` - If true, watchdog timer will be paused
     pub fn pause_on_debug(&mut self, pause: bool) {
         self.watchdog.ctrl.write(|w| {
             w.pause_dbg0()
@@ -59,7 +68,7 @@ impl watchdog::WatchdogEnable for Watchdog {
     type Time = duration::Microseconds;
 
     fn start<T: Into<Self::Time>>(&mut self, period: T) {
-        const MAX_PERIOD: u32 = 0x7FFFFF;
+        const MAX_PERIOD: u32 = 0xFFFFFF;
 
         // Due to a logic error, the watchdog decrements by 2 and
         // the load value must be compensated; see RP2040-E1

--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -1,3 +1,75 @@
 //! Watchdog
 // See [Chapter 4 Section 7](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
-// TODO
+use embedded_hal::watchdog;
+use embedded_time::{
+    duration,
+    fixed_point::FixedPoint,
+};
+use crate::pac::WATCHDOG;
+
+
+//const MAX_LOAD: u32 = 0x7FFFFF;
+
+
+pub struct Watchdog {
+    watchdog: WATCHDOG,
+    delay_ms: u32,
+}
+
+impl Watchdog {
+    pub fn new(watchdog: WATCHDOG) -> Self {
+        Self {
+            watchdog,
+            delay_ms: 0,
+        }
+    }
+
+    pub fn enable_tick_generation(&mut self, cycles: u8) {
+        const WATCHDOG_TICK_ENABLE_BITS: u32 = 0x200;
+
+        self.watchdog
+            .tick
+            .write(|w| unsafe { w.bits(WATCHDOG_TICK_ENABLE_BITS | cycles as u32)})
+    }
+
+    fn load_counter(&self, counter: u32) {
+        self.watchdog
+            .load
+            .write(|w| unsafe { w.bits(counter)});
+    }
+
+    fn enable(&self) {
+        self.watchdog
+            .ctrl
+            .write(|w| w.enable().set_bit())
+    }
+}
+
+impl watchdog::Watchdog for Watchdog {
+    fn feed(&mut self) {
+        self.load_counter(self.delay_ms)
+    }
+}
+
+impl watchdog::WatchdogEnable for Watchdog {
+    type Time = duration::Microseconds;
+
+    /// Due to a logic error, the watchdog decrements by 2 and
+    /// value must be compensated; see RP2040-E1
+    fn start<T: Into<Self::Time>>(&mut self, period: T) {
+        let delay_ms = period
+            .into()
+            .integer() * 2;
+
+        self.load_counter(delay_ms);
+        self.enable();
+    }
+}
+
+impl watchdog::WatchdogDisable for Watchdog {
+    fn disable(&mut self) {
+        self.watchdog
+            .ctrl
+            .write(|w| w.enable().clear_bit())
+    }
+}


### PR DESCRIPTION
I have limited experience in this space (both embedded and rust) so I was hoping to iterate on the design and implementation of this from feedback.

I'm aware of two things that may drive design (not to say there aren't more):
* Tick generation should be enabled prior to enabling the watchdog
* RP2040-E1

In regards to RP2040-E1, should we restrict the counter to the maximum load value (0xFFFFFF / 2) and if so, how?