### PR TITLE
Fix UART init code

### DIFF
--- a/rp2040-hal/src/uart.rs
+++ b/rp2040-hal/src/uart.rs
@@ -221,18 +221,17 @@ impl<D: UartDevice> UartPeripheral<Disabled, D> {
 
         let effective_baudrate = configure_baudrate(&mut device, &config.baudrate, &frequency)?;
 
+        device.uartlcr_h.write(|w| {
+            w.fen().set_bit();
+            set_format(w, &config.data_bits, &config.stop_bits, &config.parity);
+            w
+        });
+
         // Enable the UART, both TX and RX
         device.uartcr.write(|w| {
             w.uarten().set_bit();
             w.txe().set_bit();
             w.rxe().set_bit();
-            w
-        });
-
-        device.uartlcr_h.write(|w| {
-            w.fen().set_bit();
-
-            set_format(w, &config.data_bits, &config.stop_bits, &config.parity);
             w
         });
 


### PR DESCRIPTION
Set uartlcr_h before enabling the UART.
Writing uartlcr_h while the UART is enabled is forbidden by the datasheet.

Details can be found here:
https://developer.arm.com/documentation/ddi0183/g/programmers-model/register-descriptions/line-control-register--uartlcr-h?lang=en
(As referenced from the Datasheet)