### PR TITLE
API to enable/disable interrupts for each PWM channel.

### DIFF
--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -402,7 +402,7 @@ where
 
     /// Did this slice trigger an overflow interrupt?
     #[inline]
-    pub fn is_overflow(&self) -> bool {
+    pub fn has_overflown(&self) -> bool {
         let mask = self.bitmask();
         unsafe { (*pac::PWM::ptr()).ints.read().bits() & mask == mask }
     }


### PR DESCRIPTION
I'm not sure this is the correct way to do this, but I would like to be able to configure the interrupt registers of the PWM peripheral.

It seems like the Interrupt struct should take ownership of some data to enforce its uniqueness, but I'm not sure what that should be.