### PR TITLE
Update changelog and bump verson for hal release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added peripheral drivers: Timer(counter)
-- Added examples: Watchdog
-- Added docs: Watchdog
+## [0.3.0] - 2021-09-20
 
-## [0.2.0]
+### Added
+- peripheral drivers: Timer(counter) with EH traits, USB, PIO
+- examples: Watchdog, GPIO, ADC, i2c, rtic blinky, usb (serial echo, mouse)
+- docs: Watchdog
+- bsps: adafruit feather
+- bsp examples: sparkfun pro micro PIO RGB rainbow LED
+
+### Changed
+- i2c fixes
+- spi fixes
+- pwm fixes
+
+## [0.2.0] - 2021-08-14
 
 ### Added
 
@@ -21,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/rp-rs/rp-hal/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rp-rs/rp-hal/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/v0.1.0

--- a/boards/adafruit_macropad/Cargo.toml
+++ b/boards/adafruit_macropad/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 
 [features]

--- a/boards/feather_rp2040/Cargo.toml
+++ b/boards/feather_rp2040/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 

--- a/boards/pico/Cargo.toml
+++ b/boards/pico/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 usb-device= "0.2.8"

--- a/boards/pico_explorer/Cargo.toml
+++ b/boards/pico_explorer/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 st7789 = "0.6.1"

--- a/boards/pico_lipo_16mb/Cargo.toml
+++ b/boards/pico_lipo_16mb/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 
 [features]

--- a/boards/pro_micro_rp2040/Cargo.toml
+++ b/boards/pro_micro_rp2040/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.2.0" }
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0" }
 cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-hal"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["evan <evanmolder@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"


### PR DESCRIPTION
It's been a bit more than a month, I think we're due for a release.
Lots of new code + docs and it would be nice for it to be on crates.io and docs.rs