### PR TITLE
Make pio-proc a dev-dependency

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -19,7 +19,6 @@ nb = "1.0"
 rp2040-pac = "0.1.5"
 paste = "1.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-pio-proc = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
 usb-device = "0.2.8"
 vcell = "0.1"
 void = { version = "1.0.2", default-features = false }
@@ -30,6 +29,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 rp2040-boot2 = { git = "https://github.com/rp-rs/rp2040-boot2-rs", rev = "67400f600b192e950b58df79ddc9b57ff209ef08" }
 hd44780-driver = "0.4.0"
+pio-proc = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
 
 [features]
 rt = ["rp2040-pac/rt"]


### PR DESCRIPTION
It's only used in an example, so it doesn't need to be a regular
dependency.