### PR TITLE
implement embedded-hal 1.0.0-alpha.5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --workspace --examples
+          args: --workspace --examples --features eh1_0_alpha
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cortex-m = "0.7.2"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
-eh1_0_alpha = { version = "1.0.0-alpha.5", package="embedded-hal", optional=true }
+eh1_0_alpha = { version = "=1.0.0-alpha.5", package="embedded-hal", optional=true }
 embedded-time = "0.12.0"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cortex-m = "0.7.2"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
+eh1_0_alpha = { version = "1.0.0-alpha.5", package="embedded-hal", optional=true }
 embedded-time = "0.12.0"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"

--- a/rp2040-hal/README.md
+++ b/rp2040-hal/README.md
@@ -102,6 +102,18 @@ NOTE This HAL is under active development. As such, it is likely to remain volat
 
 See the [open issues](https://github.com/rp-rs/rp-hal/issues) for a list of proposed features (and known issues).
 
+### Support for embedded-hal 1.0
+
+We plan to support embedded-hal 1.0 soon after it is released.
+
+For now, there is preliminary support for alpha versions of embedded-hal, which can
+be enabled with the feature `eh1_0_alpha`. Please note that this support does not
+provide any semver compatibility guarantees: With that feature activated, there
+will be breaking changes even in minor versions of rp2040-hal.
+
+Support for embedded-hal 1.0(-alpha) exists in parallel to support for
+embedded-hal 0.2: Traits of both versions are implemented and can be used
+at the same time.
 
 <!-- CONTRIBUTING -->
 ## Contributing

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -103,6 +103,15 @@ macro_rules! channel {
                 $channel
             }
         }
+
+        #[cfg(feature = "eh1_0_alpha")]
+        impl eh1_0_alpha::adc::nb::Channel<Adc> for Pin<$pin, FloatingInput> {
+            type ID = u8; // ADC channels are identified numerically
+
+            fn channel(&self) -> u8 {
+                $channel
+            }
+        }
     };
 }
 
@@ -124,6 +133,15 @@ impl Channel<Adc> for TempSense {
     }
 }
 
+#[cfg(feature = "eh1_0_alpha")]
+impl eh1_0_alpha::adc::nb::Channel<Adc> for TempSense {
+    type ID = u8; // ADC channels are identified numerically
+
+    fn channel(&self) -> u8 {
+        TEMPERATURE_SENSOR_CHANNEL
+    }
+}
+
 impl<WORD, PIN> OneShot<Adc, WORD, PIN> for Adc
 where
     WORD: From<u16>,
@@ -133,6 +151,37 @@ where
 
     fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
         let chan = PIN::channel();
+
+        if chan == 4 {
+            self.device.cs.modify(|_, w| w.ts_en().set_bit())
+        }
+
+        while !self.device.cs.read().ready().bit_is_set() {
+            cortex_m::asm::nop();
+        }
+
+        self.device
+            .cs
+            .modify(|_, w| unsafe { w.ainsel().bits(chan).start_once().set_bit() });
+
+        while !self.device.cs.read().ready().bit_is_set() {
+            cortex_m::asm::nop();
+        }
+
+        Ok(self.device.result.read().result().bits().into())
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl<WORD, PIN> eh1_0_alpha::adc::nb::OneShot<Adc, WORD, PIN> for Adc
+where
+    WORD: From<u16>,
+    PIN: eh1_0_alpha::adc::nb::Channel<Adc, ID = u8>,
+{
+    type Error = ();
+
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        let chan = PIN::channel(pin);
 
         if chan == 4 {
             self.device.cs.modify(|_, w| w.ts_en().set_bit())

--- a/rp2040-hal/src/gpio/dynpin.rs
+++ b/rp2040-hal/src/gpio/dynpin.rs
@@ -78,6 +78,8 @@ use super::pin::{Pin, PinId, PinMode, ValidPinMode};
 use super::reg::RegisterInterface;
 use core::convert::TryFrom;
 
+#[cfg(feature = "eh1_0_alpha")]
+use eh1_0_alpha::digital::blocking as eh1;
 use hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 //==============================================================================
@@ -530,6 +532,53 @@ impl ToggleableOutputPin for DynPin {
 }
 
 impl StatefulOutputPin for DynPin {
+    #[inline]
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        self._is_set_high()
+    }
+    #[inline]
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        self._is_set_low()
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl eh1::OutputPin for DynPin {
+    type Error = Error;
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self._set_high()
+    }
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self._set_low()
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl eh1::InputPin for DynPin {
+    type Error = Error;
+    #[inline]
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        self._is_high()
+    }
+    #[inline]
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        self._is_low()
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl eh1::ToggleableOutputPin for DynPin {
+    type Error = Error;
+    #[inline]
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self._toggle()
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl eh1::StatefulOutputPin for DynPin {
     #[inline]
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         self._is_set_high()

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -103,6 +103,8 @@ use core::convert::Infallible;
 use core::marker::PhantomData;
 
 use crate::gpio::dynpin::DynFunction;
+#[cfg(feature = "eh1_0_alpha")]
+use eh1_0_alpha::digital::blocking as eh1;
 use hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 use core::mem::transmute;
@@ -757,6 +759,88 @@ where
 }
 
 impl<I, C> StatefulOutputPin for Pin<I, Output<C>>
+where
+    I: PinId,
+    C: OutputConfig,
+{
+    #[inline]
+    fn is_set_high(&self) -> Result<bool, Self::Error> {
+        Ok(self._is_set_high())
+    }
+    #[inline]
+    fn is_set_low(&self) -> Result<bool, Self::Error> {
+        Ok(self._is_set_low())
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl<I, C> eh1::OutputPin for Pin<I, Output<C>>
+where
+    I: PinId,
+    C: OutputConfig,
+{
+    type Error = Infallible;
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self._set_high();
+        Ok(())
+    }
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self._set_low();
+        Ok(())
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl<I> eh1::InputPin for Pin<I, ReadableOutput>
+where
+    I: PinId,
+{
+    type Error = Infallible;
+    #[inline]
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(self._is_high())
+    }
+    #[inline]
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(self._is_low())
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl<I, C> eh1::InputPin for Pin<I, Input<C>>
+where
+    I: PinId,
+    C: InputConfig,
+{
+    type Error = Infallible;
+    #[inline]
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        Ok(self._is_high())
+    }
+    #[inline]
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(self._is_low())
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl<I, C> eh1::ToggleableOutputPin for Pin<I, Output<C>>
+where
+    I: PinId,
+    C: OutputConfig,
+{
+    type Error = Infallible;
+    #[inline]
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self._toggle();
+        Ok(())
+    }
+}
+
+#[cfg(feature = "eh1_0_alpha")]
+impl<I, C> eh1::StatefulOutputPin for Pin<I, Output<C>>
 where
     I: PinId,
     C: OutputConfig,

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -52,6 +52,8 @@ use crate::{
     resets::SubsystemReset,
     typelevel::Sealed,
 };
+#[cfg(feature = "eh1_0_alpha")]
+use eh1_0_alpha::i2c::blocking as eh1;
 use embedded_time::rate::Hertz;
 use hal::blocking::i2c::{Read, Write, WriteRead};
 use rp2040_pac::{I2C0, I2C1, RESETS};
@@ -487,6 +489,30 @@ macro_rules! hal {
                     } else {
                         Ok(())
                     }
+                }
+            }
+
+            #[cfg(feature = "eh1_0_alpha")]
+            impl<PINS> eh1::Write for I2C<$I2CX, PINS> {
+                type Error = Error;
+
+                fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+                    Write::write(self, addr, bytes)
+                }
+            }
+            #[cfg(feature = "eh1_0_alpha")]
+            impl<PINS> eh1::WriteRead for I2C<$I2CX, PINS> {
+                type Error = Error;
+                fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Error> {
+                        WriteRead::write_read(self, addr, bytes, buffer)
+                }
+            }
+            #[cfg(feature = "eh1_0_alpha")]
+            impl<PINS> eh1::Read for I2C<$I2CX, PINS> {
+                type Error = Error;
+
+                fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+                    Read::read(self, addr, buffer)
                 }
             }
 


### PR DESCRIPTION
With this change, it is possible to use rp2040-hal with embedded-hal 1.0.0-alpha.5.
The new trait implementations are hidden behind a feature flag, `eh1_0_alpha`, to avoid semver breaking changes as long as that flag is not set.

When using that flag, breaking changes can be expected, as embedded-hal 1.0 is not yet released. This is documented in README.md.

When embedded-hal 1.0 is released, we have several options:
- We could activate it unconditionally (and just remove the feature flag).
- We could rename the feature flag to `eh1_0` or similar.
- We could hide support for embedded-hal 0.2 behind a feature flag and support 1.0 by default.
- We could remove support for embedded-hal 0.2 and replace it with support for version 1.0.

Currently I'd prefer the first option, as long as support for 1.0 can be activated without breaking changes for existing users. The last to options are added for completeness, I don't think it would be sensible to remove support for embedded-hal 0.2 in the near future.