### PR TITLE
i2c lockup fix

### DIFF
--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -309,7 +309,7 @@ macro_rules! hal {
                         let first = i == 0;
                         let last = i == bytes.len() - 1;
 
-                        while 16 - self.i2c.ic_txflr.read().txflr().bits() > 0 {}
+                        while self.i2c.ic_txflr.read().txflr().bits() > 0 {}
 
                         self.i2c.ic_data_cmd.write(|w| {
                             if first {

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -181,7 +181,7 @@ macro_rules! hal {
 
                 fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
-                    assert!(bytes.len() < 256 && bytes.len() > 0);
+                    assert!(bytes.len() < 256);
 
                     assert!(addr < 0x80);
                     assert!(!i2c_reserved_addr(addr));
@@ -252,8 +252,8 @@ macro_rules! hal {
 
                 fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
-                    assert!(bytes.len() < 256 && bytes.len() > 0);
-                    assert!(buffer.len() < 256 && buffer.len() > 0);
+                    assert!(bytes.len() < 256);
+                    assert!(buffer.len() < 256);
 
                     assert!(addr < 0x80);
                     assert!(!i2c_reserved_addr(addr));

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -181,7 +181,7 @@ macro_rules! hal {
 
                 fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
-                    assert!(bytes.len() < 256);
+                    assert!(bytes.len() < 256 && bytes.len() > 0);
 
                     assert!(addr < 0x80);
                     assert!(!i2c_reserved_addr(addr));
@@ -252,8 +252,8 @@ macro_rules! hal {
 
                 fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
-                    assert!(bytes.len() < 256);
-                    assert!(buffer.len() < 256);
+                    assert!(bytes.len() < 256 && bytes.len() > 0);
+                    assert!(buffer.len() < 256 && buffer.len() > 0);
 
                     assert!(addr < 0x80);
                     assert!(!i2c_reserved_addr(addr));

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -179,19 +179,19 @@ macro_rules! hal {
             }
 
             impl<PINS> I2C<$I2CX, PINS> {
-                // Number of bytes currently in the TX FIFO
+                /// Number of bytes currently in the TX FIFO
                 #[inline]
                 fn tx_fifo_used(&self) -> u8 {
                     self.i2c.ic_txflr.read().txflr().bits()
                 }
 
-                // Remaining capacity in the TX FIFO
+                /// Remaining capacity in the TX FIFO
                 #[inline]
                 fn tx_fifo_free(&self) -> u8 {
                     TX_FIFO_SIZE - self.tx_fifo_used()
                 }
 
-                // TX FIFO is at capacity
+                /// TX FIFO is at capacity
                 #[inline]
                 fn tx_fifo_full(&self) -> bool {
                     self.tx_fifo_free() == 0

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -24,13 +24,13 @@ pub enum Error {
     /// I2C abort with error
     Abort(u32),
     /// User passed in a read buffer that was 0 or >255 length
-    InvalidReadBufferLength(u32),
+    InvalidReadBufferLength(usize),
     /// User passed in a write buffer that was 0 or >255 length
-    InvalidWriteBufferLength(u32),
+    InvalidWriteBufferLength(usize),
     /// Target i2c address is out of range
-    AddressOutOfRange(u32),
+    AddressOutOfRange(u8),
     /// Target i2c address is reserved
-    AddressReserved(u32),
+    AddressReserved(u8),
 }
 
 /// SCL pin
@@ -212,11 +212,11 @@ macro_rules! hal {
                 fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
                     if (bytes.len() > 255 || bytes.len() == 0) {
-                        return Err(Error::InvalidWriteBufferLength(bytes.len() as u32));
+                        return Err(Error::InvalidWriteBufferLength(bytes.len()));
                     } else if addr >= 0x80 {
-                        return Err(Error::AddressOutOfRange(addr as u32));
+                        return Err(Error::AddressOutOfRange(addr));
                     } else if i2c_reserved_addr(addr) {
-                        return Err(Error::AddressReserved(addr as u32));
+                        return Err(Error::AddressReserved(addr));
                     }
 
                     self.i2c.ic_enable.write(|w| w.enable().disabled());
@@ -286,13 +286,13 @@ macro_rules! hal {
                 fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
                     if (bytes.len() > 255 || bytes.len() == 0) {
-                        return Err(Error::InvalidWriteBufferLength(bytes.len() as u32));
+                        return Err(Error::InvalidWriteBufferLength(bytes.len()));
                     } else if (buffer.len() > 255 || buffer.len() == 0) {
-                        return Err(Error::InvalidReadBufferLength(buffer.len() as u32));
+                        return Err(Error::InvalidReadBufferLength(buffer.len()));
                     } else if addr >= 0x80 {
-                        return Err(Error::AddressOutOfRange(addr as u32));
+                        return Err(Error::AddressOutOfRange(addr));
                     } else if i2c_reserved_addr(addr) {
-                        return Err(Error::AddressReserved(addr as u32));
+                        return Err(Error::AddressReserved(addr));
                     }
 
                     self.i2c.ic_enable.write(|w| w.enable().disabled());
@@ -391,11 +391,11 @@ macro_rules! hal {
                 fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
                     // TODO support transfers of more than 255 bytes
                     if (buffer.len() > 255 || buffer.len() == 0) {
-                        return Err(Error::InvalidReadBufferLength(buffer.len() as u32));
+                        return Err(Error::InvalidReadBufferLength(buffer.len()));
                     } else if addr >= 0x80 {
-                        return Err(Error::AddressOutOfRange(addr as u32));
+                        return Err(Error::AddressOutOfRange(addr));
                     } else if i2c_reserved_addr(addr) {
-                        return Err(Error::AddressReserved(addr as u32));
+                        return Err(Error::AddressReserved(addr));
                     }
 
                     self.i2c.ic_enable.write(|w| w.enable().disabled());


### PR DESCRIPTION
When doing an i2c WriteRead the driver would lock up indefinitely due to an error in how the transmit FIFO was being checked.
I also removed asserts for zero length read and writes, since it's quite legal for someone to do a zero length write to check for the existence of a peripheral on the bus, and some devices do not have any registers, so they do not require writes in WriteRead.
Also improves error handling.
Fixes #95 