### PR TITLE
Implement bus keep inputs, as documented in C SDK

### DIFF
--- a/rp2040-hal/src/gpio/dynpin.rs
+++ b/rp2040-hal/src/gpio/dynpin.rs
@@ -91,6 +91,7 @@ pub enum DynDisabled {
     Floating,
     PullDown,
     PullUp,
+    BusKeep,
 }
 
 /// Value-level `enum` for input configurations
@@ -100,6 +101,7 @@ pub enum DynInput {
     Floating,
     PullDown,
     PullUp,
+    BusKeep,
 }
 
 /// Value-level `enum` for output configurations

--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -45,6 +45,10 @@ impl From<DynPinMode> for ModeFields {
                     PullUp => {
                         fields.pue = true;
                     }
+                    BusKeep => {
+                        fields.pde = true;
+                        fields.pue = true;
+                    }
                 }
             }
             Input(config) => {
@@ -59,6 +63,10 @@ impl From<DynPinMode> for ModeFields {
                         fields.pde = true;
                     }
                     PullUp => {
+                        fields.pue = true;
+                    }
+                    BusKeep => {
+                        fields.pde = true;
                         fields.pue = true;
                     }
                 }


### PR DESCRIPTION
When both pull-up and pull-down are enabled, the RP2040 enters a
so-called "bus keep" function, which uses a weak pull to tue current
high/low state of the GPIO.

See for example
https://raspberrypi.github.io/pico-sdk-doxygen/group__hardware__gpio.html#gab6bf9552da32b3dd0a5d0db45d8374fc

As this change adds new variants to public enums, it is a semver breaking change and therefore needs an appropriate version increment, when merged.