### PR TITLE
Update example feather_neopixel_rainbow.rs for new Timer syntax

### DIFF
--- a/boards/feather_rp2040/examples/feather_neopixel_rainbow.rs
+++ b/boards/feather_rp2040/examples/feather_neopixel_rainbow.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
 
     let _neopixel: Pin<_, FunctionPio0> = pins.neopixel.into_mode();
 
-    let timer = Timer::new(pac.TIMER);
+    let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
     let mut delay = timer.count_down();
 
     // Configure the addressable LED


### PR DESCRIPTION
The signature for Timer::new() changed in #136 to require passing resets, this PR was created before that was merged.
Updated the call to Timer::new() to match all the other examples.