### PR TITLE
Add 'rt' feature [for the HAL to pass to the PAC]

### DIFF
--- a/boards/feather_rp2040/Cargo.toml
+++ b/boards/feather_rp2040/Cargo.toml
@@ -16,4 +16,4 @@ cortex-m-rt = { version = "0.6.14", optional = true }
 
 [features]
 default = ["rt"]
-rt = ["cortex-m-rt"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pico/Cargo.toml
+++ b/boards/pico/Cargo.toml
@@ -13,3 +13,7 @@ license = "MIT OR Apache-2.0"
 cortex-m = "0.7.2"
 rp2040-hal = { path = "../../rp2040-hal", version = "0.1.0" }
 cortex-m-rt = { version = "0.6.14", optional = true }
+
+[features]
+default = ["rt"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pico_explorer/Cargo.toml
+++ b/boards/pico_explorer/Cargo.toml
@@ -16,4 +16,4 @@ cortex-m-rt = { version = "0.6.14", optional = true }
 
 [features]
 default = ["rt"]
-rt = ["cortex-m-rt"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pico_lipo_16mb/Cargo.toml
+++ b/boards/pico_lipo_16mb/Cargo.toml
@@ -16,4 +16,4 @@ cortex-m-rt = { version = "0.6.14", optional = true }
 
 [features]
 default = ["rt"]
-rt = ["cortex-m-rt"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -21,3 +21,6 @@ paste = "1.0"
 cortex-m-rt = "0.6.14"
 panic-halt = "0.2.0"
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
+
+[features]
+rt = ["rp2040-pac/rt"]


### PR DESCRIPTION
For the HAL, currently just passes the feature to the PAC.

Also pass the 'rt' feature through to the HAL for all the BSP crates.

This is needed to make using interrupts easier (feature use is global in Cargo, so if you include the PAC as a dependency in your application with the 'rt' feature, that will pollute the dependency inside the HAL -- but we probably shouldn't rely on that)

And either way, BSPs (should) re-export the HAL (as `bsp::hal`), and the HAL re-exports the PAC (as `hal::pac`) -- so there should be no reason to actually directly depend on the PAC (or the HAL if you are using a BSP)