### PR TITLE
Rework the PIO API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - implement `rng_core::RngCore` for `RingOscillator`
 
+### Changed
+- Modified PIO API for better ergonomics
+
 ## [0.3.0] - 2021-09-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "rp2040-hal",
     "boards/feather_rp2040",

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -18,6 +18,7 @@ nb = "1.0"
 rp2040-pac = "0.1.5"
 paste = "1.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
+pio-proc = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
 usb-device = "0.2.8"
 vcell = "0.1"
 void = { version = "1.0.2", default-features = false }

--- a/rp2040-hal/examples/pio_blink.rs
+++ b/rp2040-hal/examples/pio_blink.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let installed = pio.install(&program).unwrap();
     let div = 0f32; // as slow as possible (0 is interpreted as 65536)
-    let sm = rp2040_hal::pio::PIOBuilder::from_program(installed)
+    let (sm, _, _) = rp2040_hal::pio::PIOBuilder::from_program(installed)
         .set_pins(led_pin_id, 1)
         .clock_divisor(div)
         .build(sm0);

--- a/rp2040-hal/examples/pio_proc_blink.rs
+++ b/rp2040-hal/examples/pio_proc_blink.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let installed = pio.install(&program.program).unwrap();
     let div = 0f32; // as slow as possible (0 is interpreted as 65536)
-    let mut sm = rp2040_hal::pio::PIOBuilder::from_program(installed)
+    let (mut sm, _, _) = rp2040_hal::pio::PIOBuilder::from_program(installed)
         .set_pins(led_pin_id, 1)
         .clock_divisor(div)
         .build(sm0);

--- a/rp2040-hal/examples/pio_proc_blink.rs
+++ b/rp2040-hal/examples/pio_proc_blink.rs
@@ -1,4 +1,4 @@
-//! This example toggles the GPIO25 pin, using a PIO program.
+//! This example toggles the GPIO25 pin, using a PIO program compiled via pio_proc::pio!().
 //!
 //! If a LED is connected to that pin, like on a Pico board, the LED should blink.
 #![no_std]
@@ -34,33 +34,26 @@ fn main() -> ! {
     let led_pin_id = 25;
 
     // Define some simple PIO program.
-    const MAX_DELAY: u8 = 31;
-    let mut a = pio::Assembler::<32>::new();
-    let mut wrap_target = a.label();
-    let mut wrap_source = a.label();
-    // Set pin as Out
-    a.set(pio::SetDestination::PINDIRS, 1);
-    // Define begin of program loop
-    a.bind(&mut wrap_target);
-    // Set pin low
-    a.set_with_delay(pio::SetDestination::PINS, 0, MAX_DELAY);
-    // Set pin high
-    a.set_with_delay(pio::SetDestination::PINS, 1, MAX_DELAY);
-    // Define end of program loop
-    a.bind(&mut wrap_source);
-    // The labels wrap_target and wrap_source, as set above,
-    // define a loop which is executed repeatedly by the PIO
-    // state machine.
-    let program = a.assemble_with_wrap(wrap_source, wrap_target);
+    let program = pio_proc::pio!(
+        32,
+        "
+.wrap_target
+    set pins, 1 [31]
+    set pins, 0 [31]
+.wrap
+        "
+    );
 
     // Initialize and start PIO
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
-    let installed = pio.install(&program).unwrap();
+    let installed = pio.install(&program.program).unwrap();
     let div = 0f32; // as slow as possible (0 is interpreted as 65536)
-    let sm = rp2040_hal::pio::PIOBuilder::from_program(installed)
+    let mut sm = rp2040_hal::pio::PIOBuilder::from_program(installed)
         .set_pins(led_pin_id, 1)
         .clock_divisor(div)
         .build(sm0);
+    // The GPIO pin needs to be configured as an output.
+    sm.set_pindirs_with_mask(1 << led_pin_id, 1 << led_pin_id);
     sm.start();
 
     // PIO runs in background, independently from CPU

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -229,7 +229,7 @@ impl<P: PIOExt> PIO<P> {
                 self.pio.instr_mem[i + offset].write(|w| unsafe { w.bits(instr as u32) })
             }
             self.used_instruction_space =
-                self.used_instruction_space | ((1 << instructions.len()) - 1);
+                self.used_instruction_space | (((1 << p.code.len()) - 1) << offset);
             Some(offset)
         } else {
             None

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -674,13 +674,13 @@ pub struct PIOBuilder<'a> {
     pull_threshold: u8,
     /// Number of bits shifted into `ISR` before autopush or conditional push will take place.
     push_threshold: u8,
-    // Shift direction for `OUT` instruction.
+    /// Shift direction for `OUT` instruction.
     out_shiftdir: ShiftDirection,
-    // Shift direction for `IN` instruction.
+    /// Shift direction for `IN` instruction.
     in_shiftdir: ShiftDirection,
-    // Enable autopull.
+    /// Enable autopull.
     autopull: bool,
-    // Enable autopush.
+    /// Enable autopush.
     autopush: bool,
 
     /// Number of pins asserted by a `SET`.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -626,7 +626,7 @@ impl<SM: ValidStateMachine> Rx<SM> {
     /// Get the next element from RX FIFO.
     ///
     /// Returns `None` if the FIFO is empty.
-    pub fn read_rx(&mut self) -> Option<u32> {
+    pub fn read(&mut self) -> Option<u32> {
         // Safety: The register is never written by software.
         let is_empty = unsafe { &*self.block }.fstat.read().rxempty().bits() & (1 << SM::id()) != 0;
 
@@ -649,7 +649,7 @@ impl<SM: ValidStateMachine> Tx<SM> {
     /// Write an element to TX FIFO.
     ///
     /// Returns `true` if the value was written to FIFO, `false` otherwise.
-    pub fn write_tx(&mut self, value: u32) -> bool {
+    pub fn write(&mut self, value: u32) -> bool {
         // Safety: The register is never written by software.
         let is_full = unsafe { &*self.block }.fstat.read().txfull().bits() & (1 << SM::id()) != 0;
 

--- a/rp2040-hal/src/prelude.rs
+++ b/rp2040-hal/src/prelude.rs
@@ -1,2 +1,3 @@
 //! Prelude
 pub use crate::clocks::Clock as _rphal_clocks_Clock;
+pub use crate::pio::PIOExt as _rphal_pio_PIOExt;


### PR DESCRIPTION
# Rationale

The current PIO API has a number of limitations:
- As the state machines are contained in `PIO`, they cannot be moved around individually. Sometimes, a single PIO block implements multiple functions that are used in completely different parts of the code base.
- `StateMachine` is not Send, although it could be.
- Multiple state machines should be able to share code to reduce instruction space usage, yet currently they are not because PIOBuilder always allocates space. Sometimes, multiple state machines implement the same functionality (e.g., multiple SPI or I2C buses).
- Some functions must only be called in specific configurations. For example, pin directions have to be set while the state machine is stopped, as PINCTRL is modified. The current API does not reflect such restrictions, which makes it harder to use than necessary.

Also, during my work, I found a bug where used instruction space was not marked properly.

This PR also fixes #141 by providing a function to set pin directions.

# Design

This PR uses different types to represent state machines in different states - `UninitStateMachine<P>` is not associated with any program, whereas `StateMachine<P, Stopped>` and `StateMachine<P, Running>` are. Program installation in instruction memory is separated from state machine initialization via `InstalledProgram` and `PIO::install()`. Access from state machines to shared registers is performed via atomic operations to enable `Send`.

Old usage example:
```
let pio = rp2040_hal::pio::PIO::new(pac.PIO0, &mut pac.RESETS);
let sm = &pio.state_machines()[0];
let div = 0f32; // as slow as possible (0 is interpreted as 65536)
rp2040_hal::pio::PIOBuilder::default()
    .with_program(&program)
    .set_pins(led_pin_id, 1)
    .clock_divisor(div)
    .build(&pio, sm)
    .unwrap();
```
New usage example:
```
let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
let installed = pio.install(&program).unwrap();
let div = 0f32; // as slow as possible (0 is interpreted as 65536)
let sm = rp2040_hal::pio::PIOBuilder::from_program(installed)
    .set_pins(led_pin_id, 1)
    .clock_divisor(div)
    .build(sm0);
sm.start();
```

# Testing

I tested that the blink examples work, and I tested with my own code that, however, does not use much more PIO functionality yet (except for sideset pins). Those programs work fine.

