### PR TITLE
Update WS2812 usage after PIO api's breaking change.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,9 @@ members = [
     "boards/adafruit_macropad",
     "boards/pro_micro_rp2040",
 ]
+
+[patch.'https://github.com/rp-rs/rp-hal.git']
+rp2040-hal = { path ="./rp2040-hal" }
+
+[patch.crates-io]
+rp2040-hal = { path ="./rp2040-hal" }

--- a/boards/feather_rp2040/examples/feather_neopixel_rainbow.rs
+++ b/boards/feather_rp2040/examples/feather_neopixel_rainbow.rs
@@ -22,6 +22,7 @@ use feather_rp2040::{
     Pins, XOSC_CRYSTAL_FREQ,
 };
 use panic_halt as _;
+use rp2040_hal::pio::PIOExt;
 use smart_leds::{brightness, SmartLedsWrite, RGB8};
 use ws2812_pio::Ws2812;
 #[link_section = ".boot2"]
@@ -60,11 +61,12 @@ fn main() -> ! {
     let mut delay = timer.count_down();
 
     // Configure the addressable LED
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
         // The onboard NeoPixel is attached to GPIO pin #16 on the Feather RP2040.
         16,
-        pac.PIO0,
-        &mut pac.RESETS,
+        &mut pio,
+        sm0,
         clocks.peripheral_clock.freq(),
         timer.count_down(),
     );

--- a/boards/pro_micro_rp2040/examples/pro_micro_rainbow.rs
+++ b/boards/pro_micro_rp2040/examples/pro_micro_rainbow.rs
@@ -25,6 +25,7 @@ use pro_micro_rp2040::{
     },
     XOSC_CRYSTAL_FREQ,
 };
+use rp2040_hal::pio::PIOExt;
 use smart_leds::{brightness, SmartLedsWrite, RGB8};
 use ws2812_pio::Ws2812;
 
@@ -75,11 +76,11 @@ fn main() -> ! {
     let mut delay = timer.count_down();
 
     // Configure the addressable LED
-
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
         25,
-        pac.PIO0,
-        &mut pac.RESETS,
+        &mut pio,
+        sm0,
         clocks.peripheral_clock.freq(),
         timer.count_down(),
     );

--- a/boards/qt_py_rp2040/examples/qt_py_rainbow.rs
+++ b/boards/qt_py_rp2040/examples/qt_py_rainbow.rs
@@ -8,6 +8,7 @@ use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;
 use panic_halt as _;
+use rp2040_hal::pio::PIOExt;
 use smart_leds::{brightness, SmartLedsWrite, RGB8};
 use ws2812_pio::Ws2812;
 
@@ -59,13 +60,14 @@ fn main() -> ! {
         .set_high()
         .unwrap();
 
-    let timer = rp2040_hal::timer::Timer::new(pac.TIMER);
+    let timer = rp2040_hal::timer::Timer::new(pac.TIMER, &mut pac.RESETS);
     let mut delay = timer.count_down();
 
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
         12,
-        pac.PIO0,
-        &mut pac.RESETS,
+        &mut pio,
+        sm0,
         clocks.peripheral_clock.freq(),
         timer.count_down(),
     );


### PR DESCRIPTION
PIO's API has had a breaking change in its API that required WS2812 to update its own API.

This PR applies the required changes.

Related changes:
* https://github.com/rp-rs/rp-hal/pull/143
* https://github.com/ithinuel/ws2812-pio-rs/pull/2