### PR TITLE
Usb fixes

### DIFF
--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -149,10 +149,12 @@ impl Inner {
             return Err(UsbError::InvalidEndpoint);
         }
 
-        // validate buffer size
-        if let (EndpointType::Isochronous, true) = (ep_type, max_packet_size > 1023) {
-            return Err(UsbError::Unsupported);
-        } else if max_packet_size > 64 {
+        // Validate buffer size. From datasheet (4.1.2.5):
+        // Data Buffers are typically 64 bytes long as this is the max normal packet size for most FS packets.
+        // For Isochronous endpoints a maximum buffer size of 1023 bytes is supported.
+        // For other packet types the maximum size is 64 bytes per buffer.
+        if (ep_type != EndpointType::Isochronous && max_packet_size > 64) || max_packet_size > 1023
+        {
             return Err(UsbError::Unsupported);
         }
 

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -133,7 +133,7 @@ impl Inner {
 
         let is_ep0 = ep_addr.index() == 0;
         let is_ctrl_ep = ep_type == EndpointType::Control;
-        if !(is_ep0 ^ !is_ctrl_ep) || (is_ep0 && (max_packet_size != 64)) {
+        if !(is_ep0 ^ !is_ctrl_ep) {
             return Err(UsbError::Unsupported);
         }
 


### PR DESCRIPTION
The check (is_ep0 && (max_packet_size != 64)) doesn't seem to be necessary, and was blocking an example I ported (#105) from working.
The validate buffer size part was upsetting clippy (two paths with the same code) so I simplified it into a single boolean expression - and also added the text from the datasheet explaining what the buffer lengths should be.