### PR TITLE
GPIO interrupt

### DIFF
--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -64,6 +64,19 @@ pub enum OutputSlewRate {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+/// Interrupt kind
+pub enum Interrupt {
+    /// While low
+    LevelLow,
+    /// While high
+    LevelHigh,
+    /// On falling edge
+    EdgeLow,
+    /// On rising edge
+    EdgeHigh,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 /// Interrupt override state.
 pub enum InterruptOverride {
     /// Don't invert the interrupt.

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -94,8 +94,8 @@
 //! [`AnyKind`]: crate::typelevel#anykind-trait-pattern
 use super::dynpin::{DynDisabled, DynInput, DynOutput, DynPinId, DynPinMode};
 use super::{
-    InputOverride, InterruptOverride, OutputDriveStrength, OutputEnableOverride, OutputOverride,
-    OutputSlewRate,
+    InputOverride, Interrupt, InterruptOverride, OutputDriveStrength, OutputEnableOverride,
+    OutputOverride, OutputSlewRate,
 };
 use crate::gpio::reg::RegisterInterface;
 use crate::typelevel::{Is, NoneT, Sealed};
@@ -545,6 +545,42 @@ where
     #[inline]
     pub fn set_slew_rate(&mut self, rate: OutputSlewRate) {
         self.regs.write_slew_rate(rate)
+    }
+
+    /// Clear interrupt.
+    #[inline]
+    pub fn clear_interrupt(&mut self, interrupt: Interrupt) {
+        self.regs.clear_interrupt(interrupt);
+    }
+
+    /// Interrupt status.
+    #[inline]
+    pub fn interrupt_status(&self, interrupt: Interrupt) -> bool {
+        self.regs.interrupt_status(interrupt)
+    }
+
+    /// Is interrupt enabled.
+    #[inline]
+    pub fn is_interrupt_enabled(&self, interrupt: Interrupt) -> bool {
+        self.regs.is_interrupt_enabled(interrupt)
+    }
+
+    /// Enable or disable interrupt.
+    #[inline]
+    pub fn set_interrupt_enabled(&self, interrupt: Interrupt, enabled: bool) {
+        self.regs.set_interrupt_enabled(interrupt, enabled);
+    }
+
+    /// Is interrupt forced.
+    #[inline]
+    pub fn is_interrupt_forced(&self, interrupt: Interrupt) -> bool {
+        self.regs.is_interrupt_forced(interrupt)
+    }
+
+    /// Force or release interrupt.
+    #[inline]
+    pub fn set_interrupt_forced(&self, interrupt: Interrupt, forced: bool) {
+        self.regs.set_interrupt_forced(interrupt, forced);
     }
 
     /// Set the interrupt override.


### PR DESCRIPTION
Both #4 and #24 left interrupts for GPIO as todos.

Adds the following methods for each PIN:
- `clear_interrupt(interrupt: Interrupt)`
- `interrupt_status(interrupt: Interrupt) -> bool`
- `is_interrupt_enabled(interrupt: Interrupt) -> bool`
- `set_interrupt_enabled(interrupt: Interrupt, enabled: bool)`
- `is_interrupt_forced(interrupt: Interrupt) -> bool`
- `set_interrupt_forced(interrupt: Interrupt, forced: bool)`
