### PR TITLE
Deny warnings in ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,8 @@ jobs:
   check:
     name: cargo-check
     runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get update

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -3,6 +3,8 @@ name: Clippy check
 jobs:
   clippy_check:
     runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -4,6 +4,8 @@ jobs:
   fmt:
     name: Rustfmt
     runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/tests_host.yml
+++ b/.github/workflows/tests_host.yml
@@ -4,6 +4,8 @@ jobs:
   check:
     name: Check and Lint
     runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -4,7 +4,6 @@
 //! NOTE This HAL is still under active development. This API will remain volatile until 1.0.0
 
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![no_std]
 
 extern crate cortex_m;

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -3,7 +3,7 @@
 //! This is an implementation of the [`embedded-hal`] traits for the RP2040 microcontroller
 //! NOTE This HAL is still under active development. This API will remain volatile until 1.0.0
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 #![no_std]
 
 extern crate cortex_m;


### PR DESCRIPTION
I have moved the deny warnings error to ci instead of every build.

See https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md for a rationale.