### PR TITLE
Handle usb interrupt flags in driver

### DIFF
--- a/boards/pico/examples/pico_usb_serial_interrupt.rs
+++ b/boards/pico/examples/pico_usb_serial_interrupt.rs
@@ -84,20 +84,6 @@ fn main() -> ! {
         USB_DEVICE = Some(usb_dev);
     }
 
-    // The USB driver doesn't enable key interrupts yet, so manually do that here
-    unsafe {
-        let p = pac::Peripherals::steal();
-        // Enable interrupts for when a buffer is done, when the bus is reset,
-        // and when a setup packet is received
-        p.USBCTRL_REGS.inte.modify(|_, w| {
-            w.buff_status()
-                .set_bit()
-                .bus_reset()
-                .set_bit()
-                .setup_req()
-                .set_bit()
-        });
-    }
     // Enable the USB interrupt
     unsafe {
         pac::NVIC::unmask(hal::pac::Interrupt::USBCTRL_IRQ);
@@ -157,22 +143,5 @@ unsafe fn USBCTRL_IRQ() {
                 });
             }
         });
-    }
-
-    // Clear pending interrupt flags here.
-    // We could also move some of our code into these states to handle events
-    let p = pac::Peripherals::steal();
-    let status = &p.USBCTRL_REGS.sie_status;
-    if status.read().ack_rec().bit_is_set() {
-        status.modify(|_r, w| w.ack_rec().set_bit());
-    }
-    if status.read().setup_rec().bit_is_set() {
-        status.modify(|_r, w| w.setup_rec().set_bit());
-    }
-    if status.read().trans_complete().bit_is_set() {
-        status.modify(|_r, w| w.trans_complete().set_bit());
-    }
-    if status.read().bus_reset().bit_is_set() {
-        status.modify(|_r, w| w.bus_reset().set_bit());
     }
 }

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -407,6 +407,18 @@ impl UsbBusTrait for UsbBus {
             // at this stage ep's are expected to be in their reset state
             // TODO: is it worth having a debug_assert for that here?
 
+            // Enable interrupt generation when a buffer is done, when the bus is reset,
+            // and when a setup packet is received
+            // this should be sufficient for device mode, will need more for host.
+            inner.ctrl_reg.inte.modify(|_, w| {
+                w.buff_status()
+                    .set_bit()
+                    .bus_reset()
+                    .set_bit()
+                    .setup_req()
+                    .set_bit()
+            });
+
             // enable pull up to let the host know we exist.
             inner
                 .ctrl_reg

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -407,17 +407,6 @@ impl UsbBusTrait for UsbBus {
             // at this stage ep's are expected to be in their reset state
             // TODO: is it worth having a debug_assert for that here?
 
-            // Enable interrupt generation when a buffer is done, when the bus is reset,
-            // and when a setup packet is received
-            // this should be sufficient for device mode, will need more for host.
-            inner.ctrl_reg.inte.modify(|_, w| {
-                w.buff_status()
-                    .set_bit()
-                    .bus_reset()
-                    .set_bit()
-                    .setup_req()
-                    .set_bit()
-            });
             // enable pull up to let the host know we exist.
             inner
                 .ctrl_reg
@@ -509,22 +498,14 @@ impl UsbBusTrait for UsbBus {
             // TODO: check for suspend request
             // TODO: check for resume request
 
-            let sie_status_flags = inner.ctrl_reg.sie_status.read();
-            let (mut ep_out, mut ep_in_complete, mut ep_setup): (u16, u16, u16) = (0, 0, 0);
-
-            // check for setup request
-            // Only report setup if OUT has been cleared.
-            if sie_status_flags.setup_rec().bit_is_set() {
-                // Clear the setup_rec interrupt flag
-                inner
-                    .ctrl_reg
-                    .sie_status
-                    .modify(|_, w| w.setup_rec().set_bit());
-                ep_setup |= 1;
-                inner.read_setup = true;
+            // check for bus reset
+            let sie_status = inner.ctrl_reg.sie_status.read();
+            if sie_status.bus_reset().bit_is_set() {
+                return PollResult::Reset;
             }
 
-            // check for bus reset
+            let (mut ep_out, mut ep_in_complete, mut ep_setup): (u16, u16, u16) = (0, 0, 0);
+
             let buff_status = inner.ctrl_reg.buff_status.read().bits();
             if buff_status != 0 {
                 // IN Complete shall only be reported once.
@@ -544,13 +525,11 @@ impl UsbBusTrait for UsbBus {
                     }
                 }
             }
-            if sie_status_flags.bus_reset().bit_is_set() {
-                // Clear interrupt flag for reset
-                inner
-                    .ctrl_reg
-                    .sie_status
-                    .modify(|_, w| w.bus_reset().set_bit());
-                return PollResult::Reset;
+            // check for setup request
+            // Only report setup if OUT has been cleared.
+            if sie_status.setup_rec().bit_is_set() {
+                ep_setup |= 1;
+                inner.read_setup = true;
             }
 
             if let (0, 0, 0) = (ep_out, ep_in_complete, ep_setup) {


### PR DESCRIPTION
Move enabling of buff_status, buff_reset and setup_req into UsbBus::enable() and clear the flags from within the UsbBus::poll() so that user code doesn't need to touch the registers.
This way you can either manually poll from within a forever loop, or you can unmask the interrupt and call poll from within the USBCTRL_IRQ.
I've updated the interrupt examples to use the latter, as a reference for how much simpler this is.

I also moved the setup_req portion of the poll handler higher up so that will happen even in the presence of a reset request. This matches the behaviour of the driver in the C USB library that the official SDK uses.