### PR TITLE
Implement QT Py BSP with example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "rp2040-hal",
     "boards/feather_rp2040",
+    "boards/qt_py_rp2040",
     "boards/pico",
     "boards/pico_explorer",
     "boards/pico_lipo_16mb",

--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ RP2040 chip according to how it is connected up on the Pro Micro RP2040.
 [Sparkfun Pro Micro RP2040]: https://www.sparkfun.com/products/18288
 [pro_micro_rp2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/pro_micro_rp2040
 
+### [qt_py_rp2040] - Board Support for the [Adafruit QT Py RP2040]
+
+You should include this crate if you are writing code that you want to run on
+an [Adafruit QT Py RP2040] - an extremely small form-factor RP2040 board from Adafruit.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Feather RP2040.
+
+[Adafruit QT Py RP2040]: https://www.adafruit.com/product/4900
+[qt_py_rp2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/qt_py_rp2040
+
 <!-- PROGRAMMING -->
 ## Programming
 

--- a/boards/qt_py_rp2040/Cargo.toml
+++ b/boards/qt_py_rp2040/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "qt_py_rp2040"
+version = "0.1.0"
+authors = ["Stephen Onnen <stephen.onnen@gmail.com>"]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal/boards/qt_py_rp2040"
+description = "Board Support Package for the Adafruit QT Py RP2040"
+license = "MIT OR Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.7.2"
+rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+cortex-m-rt = { version = "0.7", optional = true }
+embedded-time = "0.12.0"
+
+[dev-dependencies]
+panic-halt= "0.2.0"
+embedded-hal ="0.2.5"
+rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs",  rev = "d2128ef9875e91e454dd0fb0d747c7439ae0627b" }
+smart-leds = "0.3"
+nb = "1.0.0"
+pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs" }
+
+[features]
+default = ["rt"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/qt_py_rp2040/README.md
+++ b/boards/qt_py_rp2040/README.md
@@ -1,0 +1,94 @@
+# [qt_py_rp2040] - Board Support for the [Adafruit QT Py RP2040]
+
+You should include this crate if you are writing code that you want to run on
+an [Adafruit QT Py RP2040] - an extremely small form-factor RP2040 board from Adafruit.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the QT Py.
+
+[Adafruit QT Py RP2040]: https://www.adafruit.com/product/4900
+[qt_py_rp2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/qt_py_rp2040
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+[Raspberry Silicon RP2040]: https://www.raspberrypi.org/products/rp2040/
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+qt_py_rp2040 = { git = "https://github.com/rp-rs/rp-hal.git" }
+```
+
+In your program, you will need to call `qt_py_rp2040::Pins::new` to create
+a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal_ repository and run:
+
+```console
+rp-hal/boards/qt_py_rp2040 $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal/boards/qt_py_rp2040 $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs, then repeating the `cargo run` command above.
+```
+
+### [qt_py_rainbow](./examples/qt_py_rainbow.rs)
+
+Continuously changes the color of the QT Py's onboard Neopixel.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can chose either the MIT licence or the
+Apache-2.0 licence when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific licence.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/qt_py_rp2040/examples/qt_py_rainbow.rs
+++ b/boards/qt_py_rp2040/examples/qt_py_rainbow.rs
@@ -1,0 +1,100 @@
+//! Continuously changes the color of the Neopixel on a Adafruit QT Py RP2040 board
+#![no_std]
+#![no_main]
+
+use core::iter::once;
+use cortex_m_rt::entry;
+use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::timer::CountDown;
+use embedded_time::duration::Extensions;
+use panic_halt as _;
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+use ws2812_pio::Ws2812;
+
+use qt_py_rp2040::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        gpio::{FunctionPio0, Pin},
+        pac,
+        sio::Sio,
+        watchdog::Watchdog,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = Sio::new(pac.SIO);
+
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let _led: Pin<_, FunctionPio0> = pins.neopixel_data.into_mode();
+
+    pins.neopixel_power
+        .into_push_pull_output()
+        .set_high()
+        .unwrap();
+
+    let timer = rp2040_hal::timer::Timer::new(pac.TIMER);
+    let mut delay = timer.count_down();
+
+    let mut ws = Ws2812::new(
+        12,
+        pac.PIO0,
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        timer.count_down(),
+    );
+
+    let mut n: u8 = 128;
+    loop {
+        ws.write(brightness(once(wheel(n)), 32)).unwrap();
+        n = n.wrapping_add(1);
+
+        delay.start(25.milliseconds());
+        let _ = nb::block!(delay.wait());
+    }
+}
+
+/// Convert a number from `0..=255` to an RGB color triplet.
+///
+/// The colours are a transition from red, to green, to blue and back to red.
+fn wheel(mut wheel_pos: u8) -> RGB8 {
+    wheel_pos = 255 - wheel_pos;
+    if wheel_pos < 85 {
+        // No green in this sector - red and blue only
+        (255 - (wheel_pos * 3), 0, wheel_pos * 3).into()
+    } else if wheel_pos < 170 {
+        // No red in this sector - green and blue only
+        wheel_pos -= 85;
+        (0, wheel_pos * 3, 255 - (wheel_pos * 3)).into()
+    } else {
+        // No blue in this sector - red and green only
+        wheel_pos -= 170;
+        (wheel_pos * 3, 255 - (wheel_pos * 3), 0).into()
+    }
+}

--- a/boards/qt_py_rp2040/src/lib.rs
+++ b/boards/qt_py_rp2040/src/lib.rs
@@ -1,0 +1,60 @@
+#![no_std]
+
+pub extern crate rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+pub use hal::pac;
+
+hal::bsp_pins!(
+    Gpio3 {
+        name: mosi,
+        aliases: { FunctionSpi: Mosi }
+    },
+    Gpio4 {
+        name: miso
+        aliases: { FunctionSpi: Miso }
+    },
+    Gpio5 {
+        name: rx,
+        aliases: { FunctionUart: UartRx }
+    },
+    Gpio6 {
+        name: sclk,
+        aliases: { FunctionSpi: Sclk }
+    },
+    Gpio11 { name: neopixel_power },
+    Gpio12 { name: neopixel_data },
+    Gpio20 {
+        name: tx,
+        aliases: { FunctionUart: UartTx }
+    },
+    Gpio21 {
+        name: button
+    },
+    Gpio22 {
+        name: sda1,
+        aliases: { FunctionI2C: Sda1 }
+    },
+    Gpio23 {
+        name: scl1,
+        aliases: { FunctionI2C: Scl1 }
+    },
+    Gpio24 {
+        name: sda,
+        aliases: { FunctionI2C: Sda }
+    },
+    Gpio25 {
+        name: scl,
+        aliases: { FunctionI2C: Scl }
+    },
+    Gpio26 { name: a3 },
+    Gpio27 { name: a2 },
+    Gpio28 { name: a1 },
+    Gpio29 { name: a0 },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
This PR implements a BSP for the Adafruit QT Py RP2040 found [here](https://www.adafruit.com/product/4900).

Neopixel example has been tested and is working on actual hardware.

Pin mappings were taken from Adafruit's CircuitPython repo and can be found [here](https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/boards/adafruit_qtpy_rp2040/pins.c).