### PR TITLE
Make ReadableOutput public to match the visibility of other Type-level variant of PinMode.

### DIFF
--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -259,7 +259,7 @@ impl<C: OutputConfig> Sealed for Output<C> {}
 pub type PushPullOutput = Output<PushPull>;
 
 /// Type-level variant of [`PinMode`] for readable push-pull output mode
-type ReadableOutput = Output<Readable>;
+pub type ReadableOutput = Output<Readable>;
 
 impl<I: PinId, C: OutputConfig> ValidPinMode<I> for Output<C> {}
 


### PR DESCRIPTION
The `PushPullOutput`  type alias is public, just like the aliases for the various `Function<T>` but `ReadableOutput` is not.
This PR fixes that inconsistency.