### PR TITLE
fix pico_usb_twitchy_mouse with usbd-hid >= 0.5.1

### DIFF
--- a/boards/pico/Cargo.toml
+++ b/boards/pico/Cargo.toml
@@ -16,7 +16,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 usb-device= "0.2.8"
 usbd-serial = "0.1.1"
-usbd-hid = "0.5.0"
+usbd-hid = "0.5.1"
 
 [dev-dependencies]
 panic-halt= "0.2.0"

--- a/boards/pico/examples/pico_usb_twitchy_mouse.rs
+++ b/boards/pico/examples/pico_usb_twitchy_mouse.rs
@@ -142,6 +142,7 @@ fn main() -> ! {
             y: 4,
             buttons: 0,
             wheel: 0,
+            pan: 0,
         };
         push_mouse_movement(rep_up).ok().unwrap_or(0);
 
@@ -152,6 +153,7 @@ fn main() -> ! {
             y: -4,
             buttons: 0,
             wheel: 0,
+            pan: 0,
         };
         push_mouse_movement(rep_down).ok().unwrap_or(0);
     }


### PR DESCRIPTION
usbd-hid 0.5.1 contained an accidental semver breaking change

fix example accordingly