### PR TITLE
Add unsafe blocks around write_with_zero calls

### DIFF
--- a/rp2040-hal/src/clocks/macros.rs
+++ b/rp2040-hal/src/clocks/macros.rs
@@ -27,7 +27,9 @@ macro_rules! clocks {
                 /// Exchanges CLOCKS block against Self.
                 pub fn new(mut clocks_block: CLOCKS) -> Self {
                     // Disable resus that may be enabled from previous software
-                    clocks_block.clk_sys_resus_ctrl.write_with_zero(|w| w);
+                    unsafe {
+                        clocks_block.clk_sys_resus_ctrl.write_with_zero(|w| w);
+                    }
 
                     let shared_clocks = ShareableClocks::new(&mut clocks_block);
                     ClocksManager {

--- a/rp2040-hal/src/pwm.rs
+++ b/rp2040-hal/src/pwm.rs
@@ -93,7 +93,9 @@ impl $PXi {
 
         pad.gpio[self.pin].write(|w| w.ie().set_bit());
         pad.gpio[self.pin].write(|w| w.od().clear_bit());
-        io.gpio[self.pin].gpio_ctrl.write_with_zero(|w| w.funcsel().pwm_a_0());
+        unsafe {
+            io.gpio[self.pin].gpio_ctrl.write_with_zero(|w| w.funcsel().pwm_a_0());
+        }
     }
 
     fn cc(&self) -> &pac::$pwmx::ch::CC {


### PR DESCRIPTION
The newer version of svd2rust marks write_with_zero calls as unsafe, where the old one did not.
This PR wraps the only 2 calls instances of this in the HAL with unsafe blocks to fix the compile errors.