### PR TITLE
Work around enumeration issues with small ep0 max packet size.

### DIFF
--- a/boards/pico/examples/pico_usb_serial.rs
+++ b/boards/pico/examples/pico_usb_serial.rs
@@ -48,7 +48,6 @@ fn main() -> ! {
         .manufacturer("Fake company")
         .product("Serial port")
         .serial_number("TEST")
-        .max_packet_size_0(64)
         .device_class(2) // from: https://www.usb.org/defined-class-codes
         .build();
 

--- a/boards/pico/examples/pico_usb_serial_interrupt.rs
+++ b/boards/pico/examples/pico_usb_serial_interrupt.rs
@@ -77,7 +77,6 @@ fn main() -> ! {
     .manufacturer("Fake company")
     .product("Serial port")
     .serial_number("TEST")
-    .max_packet_size_0(64)
     .device_class(2) // from: https://www.usb.org/defined-class-codes
     .build();
     unsafe {


### PR DESCRIPTION
Prevents `DataIn` of the previous request from being sent to the host when a new setup is received.