### PR TITLE
Correct limit for PIOBuilder::out_pins count argument

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1174,7 +1174,7 @@ impl<P: PIOExt> PIOBuilder<P> {
     /// The least-significant bit of `OUT` instruction asserts the state of the pin indicated by `base`, the next bit
     /// asserts the state of the next pin, and so on up to `count` pins. The pin numbers are considered modulo 32.
     pub fn out_pins(mut self, base: u8, count: u8) -> Self {
-        assert!(count <= 5);
+        assert!(count <= 32);
         self.out_base = base;
         self.out_count = count;
         self


### PR DESCRIPTION
This value is written to the PINCTRL register field
OUT_COUNT, which accoding to the data sheet has a valid range
of 0-32.

Fixes #181