### PR TITLE
PIO support

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -13,12 +13,14 @@ license = "MIT OR Apache-2.0"
 cortex-m = "0.7.2"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 embedded-time = "0.12.0"
-nb = "1.0"
-rp2040-pac = { git = "https://github.com/rp-rs/rp2040-pac", rev = "0226d2c28e8dca03475d6783cbdf07f535859c23" }
-paste = "1.0"
-void = { version = "1.0.2", default-features = false }
-usb-device = "0.2.8"
 itertools = { version = "0.10.1", default-features = false }
+nb = "1.0"
+paste = "1.0"
+pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
+rp2040-pac = { git = "https://github.com/rp-rs/rp2040-pac", rev = "0226d2c28e8dca03475d6783cbdf07f535859c23" }
+usb-device = "0.2.8"
+vcell = "0.1"
+void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]
 cortex-m-rt = "0.6.14"

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -17,6 +17,7 @@ pub mod adc;
 pub mod clocks;
 pub mod gpio;
 pub mod i2c;
+pub mod pio;
 pub mod pll;
 pub mod prelude;
 pub mod pwm;

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -606,7 +606,7 @@ pub enum BuildError {
 impl<'a> PIOBuilder<'a> {
     /// Set config settings based on information from the given [`pio::Program`].
     /// Additional configuration may be needed in addition to this.
-    pub fn with_program(mut self, p: &'a Program) -> Self {
+    pub fn with_program<P>(mut self, p: &'a Program<P>) -> Self {
         self.instruction_origin = p.origin;
         self.instructions(&p.instructions)
             .wrap(p.wrap)

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -231,16 +231,6 @@ impl<P: Instance> StateMachine<P> {
             .write(|w| unsafe { w.sm0_instr().bits(instruction) })
     }
 
-    /// Pull a word from the RX FIFO
-    pub fn pull(&self) -> u32 {
-        self.block().rxf[self.id as usize].read().bits()
-    }
-
-    /// Push a word into the TX FIFO
-    pub fn push(&self, word: u32) {
-        self.block().txf[self.id as usize].write(|w| unsafe { w.bits(word) })
-    }
-
     /// Check if the current instruction is stalled.
     pub fn stalled(&self) -> bool {
         self.sm().sm_execctrl.read().exec_stalled().bits()

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -30,6 +30,9 @@ impl<P: Instance> core::fmt::Debug for PIO<P> {
     }
 }
 
+// TODO: Check is this sound.
+unsafe impl<P: Instance + Send> Send for PIO<P> {}
+
 impl<P: Instance> PIO<P> {
     /// Create a new PIO wrapper.
     pub fn new(pio: P, resets: &mut pac::RESETS) -> Self {
@@ -130,9 +133,6 @@ pub struct StateMachine<P: Instance> {
     block: *const rp2040_pac::pio0::RegisterBlock,
     _phantom: core::marker::PhantomData<P>,
 }
-
-// TODO: Check is this sound.
-unsafe impl<P: Instance + Send> Send for StateMachine<P> {}
 
 impl<P: Instance> StateMachine<P> {
     /// Start and stop the state machine.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -644,7 +644,7 @@ pub enum BuildError {
 impl<'a> PIOBuilder<'a> {
     /// Set config settings based on information from the given [`pio::Program`].
     /// Additional configuration may be needed in addition to this.
-    pub fn with_program<P>(mut self, p: &'a Program<P>) -> Self {
+    pub fn with_program(mut self, p: &'a Program<{ pio::RP2040_MAX_PROGRAM_SIZE }>) -> Self {
         self.instruction_origin = p.origin;
         self.instructions(&p.code).wrap(p.wrap).side_set(p.side_set)
     }

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -627,7 +627,7 @@ impl<'a> PIOBuilder<'a> {
         self
     }
 
-    /// Sets the pins asserted by `SET` instruction.
+    /// Set the pins asserted by `SET` instruction.
     ///
     /// The least-significant bit of `SET` instruction asserts the state of the pin indicated by `base`, the next bit
     /// asserts the state of the next pin, and so on up to `count` pins. The pin numbers are considered modulo 32.
@@ -635,13 +635,10 @@ impl<'a> PIOBuilder<'a> {
         assert!(count <= 5);
         self.set_base = base;
         self.set_count = count;
-        // self.in_base = base;
-        // self.out_base = base;
-        // self.out_count = count;
         self
     }
 
-    /// Sets the pins asserted by `OUT` instruction.
+    /// Set the pins asserted by `OUT` instruction.
     ///
     /// The least-significant bit of `OUT` instruction asserts the state of the pin indicated by `base`, the next bit
     /// asserts the state of the next pin, and so on up to `count` pins. The pin numbers are considered modulo 32.
@@ -652,16 +649,27 @@ impl<'a> PIOBuilder<'a> {
         self
     }
 
+    /// Set the pins used by `IN` instruction.
+    ///
+    /// The `IN` instruction reads the least significant bit from the pin indicated by `base`, the next bit from the
+    /// next pin, and so on. The pin numbers are considered modulo 32.
     pub fn in_pin_base(mut self, base: u8) -> Self {
         self.in_base = base;
         self
     }
 
+    /// Set the pin used by `JMP PIN` instruction.
+    ///
+    /// When the pin set by this function is high, the jump is taken, otherwise not.
     pub fn jmp_pin(mut self, pin: u8) -> Self {
         self.jmp_pin = pin;
         self
     }
 
+    /// Set the pins used by side-set instructions.
+    ///
+    /// The least-significant side-set bit asserts the state of the pin indicated by `base`, the next bit asserts the
+    /// state of the next pin, and so on up to number of bits set using [`Self::side_set`] function.
     pub fn side_set_pin_base(mut self, base: u8) -> Self {
         self.side_set_base = base;
         self

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -608,9 +608,7 @@ impl<'a> PIOBuilder<'a> {
     /// Additional configuration may be needed in addition to this.
     pub fn with_program<P>(mut self, p: &'a Program<P>) -> Self {
         self.instruction_origin = p.origin;
-        self.instructions(&p.code)
-            .wrap(p.wrap)
-            .side_set(p.side_set)
+        self.instructions(&p.code).wrap(p.wrap).side_set(p.side_set)
     }
 
     /// Set the instructions of the program.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -301,10 +301,10 @@ impl<P: Instance> Interrupt<P> {
     /// don't correspond with the state machine index; any state machine can raise any one of the four interrupts.
     pub fn enable_sm_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_inte.write(|w| w.sm0().set_bit()),
-            1 => self.irq().irq_inte.write(|w| w.sm1().set_bit()),
-            2 => self.irq().irq_inte.write(|w| w.sm2().set_bit()),
-            3 => self.irq().irq_inte.write(|w| w.sm3().set_bit()),
+            0 => self.irq().irq_inte.modify(|_, w| w.sm0().set_bit()),
+            1 => self.irq().irq_inte.modify(|_, w| w.sm1().set_bit()),
+            2 => self.irq().irq_inte.modify(|_, w| w.sm2().set_bit()),
+            3 => self.irq().irq_inte.modify(|_, w| w.sm3().set_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -314,10 +314,10 @@ impl<P: Instance> Interrupt<P> {
     /// See [`Self::enable_sm_interrupt`] for info about the index.
     pub fn disable_sm_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_inte.write(|w| w.sm0().clear_bit()),
-            1 => self.irq().irq_inte.write(|w| w.sm1().clear_bit()),
-            2 => self.irq().irq_inte.write(|w| w.sm2().clear_bit()),
-            3 => self.irq().irq_inte.write(|w| w.sm3().clear_bit()),
+            0 => self.irq().irq_inte.modify(|_, w| w.sm0().clear_bit()),
+            1 => self.irq().irq_inte.modify(|_, w| w.sm1().clear_bit()),
+            2 => self.irq().irq_inte.modify(|_, w| w.sm2().clear_bit()),
+            3 => self.irq().irq_inte.modify(|_, w| w.sm3().clear_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -329,10 +329,10 @@ impl<P: Instance> Interrupt<P> {
     /// See [`Self::enable_sm_interrupt`] for info about the index.
     pub fn force_sm_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_intf.write(|w| w.sm0().set_bit()),
-            1 => self.irq().irq_intf.write(|w| w.sm1().set_bit()),
-            2 => self.irq().irq_intf.write(|w| w.sm2().set_bit()),
-            3 => self.irq().irq_intf.write(|w| w.sm3().set_bit()),
+            0 => self.irq().irq_intf.modify(|_, w| w.sm0().set_bit()),
+            1 => self.irq().irq_intf.modify(|_, w| w.sm1().set_bit()),
+            2 => self.irq().irq_intf.modify(|_, w| w.sm2().set_bit()),
+            3 => self.irq().irq_intf.modify(|_, w| w.sm3().set_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -343,10 +343,10 @@ impl<P: Instance> Interrupt<P> {
     /// one could push more data to it.
     pub fn enable_tx_not_full_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_inte.write(|w| w.sm0_txnfull().set_bit()),
-            1 => self.irq().irq_inte.write(|w| w.sm1_txnfull().set_bit()),
-            2 => self.irq().irq_inte.write(|w| w.sm2_txnfull().set_bit()),
-            3 => self.irq().irq_inte.write(|w| w.sm3_txnfull().set_bit()),
+            0 => self.irq().irq_inte.modify(|_, w| w.sm0_txnfull().set_bit()),
+            1 => self.irq().irq_inte.modify(|_, w| w.sm1_txnfull().set_bit()),
+            2 => self.irq().irq_inte.modify(|_, w| w.sm2_txnfull().set_bit()),
+            3 => self.irq().irq_inte.modify(|_, w| w.sm3_txnfull().set_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -356,10 +356,22 @@ impl<P: Instance> Interrupt<P> {
     /// See [`Self::enable_tx_not_full_interrupt`] for info about the index.
     pub fn disable_tx_not_full_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_inte.write(|w| w.sm0_txnfull().clear_bit()),
-            1 => self.irq().irq_inte.write(|w| w.sm1_txnfull().clear_bit()),
-            2 => self.irq().irq_inte.write(|w| w.sm2_txnfull().clear_bit()),
-            3 => self.irq().irq_inte.write(|w| w.sm3_txnfull().clear_bit()),
+            0 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm0_txnfull().clear_bit()),
+            1 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm1_txnfull().clear_bit()),
+            2 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm2_txnfull().clear_bit()),
+            3 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm3_txnfull().clear_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -369,10 +381,10 @@ impl<P: Instance> Interrupt<P> {
     /// See [`Self::enable_tx_not_full_interrupt`] for info about the index.
     pub fn force_tx_not_full_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_intf.write(|w| w.sm0_txnfull().set_bit()),
-            1 => self.irq().irq_intf.write(|w| w.sm1_txnfull().set_bit()),
-            2 => self.irq().irq_intf.write(|w| w.sm2_txnfull().set_bit()),
-            3 => self.irq().irq_intf.write(|w| w.sm3_txnfull().set_bit()),
+            0 => self.irq().irq_intf.modify(|_, w| w.sm0_txnfull().set_bit()),
+            1 => self.irq().irq_intf.modify(|_, w| w.sm1_txnfull().set_bit()),
+            2 => self.irq().irq_intf.modify(|_, w| w.sm2_txnfull().set_bit()),
+            3 => self.irq().irq_intf.modify(|_, w| w.sm3_txnfull().set_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -383,10 +395,22 @@ impl<P: Instance> Interrupt<P> {
     /// i.e. one could read more data from it.
     pub fn enable_rx_not_empty_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_inte.write(|w| w.sm0_rxnempty().set_bit()),
-            1 => self.irq().irq_inte.write(|w| w.sm1_rxnempty().set_bit()),
-            2 => self.irq().irq_inte.write(|w| w.sm2_rxnempty().set_bit()),
-            3 => self.irq().irq_inte.write(|w| w.sm3_rxnempty().set_bit()),
+            0 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm0_rxnempty().set_bit()),
+            1 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm1_rxnempty().set_bit()),
+            2 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm2_rxnempty().set_bit()),
+            3 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm3_rxnempty().set_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -396,10 +420,22 @@ impl<P: Instance> Interrupt<P> {
     /// See [`Self::enable_rx_not_empty_interrupt`] for info about the index.
     pub fn disable_rx_not_empty_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_inte.write(|w| w.sm0_rxnempty().clear_bit()),
-            1 => self.irq().irq_inte.write(|w| w.sm1_rxnempty().clear_bit()),
-            2 => self.irq().irq_inte.write(|w| w.sm2_rxnempty().clear_bit()),
-            3 => self.irq().irq_inte.write(|w| w.sm3_rxnempty().clear_bit()),
+            0 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm0_rxnempty().clear_bit()),
+            1 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm1_rxnempty().clear_bit()),
+            2 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm2_rxnempty().clear_bit()),
+            3 => self
+                .irq()
+                .irq_inte
+                .modify(|_, w| w.sm3_rxnempty().clear_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }
@@ -409,10 +445,22 @@ impl<P: Instance> Interrupt<P> {
     /// See [`Self::enable_rx_not_empty_interrupt`] for info about the index.
     pub fn force_rx_not_empty_interrupt(&self, id: u8) {
         match id {
-            0 => self.irq().irq_intf.write(|w| w.sm0_rxnempty().set_bit()),
-            1 => self.irq().irq_intf.write(|w| w.sm1_rxnempty().set_bit()),
-            2 => self.irq().irq_intf.write(|w| w.sm2_rxnempty().set_bit()),
-            3 => self.irq().irq_intf.write(|w| w.sm3_rxnempty().set_bit()),
+            0 => self
+                .irq()
+                .irq_intf
+                .modify(|_, w| w.sm0_rxnempty().set_bit()),
+            1 => self
+                .irq()
+                .irq_intf
+                .modify(|_, w| w.sm1_rxnempty().set_bit()),
+            2 => self
+                .irq()
+                .irq_intf
+                .modify(|_, w| w.sm2_rxnempty().set_bit()),
+            3 => self
+                .irq()
+                .irq_intf
+                .modify(|_, w| w.sm3_rxnempty().set_bit()),
             _ => panic!("invalid state machine interrupt number"),
         }
     }

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1,0 +1,290 @@
+//! Programmable IO (PIO)
+/// See [Chapter 3](https://rptl.io/pico-datasheet) for more details.
+
+use rp2040_pac::Peripherals;
+// use vcell::VolatileCell;
+
+/*
+/// aaa
+pub fn aaa<P>(p: &Peripherals, program: &pio::Program<P>) {
+    // atomic steps numbered
+
+    let instrs: &[VolatileCell<u32>; 16] = unsafe { core::mem::transmute(&p.PIO0.instr_mem0) };
+    // 1. Move program somewhere into the 32 instrs of memory in pio
+    for (i, instr) in program.code().iter().enumerate() {
+        instrs[i].set(*instr as u32);
+    }
+
+    // 2. Find a free state machine
+
+    unsafe {
+        // 8. Interact with the state machine.
+        p.PIO0.sm0_addr.read().bits();
+        p.PIO0.rxf0.read().bits();
+        p.PIO0.txf0.write(|w| w.bits(0));
+        p.PIO0.sm0_execctrl.read().exec_stalled().bit();
+    }
+}
+*/
+
+/// a
+pub struct PIOBuilder<'a> {
+    p: &'a Peripherals,
+    // wrap program from top to bottom
+    wrap_top: u8,
+    wrap_bottom: u8,
+    // sideset is optional
+    side_en: bool,
+    // sideset sets pindirs
+    side_pindir: bool,
+    // gpio pin used by `jmp pin` instr
+    jmp_pin: u8,
+    // continuously assert the most recent OUT/SET to the pins.
+    out_sticky: bool,
+    // use a bit of OUT data as an auxilary write enable.
+    // when OUT_STICKY is enabled, setting the bit to 0 deasserts for that instr.
+    inline_out_en: bool,
+    // which bit to use
+    out_en_sel: u8,
+    // for `mov x, status`.
+    // false -> all ones if tx fifo level < N
+    // true -> all ones if rx fifo level < N
+    status_sel: bool,
+    // base = starting pin
+    // count = number of pins
+    in_base: u8,
+    out_base: u8,
+    out_count: u8,
+    set_base: u8,
+    set_count: u8,
+    sideset_base: u8,
+    sideset_count: u8,
+    // rx fifo steals tx fifo storage to be twice as deep
+    fjoin_rx: bool,
+    // tx fifo steals rx fifo storage to be twice as deep
+    fjoin_tx: bool,
+    // enable autopull
+    autopull: bool,
+    // enable autopush
+    autopush: bool,
+    // threhold for autopull
+    pull_thresh: u8,
+    // threshold for autopush
+    push_thresh: u8,
+    // true = shift out of OSR to right
+    in_shiftdir: bool,
+    // true = shift into ISR from right
+    out_shiftdir: bool,
+    // sm frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+    clkdiv_int: u16,
+    clkdiv_frac: u8,
+}
+
+impl<'a> PIOBuilder<'a> {
+    /// a
+    pub fn new(p: &'a Peripherals) -> Self {
+        PIOBuilder {
+            p,
+            wrap_top: 0,
+            wrap_bottom: 31,
+            side_en: false,
+            side_pindir: false,
+            jmp_pin: 0,
+            out_sticky: false,
+            inline_out_en: false,
+            out_en_sel: 0,
+            status_sel: false,
+            in_base: 0,
+            out_base: 0,
+            out_count: 32,
+            set_base: 0,
+            set_count: 0,
+            sideset_base: 0,
+            sideset_count: 0,
+            fjoin_rx: false,
+            fjoin_tx: false,
+            autopull: false,
+            autopush: false,
+            pull_thresh: 32,
+            push_thresh: 32,
+            in_shiftdir: true,
+            out_shiftdir: true,
+            clkdiv_int: 1,
+            clkdiv_frac: 0,
+        }
+    }
+}
+
+/// a
+pub enum Buffers {
+    /// a
+    RxTx,
+    /// a
+    OnlyTx,
+    /// a
+    OnlyRx,
+}
+
+impl<'a> PIOBuilder<'a> {
+    /// a
+    pub fn with_program<P>(&mut self, p: &pio::Program<P>) -> &mut Self {
+        self.wrap_top = p.wrap().0;
+        self.wrap_bottom = p.wrap().1;
+
+        self.side_en = p.side_set().optional();
+        self.side_pindir = p.side_set().pindirs();
+
+        self.sideset_count = p.side_set().bits();
+
+        self
+    }
+
+    /// a
+    pub fn buffers(&mut self, buffers: Buffers) -> &mut Self {
+        match buffers {
+            Buffers::RxTx => {
+                self.fjoin_tx = false;
+                self.fjoin_rx = false;
+            }
+            Buffers::OnlyTx => {
+                self.fjoin_rx = false;
+                self.fjoin_tx = true;
+            }
+            Buffers::OnlyRx => {
+                self.fjoin_rx = true;
+                self.fjoin_tx = true;
+            }
+        }
+        self
+    }
+
+    /// 1 for full speed. A clock divisor of `n` will cause the state macine to run 1 cycle every
+    /// `n`. For a small `n`, a fractional divisor may introduce unacceptable jitter.
+    pub fn clock_divisor(&mut self, div: f32) -> &mut Self {
+        // sm frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+        self.clkdiv_int = div as u16;
+        self.clkdiv_frac = (div.fract() * 256.0) as u8;
+        self
+    }
+
+    /// a
+    pub fn build(self) {
+        const SM_ID: u8 = 0;
+
+        // ### STOP SM ####
+        self.set_sm_enabled(SM_ID, false);
+
+        // ### CONFIGURE SM ###
+        self.p.PIO0.sm0_execctrl.write(|w| {
+            unsafe {
+                w.wrap_top().bits(self.wrap_top);
+                w.wrap_bottom().bits(self.wrap_bottom);
+            }
+
+            w.side_en().bit(self.side_en);
+            w.side_pindir().bit(self.side_pindir);
+
+            unsafe {
+                w.jmp_pin().bits(self.jmp_pin);
+            }
+
+            w.out_sticky().bit(self.out_sticky);
+
+            w.inline_out_en().bit(self.inline_out_en);
+            unsafe {
+                w.out_en_sel().bits(self.out_en_sel);
+            }
+
+            w.status_sel().bit(self.status_sel);
+
+            w
+        });
+
+        self.p.PIO0.sm0_pinctrl.write(|w| {
+            unsafe {
+                w.in_base().bits(self.in_base);
+            }
+
+            unsafe {
+                w.out_base().bits(self.out_base);
+                w.out_count().bits(self.out_count);
+            }
+
+            unsafe {
+                w.set_base().bits(self.set_base);
+                w.set_count().bits(self.set_count);
+            }
+
+            unsafe {
+                w.sideset_base().bits(self.sideset_base);
+                w.sideset_count().bits(self.sideset_count);
+            }
+
+            w
+        });
+
+        self.p.PIO0.sm0_shiftctrl.write(|w| {
+            w.fjoin_rx().bit(self.fjoin_rx);
+            w.fjoin_tx().bit(self.fjoin_tx);
+
+            w.autopull().bit(self.autopull);
+            w.autopush().bit(self.autopush);
+
+            unsafe {
+                w.pull_thresh().bits(self.pull_thresh);
+                w.push_thresh().bits(self.push_thresh);
+            }
+
+            w.out_shiftdir().bit(self.out_shiftdir);
+            w.in_shiftdir().bit(self.in_shiftdir);
+
+            w
+        });
+
+        self.p.PIO0.sm0_clkdiv.write(|w| {
+            unsafe {
+                w.int().bits(self.clkdiv_int);
+                w.frac().bits(self.clkdiv_frac);
+            }
+
+            w
+        });
+
+        // ### RESTART SM & RESET SM CLOCK ###
+        self.p.PIO0.ctrl.write(|w| {
+            unsafe {
+                w.sm_restart()
+                    .bits(self.p.PIO0.ctrl.read().sm_restart().bits() | 1 << SM_ID);
+                w.clkdiv_restart()
+                    .bits(self.p.PIO0.ctrl.read().clkdiv_restart().bits() | 1 << SM_ID);
+            }
+
+            w
+        });
+
+        // ### SET SM PC ###
+        self.p.PIO0.sm0_instr.write(|w| {
+            // set starting location by setting the state machine
+            // to execute a jmp to the beginning of the program
+            // we loaded in.
+            unsafe {
+                w.sm0_instr().bits(0b000_00000_000_00000); // jmp 0
+            }
+            w
+        });
+
+        // ### ENABLE SM ###
+        self.set_sm_enabled(0, true);
+    }
+}
+
+impl<'a> PIOBuilder<'a> {
+    fn set_sm_enabled(&self, id: u8, enabled: bool) {
+        let bits = self.p.PIO0.ctrl.read().sm_enable().bits();
+        let bits = (bits & !(1 << id)) | ((enabled as u8) << id);
+        self.p
+            .PIO0
+            .ctrl
+            .write(|w| unsafe { w.sm_enable().bits(bits) });
+    }
+}

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -608,7 +608,7 @@ impl<'a> PIOBuilder<'a> {
     /// Additional configuration may be needed in addition to this.
     pub fn with_program<P>(mut self, p: &'a Program<P>) -> Self {
         self.instruction_origin = p.origin;
-        self.instructions(&p.instructions)
+        self.instructions(&p.code)
             .wrap(p.wrap)
             .side_set(p.side_set)
     }


### PR DESCRIPTION
Add support for PIO hardware. This PR is based on #9 and implements most of the missing features, including interrupts.

This PR depends on [`pio-rs#3`](https://github.com/rp-rs/pio-rs/pull/3).

Closes #5.