### PR TITLE
I2c fixes

### DIFF
--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -38,9 +38,11 @@ impl From<DynPinMode> for ModeFields {
                     Floating => (),
                     PullDown => {
                         fields.pde = true;
+                        fields.pue = false;
                     }
                     PullUp => {
                         fields.pue = true;
+                        fields.pde = false;
                     }
                 }
             }
@@ -54,9 +56,11 @@ impl From<DynPinMode> for ModeFields {
                     Floating => (),
                     PullDown => {
                         fields.pde = true;
+                        fields.pue = false;
                     }
                     PullUp => {
                         fields.pue = true;
+                        fields.pde = false;
                     }
                 }
             }

--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -38,11 +38,9 @@ impl From<DynPinMode> for ModeFields {
                     Floating => (),
                     PullDown => {
                         fields.pde = true;
-                        fields.pue = false;
                     }
                     PullUp => {
                         fields.pue = true;
-                        fields.pde = false;
                     }
                 }
             }
@@ -56,11 +54,9 @@ impl From<DynPinMode> for ModeFields {
                     Floating => (),
                     PullDown => {
                         fields.pde = true;
-                        fields.pue = false;
                     }
                     PullUp => {
                         fields.pue = true;
-                        fields.pde = false;
                     }
                 }
             }
@@ -94,7 +90,6 @@ impl From<DynPinMode> for ModeFields {
                 fields.inen = true;
                 if func == I2C {
                     fields.pue = true;
-                    fields.pde = false;
                 }
             }
         };

--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -88,6 +88,10 @@ impl From<DynPinMode> for ModeFields {
                     UsbAux => 9,
                 };
                 fields.inen = true;
+                if func == I2C {
+                    fields.pue = true;
+                    fields.pde = false;
+                }
             }
         };
 

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -130,10 +130,10 @@ macro_rules! hal {
                     let hcnt = period - lcnt;
 
                     // Check for out-of-range divisors:
-                    assert!(hcnt < 0xffff);
-                    assert!(lcnt < 0xffff);
-                    assert!(hcnt > 8);
-                    assert!(lcnt > 8);
+                    assert!(hcnt <= 0xffff);
+                    assert!(lcnt <= 0xffff);
+                    assert!(hcnt >= 8);
+                    assert!(lcnt >= 8);
 
                     // Per I2C-bus specification a device in standard or fast mode must
                     // internally provide a hold time of at least 300ns for the SDA signal to

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -126,8 +126,8 @@ macro_rules! hal {
                     // There are some subtleties to I2C timing which we are completely ignoring here
                     // See: https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_i2c/i2c.c#L69
                     let period = (freq_in + freq / 2) / freq;
-                    let hcnt = period * 3 / 5; // oof this one hurts
-                    let lcnt = period - hcnt;
+                    let lcnt = period * 3 / 5; // oof this one hurts
+                    let hcnt = period - lcnt;
 
                     // Check for out-of-range divisors:
                     assert!(hcnt < 0xffff);

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -105,7 +105,7 @@ macro_rules! hal {
 
                     i2c.ic_enable.write(|w| w.enable().disabled());
 
-                    i2c.ic_con.write(|w| {
+                    i2c.ic_con.modify(|_,w| {
                         w.speed().fast();
                         w.master_mode().enabled();
                         w.ic_slave_disable().slave_disabled();
@@ -162,7 +162,7 @@ macro_rules! hal {
                                 .bits(if lcnt < 16 { 1 } else { (lcnt / 16) as u8 })
                         });
                         i2c.ic_sda_hold
-                            .write(|w| w.ic_sda_tx_hold().bits(sda_tx_hold_count as u16));
+                            .modify(|_r,w| w.ic_sda_tx_hold().bits(sda_tx_hold_count as u16));
                     }
 
                     i2c.ic_enable.write(|w| w.enable().enabled());


### PR DESCRIPTION
- lcnt and hcnt were swapped when porting from the C SDK, swapped them back so timings are calculated correctly
https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_i2c/i2c.c#L71

- fixed asserts on the limits of lcnt and hcnt to match the C SDK
https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_i2c/i2c.c#L74

- ic_con and ic_sda_hold register writes in the C SDK were read-modify-write, so switch them to modify calls to avoid clobbering other fields in the register
https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_i2c/i2c.c#L99
https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_i2c/i2c.c#L106

- enable pull-up on pins in i2c mode by default. changing to i2c mode erases all pin modifiers, and we currently have no way of changing pin options once in the pins are in i2c mode.
I'd like this to be configurable, but until that is implemented this is a better default