### PR TITLE
Implement GPIO override

### DIFF
--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -62,3 +62,55 @@ pub enum OutputSlewRate {
     /// Slew fast
     Fast,
 }
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+/// Interrupt override state.
+pub enum InterruptOverride {
+    /// Don't invert the interrupt.
+    DontInvert = 0,
+    /// Invert the interrupt.
+    Invert = 1,
+    /// Drive interrupt low.
+    AlwaysLow = 2,
+    /// Drive interrupt high.
+    AlwaysHigh = 3,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+/// Input override state.
+pub enum InputOverride {
+    /// Don't invert the peripheral input.
+    DontInvert = 0,
+    /// Invert the peripheral input.
+    Invert = 1,
+    /// Drive peripheral output low.
+    AlwaysLow = 2,
+    /// Drive peripheral output high.
+    AlwaysHigh = 3,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+/// Output enable override state.
+pub enum OutputEnableOverride {
+    /// Use the original output enable signal from selected peripheral.
+    DontInvert = 0,
+    /// Invert the output enable signal from selected peripheral.
+    Invert = 1,
+    /// Disable output.
+    Disable = 2,
+    /// Enable output.
+    Enable = 3,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+/// Output  override state.
+pub enum OutputOverride {
+    /// Use the original output  signal from selected peripheral.
+    DontInvert = 0,
+    /// Invert the output  signal from selected peripheral.
+    Invert = 1,
+    /// Drive output low.
+    Disable = 2,
+    /// Drive output high.
+    Enable = 3,
+}

--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -83,9 +83,9 @@ pub enum InputOverride {
     DontInvert = 0,
     /// Invert the peripheral input.
     Invert = 1,
-    /// Drive peripheral output low.
+    /// Drive peripheral input low.
     AlwaysLow = 2,
-    /// Drive peripheral output high.
+    /// Drive peripheral input high.
     AlwaysHigh = 3,
 }
 
@@ -103,14 +103,14 @@ pub enum OutputEnableOverride {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-/// Output  override state.
+/// Output override state.
 pub enum OutputOverride {
-    /// Use the original output  signal from selected peripheral.
+    /// Use the original output signal from selected peripheral.
     DontInvert = 0,
-    /// Invert the output  signal from selected peripheral.
+    /// Invert the output signal from selected peripheral.
     Invert = 1,
     /// Drive output low.
-    Disable = 2,
+    AlwaysLow = 2,
     /// Drive output high.
-    Enable = 3,
+    AlwaysHigh = 3,
 }

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -93,7 +93,10 @@
 //! [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
 //! [`AnyKind`]: crate::typelevel#anykind-trait-pattern
 use super::dynpin::{DynDisabled, DynInput, DynOutput, DynPinId, DynPinMode};
-use super::{OutputDriveStrength, OutputSlewRate};
+use super::{
+    InputOverride, InterruptOverride, OutputDriveStrength, OutputEnableOverride, OutputOverride,
+    OutputSlewRate,
+};
 use crate::gpio::reg::RegisterInterface;
 use crate::typelevel::{Is, NoneT, Sealed};
 use core::convert::Infallible;
@@ -517,10 +520,34 @@ where
         self.regs.read_slew_rate()
     }
 
-    /// Set the slew rate for the pin
+    /// Set the slew rate for the pin.
     #[inline]
     pub fn set_slew_rate(&mut self, rate: OutputSlewRate) {
         self.regs.write_slew_rate(rate)
+    }
+
+    /// Set the interrupt override.
+    #[inline]
+    pub fn set_interrupt_override(&mut self, r#override: InterruptOverride) {
+        self.regs.set_interrupt_override(r#override);
+    }
+
+    /// Set the input override.
+    #[inline]
+    pub fn set_input_override(&mut self, r#override: InputOverride) {
+        self.regs.set_input_override(r#override);
+    }
+
+    /// Set the output enable override.
+    #[inline]
+    pub fn set_output_enable_override(&mut self, r#override: OutputEnableOverride) {
+        self.regs.set_output_enable_override(r#override);
+    }
+
+    /// Set the output override.
+    #[inline]
+    pub fn set_output_override(&mut self, r#override: OutputOverride) {
+        self.regs.set_output_override(r#override);
     }
 
     #[inline]

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -528,26 +528,26 @@ where
 
     /// Set the interrupt override.
     #[inline]
-    pub fn set_interrupt_override(&mut self, r#override: InterruptOverride) {
-        self.regs.set_interrupt_override(r#override);
+    pub fn set_interrupt_override(&mut self, override_value: InterruptOverride) {
+        self.regs.set_interrupt_override(override_value);
     }
 
     /// Set the input override.
     #[inline]
-    pub fn set_input_override(&mut self, r#override: InputOverride) {
-        self.regs.set_input_override(r#override);
+    pub fn set_input_override(&mut self, override_value: InputOverride) {
+        self.regs.set_input_override(override_value);
     }
 
     /// Set the output enable override.
     #[inline]
-    pub fn set_output_enable_override(&mut self, r#override: OutputEnableOverride) {
-        self.regs.set_output_enable_override(r#override);
+    pub fn set_output_enable_override(&mut self, override_value: OutputEnableOverride) {
+        self.regs.set_output_enable_override(override_value);
     }
 
     /// Set the output override.
     #[inline]
-    pub fn set_output_override(&mut self, r#override: OutputOverride) {
-        self.regs.set_output_override(r#override);
+    pub fn set_output_override(&mut self, override_value: OutputOverride) {
+        self.regs.set_output_override(override_value);
     }
 
     #[inline]

--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -249,38 +249,38 @@ pub(super) unsafe trait RegisterInterface {
 
     /// Set the interrupt override.
     #[inline]
-    fn set_interrupt_override(&self, r#override: InterruptOverride) {
+    fn set_interrupt_override(&self, override_value: InterruptOverride) {
         let num = self.id().num as usize;
         unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
             .gpio_ctrl
-            .modify(|_, w| w.irqover().bits(r#override as u8));
+            .modify(|_, w| w.irqover().bits(override_value as u8));
     }
 
     /// Set the input override.
     #[inline]
-    fn set_input_override(&self, r#override: InputOverride) {
+    fn set_input_override(&self, override_value: InputOverride) {
         let num = self.id().num as usize;
         unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
             .gpio_ctrl
-            .modify(|_, w| w.inover().bits(r#override as u8));
+            .modify(|_, w| w.inover().bits(override_value as u8));
     }
 
     /// Set the output enable override.
     #[inline]
-    fn set_output_enable_override(&self, r#override: OutputEnableOverride) {
+    fn set_output_enable_override(&self, override_value: OutputEnableOverride) {
         let num = self.id().num as usize;
         unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
             .gpio_ctrl
-            .modify(|_, w| w.oeover().bits(r#override as u8));
+            .modify(|_, w| w.oeover().bits(override_value as u8));
     }
 
     /// Set the output override.
     #[inline]
-    fn set_output_override(&self, r#override: OutputOverride) {
+    fn set_output_override(&self, override_value: OutputOverride) {
         let num = self.id().num as usize;
         unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
             .gpio_ctrl
-            .modify(|_, w| w.outover().bits(r#override as u8));
+            .modify(|_, w| w.outover().bits(override_value as u8));
     }
 }
 

--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -1,6 +1,9 @@
 // Based heavily on and in some places copied from `atsamd-hal` gpio::v2
 use super::dynpin::{DynGroup, DynPinId};
-use super::{OutputDriveStrength, OutputSlewRate};
+use super::{
+    InputOverride, InterruptOverride, OutputDriveStrength, OutputEnableOverride, OutputOverride,
+    OutputSlewRate,
+};
 use crate::gpio::dynpin::{DynDisabled, DynFunction, DynInput, DynOutput, DynPinMode};
 use crate::pac;
 
@@ -242,6 +245,42 @@ pub(super) unsafe trait RegisterInterface {
             DynGroup::Bank0 => gpio_change_mode(num, mode),
             DynGroup::Qspi => qspi_change_mode(num, mode),
         }
+    }
+
+    /// Set the interrupt override.
+    #[inline]
+    fn set_interrupt_override(&self, r#override: InterruptOverride) {
+        let num = self.id().num as usize;
+        unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
+            .gpio_ctrl
+            .modify(|_, w| w.irqover().bits(r#override as u8));
+    }
+
+    /// Set the input override.
+    #[inline]
+    fn set_input_override(&self, r#override: InputOverride) {
+        let num = self.id().num as usize;
+        unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
+            .gpio_ctrl
+            .modify(|_, w| w.inover().bits(r#override as u8));
+    }
+
+    /// Set the output enable override.
+    #[inline]
+    fn set_output_enable_override(&self, r#override: OutputEnableOverride) {
+        let num = self.id().num as usize;
+        unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
+            .gpio_ctrl
+            .modify(|_, w| w.oeover().bits(r#override as u8));
+    }
+
+    /// Set the output override.
+    #[inline]
+    fn set_output_override(&self, r#override: OutputOverride) {
+        let num = self.id().num as usize;
+        unsafe { &(*pac::IO_BANK0::ptr()) }.gpio[num]
+            .gpio_ctrl
+            .modify(|_, w| w.outover().bits(r#override as u8));
     }
 }
 


### PR DESCRIPTION
Interrupt status, input, output enable and output can be overridden. See documentation for GPIO0_CTRL for more info.

As a background, I happen to need input inversion as my optocoupler inverts the signal and I don't want to modify my existing PIO code.