### PR TITLE
Hardware divide/modulo support

### DIFF
--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -62,39 +62,43 @@ impl Sio {
 }
 
 /// Perform hardware unsigned divide/module operation
-pub fn div_unsigned(sio: &pac::SIO, dividend: u32, divisor: u32) -> DivResult<u32> {
-    sio.div_sdividend.write(|w| unsafe { w.bits(dividend) });
+impl HwDivider {
+    pub fn unsigned(&self, dividend: u32, divisor: u32) -> DivResult<u32> {
+        let sio = unsafe { &(*pac::SIO::ptr()) };
+        sio.div_sdividend.write(|w| unsafe { w.bits(dividend) });
 
-    sio.div_sdivisor.write(|w| unsafe { w.bits(divisor) });
+        sio.div_sdivisor.write(|w| unsafe { w.bits(divisor) });
 
-    cortex_m::asm::delay(8);
+        cortex_m::asm::delay(8);
 
-    // Note: quotient must be read last
-    let remainder = sio.div_remainder.read().bits();
-    let quotient = sio.div_quotient.read().bits();
+        // Note: quotient must be read last
+        let remainder = sio.div_remainder.read().bits();
+        let quotient = sio.div_quotient.read().bits();
 
-    DivResult {
-        remainder,
-        quotient,
+        DivResult {
+            remainder,
+            quotient,
+        }
     }
-}
 
 /// Perform hardware signed divide/module operation
-pub fn div_signed(sio: &pac::SIO, dividend: i32, divisor: i32) -> DivResult<i32> {
-    sio.div_sdividend
-        .write(|w| unsafe { w.bits(dividend as u32) });
+    pub fn signed(&self, dividend: i32, divisor: i32) -> DivResult<i32> {
+        let sio = unsafe { &(*pac::SIO::ptr()) };
+        sio.div_sdividend
+            .write(|w| unsafe { w.bits(dividend as u32) });
 
-    sio.div_sdivisor
-        .write(|w| unsafe { w.bits(divisor as u32) });
+        sio.div_sdivisor
+            .write(|w| unsafe { w.bits(divisor as u32) });
 
-    cortex_m::asm::delay(8);
+        cortex_m::asm::delay(8);
 
-    // Note: quotient must be read last
-    let remainder = sio.div_remainder.read().bits() as i32;
-    let quotient = sio.div_quotient.read().bits() as i32;
+        // Note: quotient must be read last
+        let remainder = sio.div_remainder.read().bits() as i32;
+        let quotient = sio.div_quotient.read().bits() as i32;
 
-    DivResult {
-        remainder,
-        quotient,
+        DivResult {
+            remainder,
+            quotient,
+        }
     }
 }

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -24,11 +24,11 @@ pub struct HwDivide {
     _private: PhantomData<u32>,
 }
 
-/// Result from signed divide/modulo operation
+/// Result from divide/modulo operation
 pub struct DivResult<T> {
-    /// The remainder result from signed divide/modulo operation
+    /// The remainder result from divide/modulo operation
     pub remainder: T,
-    /// The quotient result from signed divide/modulo operation
+    /// The quotient result from divide/modulo operation
     pub quotient: T,
 }
 
@@ -36,7 +36,6 @@ pub struct DivResult<T> {
 pub struct Sio {
     /// SIO
     pub sio: pac::SIO,
-
     /// GPIO Bank 0 registers
     pub gpio_bank0: SioGpioBank0,
     /// 8-cycle hardware divide/modulo module

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -20,7 +20,7 @@ pub struct SioGpioBank0 {
 }
 
 /// Marker struct for ownership of divide/modulo
-pub struct HwDivide {
+pub struct HwDivider {
     _private: PhantomData<u32>,
 }
 
@@ -34,12 +34,11 @@ pub struct DivResult<T> {
 
 /// Struct containing ownership markers for managing ownership of the SIO registers.
 pub struct Sio {
-    /// SIO
-    pub sio: pac::SIO,
+    _sio: pac::SIO,
     /// GPIO Bank 0 registers
     pub gpio_bank0: SioGpioBank0,
     /// 8-cycle hardware divide/modulo module
-    pub hw_divide: HwDivide,
+    pub hwdivider: HwDivider,
     // we can hand out other things here, for example:
     // gpio_qspi
     // interp0
@@ -49,13 +48,13 @@ impl Sio {
     /// Create `Sio` from the PAC.
     pub fn new(sio: pac::SIO) -> Self {
         Self {
-            sio,
+            _sio: sio,
 
             gpio_bank0: SioGpioBank0 {
                 _private: PhantomData,
             },
 
-            hw_divide: HwDivide {
+            hwdivider: HwDivider {
                 _private: PhantomData,
             },
         }

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -19,16 +19,16 @@ pub struct SioGpioBank0 {
     _private: PhantomData<u32>,
 }
 
-/// Marker struct for ownership of divide/modulo
+/// Marker struct for ownership of divide/modulo module
 pub struct HwDivider {
     _private: PhantomData<u32>,
 }
 
-/// Result from divide/modulo operation
+/// Result of divide/modulo operation
 pub struct DivResult<T> {
-    /// The remainder result from divide/modulo operation
+    /// The remainder of divide/modulo operation
     pub remainder: T,
-    /// The quotient result from divide/modulo operation
+    /// The quotient of divide/modulo operation
     pub quotient: T,
 }
 
@@ -61,8 +61,8 @@ impl Sio {
     }
 }
 
-/// Perform hardware unsigned divide/module operation
 impl HwDivider {
+    /// Perform hardware unsigned divide/modulo operation
     pub fn unsigned(&self, dividend: u32, divisor: u32) -> DivResult<u32> {
         let sio = unsafe { &(*pac::SIO::ptr()) };
         sio.div_sdividend.write(|w| unsafe { w.bits(dividend) });
@@ -81,7 +81,7 @@ impl HwDivider {
         }
     }
 
-/// Perform hardware signed divide/module operation
+    /// Perform hardware signed divide/modulo operation
     pub fn signed(&self, dividend: i32, divisor: i32) -> DivResult<i32> {
         let sio = unsafe { &(*pac::SIO::ptr()) };
         sio.div_sdividend

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -12,16 +12,15 @@
 //! let pins = pac.IO_BANK0.split(pac.PADS_BANK0, sio.gpio_bank0, &mut pac.RESETS);
 //! ```
 use super::*;
-use core::marker::PhantomData;
 
 /// Marker struct for ownership of SIO gpio bank0
 pub struct SioGpioBank0 {
-    _private: PhantomData<u32>,
+    _private: (),
 }
 
 /// Marker struct for ownership of divide/modulo module
 pub struct HwDivider {
-    _private: PhantomData<u32>,
+    _private: (),
 }
 
 /// Result of divide/modulo operation
@@ -50,13 +49,9 @@ impl Sio {
         Self {
             _sio: sio,
 
-            gpio_bank0: SioGpioBank0 {
-                _private: PhantomData,
-            },
+            gpio_bank0: SioGpioBank0 { _private: () },
 
-            hwdivider: HwDivider {
-                _private: PhantomData,
-            },
+            hwdivider: HwDivider { _private: () },
         }
     }
 }


### PR DESCRIPTION
A simple working implementation of hardware divide/modulo, tested on hardware.
I don't have much experience (both embedded and Rust) so there are a bunch of questions I want to ask:
* In the `sio.rs` module, there are comment that say:
```rust
// we can hand out other things here, for example:
// gpio_qspi
// divider
// interp0
// interp1
```
but I could not figure out how to fit my divmod implementation in there.
* For this initial implementation I split it into two different structs for unsigned and signed divmod operations. Is it possible to define a more generic implementation? I thought about using the trait bound `impl Into<u32>` or `impl Into<i32>` but both doesn't capture everything.
* I shamelessly copied the `sio()` function from the module `gpio.rs`. However, I'm not so sure about the safeness of it in this implementation. Also I had to duplicate the this piece of code since I split to two different structs. Not happy about this.
* I'm not sure if defining a different struct for result is even idiomatic rust. I thought about simply returning a tuple, but then the user would have to look at the documentation to know which one is the remainder/quotient.
* For signed divmod operation, I have to use `as u32` and `as i32` to cast the value around to make the compiler happy. I wonder if there is a overhead doing this. Is there a better way to do this?

Things that I also want to implement and would like some pointers for them:
* Maybe don't use blocking delay. In the datasheet it say we are free to do other operations except divmod during these 8 cycles.
* Logic to handle interrupt.
* Also implement for 2nd core.