### PR TITLE
README: Add option --locked to cargo install elf2uf2-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You may also want to install these helpful tools:
 
 ```sh
 # Useful to creating UF2 images for the RP2040 USB Bootloader
-cargo install elf2uf2-rs
+cargo install elf2uf2-rs --locked
 # Useful for flashing over the SWD pins using a supported JTAG probe
 cargo install --git https://github.com/rp-rs/probe-run.git --branch rp2040-support 
 ```


### PR DESCRIPTION
Without the --locked option, cargo currently tries to compile it using
clap v3.0.0-beta.5, which fails:

```
[...]
   Compiling clap v3.0.0-beta.5
   Compiling elf2uf2-rs v1.3.5
error[E0432]: unresolved import `clap::Clap`
 -->
/home/jan/.cargo/registry/src/github.com-1ecc6299db9ec823/elf2uf2-rs-1.3.5/src/main.rs:3:5
  |
3 | use clap::Clap;
  |     ^^^^^^^^^^ no `Clap` in the root
[...]
```

With --locked, it uses clap v3.0.0-beta.4, which works.