### PR TITLE
Adafruit feather rp2040

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ members = [
     "boards/pico_lipo_16mb",
     "boards/adafruit_macropad",
 ]
+
+[patch."https://github.com/rp-rs/rp2040-boot2-rs"]
+rp2040-boot2 = { path = "../rp2040-boot2-rs"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ members = [
     "boards/pico_lipo_16mb",
     "boards/adafruit_macropad",
 ]
-
-[patch."https://github.com/rp-rs/rp2040-boot2-rs"]
-rp2040-boot2 = { path = "../rp2040-boot2-rs"}

--- a/boards/feather_rp2040/Cargo.toml
+++ b/boards/feather_rp2040/Cargo.toml
@@ -18,8 +18,7 @@ embedded-time = "0.12.0"
 [dev-dependencies]
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
-rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
-
+rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs",  rev = "d2128ef9875e91e454dd0fb0d747c7439ae0627b" }
 
 [features]
 default = ["rt"]

--- a/boards/feather_rp2040/Cargo.toml
+++ b/boards/feather_rp2040/Cargo.toml
@@ -13,6 +13,13 @@ license = "MIT OR Apache-2.0"
 cortex-m = "0.7.2"
 rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0"}
 cortex-m-rt = { version = "0.6.14", optional = true }
+embedded-time = "0.12.0"
+
+[dev-dependencies]
+panic-halt= "0.2.0"
+embedded-hal ="0.2.5"
+rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", branch="main" }
+
 
 [features]
 default = ["rt"]

--- a/boards/feather_rp2040/README.md
+++ b/boards/feather_rp2040/README.md
@@ -1,0 +1,1 @@
+Adafruit Feather RP2040 Board Support Crate

--- a/boards/feather_rp2040/examples/feather_blinky.rs
+++ b/boards/feather_rp2040/examples/feather_blinky.rs
@@ -1,0 +1,60 @@
+//! Blinks the LED on a Pico board
+//!
+//! This will blink an LED attached to GP25, which is the pin the Pico uses for the on-board LED.
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use embedded_hal::digital::v2::OutputPin;
+use embedded_time::rate::*;
+use panic_halt as _;
+use feather_rp2040::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        sio::Sio,
+        watchdog::Watchdog,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_25Q64CS;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+    let mut led_pin = pins.d13.into_push_pull_output();
+
+    loop {
+        led_pin.set_high().unwrap();
+        delay.delay_ms(1000);
+        led_pin.set_low().unwrap();
+        delay.delay_ms(1000);
+    }
+}

--- a/boards/feather_rp2040/examples/feather_blinky.rs
+++ b/boards/feather_rp2040/examples/feather_blinky.rs
@@ -7,7 +7,6 @@
 use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_time::rate::*;
-use panic_halt as _;
 use feather_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
@@ -17,6 +16,7 @@ use feather_rp2040::{
     },
     Pins, XOSC_CRYSTAL_FREQ,
 };
+use panic_halt as _;
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;

--- a/boards/feather_rp2040/examples/feather_blinky.rs
+++ b/boards/feather_rp2040/examples/feather_blinky.rs
@@ -1,6 +1,6 @@
-//! Blinks the LED on a Pico board
+//! Blinks the LED on a Adafruit Feather RP2040 board
 //!
-//! This will blink an LED attached to GP25, which is the pin the Pico uses for the on-board LED.
+//! This will blink on-board LED.
 #![no_std]
 #![no_main]
 
@@ -19,7 +19,7 @@ use feather_rp2040::{
 };
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_25Q64CS;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
 
 #[entry]
 fn main() -> ! {
@@ -53,8 +53,8 @@ fn main() -> ! {
 
     loop {
         led_pin.set_high().unwrap();
-        delay.delay_ms(1000);
+        delay.delay_ms(1500);
         led_pin.set_low().unwrap();
-        delay.delay_ms(1000);
+        delay.delay_ms(1500);
     }
 }

--- a/boards/feather_rp2040/src/lib.rs
+++ b/boards/feather_rp2040/src/lib.rs
@@ -55,5 +55,4 @@ hal::bsp_pins!(
     Gpio29 { name: a3 },
 );
 
-
 pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;

--- a/boards/feather_rp2040/src/lib.rs
+++ b/boards/feather_rp2040/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-extern crate rp2040_hal as hal;
+pub extern crate rp2040_hal as hal;
 
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
@@ -54,3 +54,6 @@ hal::bsp_pins!(
     Gpio28 { name: a2 },
     Gpio29 { name: a3 },
 );
+
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
Added a blinky example for the Adafruit Feather RP2040 board which uses the flash support added in rp-rs/rp2040-boot2-rs#9 . The example is based on the Pico board example with modifications to utilize the board support crate for the Feather RP2040 board. The Cargo.toml references the specific version rp-rs/rp2040-boot2-rs#9 , this should be changed once we have a new release for rp2040-boot2-rs.