### PR TITLE
Mark Timer as sync

### DIFF
--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -11,6 +11,9 @@ pub struct Timer {
     timer: TIMER,
 }
 
+// Safety: All access is read-only.
+unsafe impl Sync for Timer {}
+
 impl Timer {
     /// Create a new [`Timer`]
     pub fn new(timer: TIMER, resets: &mut RESETS) -> Self {


### PR DESCRIPTION
Since all accesses are read-only there is no synchronizing to be done.