### PR TITLE
Fix i2c write read

### DIFF
--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -381,6 +381,10 @@ macro_rules! hal {
                         }
                     }
 
+                    if abort {
+                        return Err(Error::Abort(abort_reason));
+                    }
+
                     for (i, byte) in buffer.iter_mut().enumerate() {
                         let first = i == 0;
                         let last = i == bytes.len() - 1;

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -385,9 +385,10 @@ macro_rules! hal {
                         return Err(Error::Abort(abort_reason));
                     }
 
+                    let buffer_len = buffer.len();
                     for (i, byte) in buffer.iter_mut().enumerate() {
                         let first = i == 0;
-                        let last = i == bytes.len() - 1;
+                        let last = i == buffer_len - 1;
 
                         // wait until there is space in the FIFO to write the next byte
                         while self.tx_fifo_full()  {}


### PR DESCRIPTION
Fixed i2c write_read function. Without that fix, reading an mpu6050 (using https://crates.io/crates/mpu6050) resulted in erratic values.