### PR TITLE
Change UART raw read return type and fix full read

### DIFF
--- a/rp2040-hal/src/uart.rs
+++ b/rp2040-hal/src/uart.rs
@@ -311,7 +311,7 @@ impl<D: UartDevice> UartPeripheral<Enabled, D> {
     /// This function reads as long as it can. As soon that the FIFO is empty, if :
     /// - 0 bytes were read, a WouldBlock Error is returned
     /// - some bytes were read, it is deemed to be a success
-    /// Upon success, the remaining slice is returned.
+    /// Upon success, it will return how many bytes were read.
     pub fn read_raw<'b>(&self, buffer: &'b mut [u8]) -> nb::Result<usize, ReadError<'b>> {
         let mut bytes_read = 0;
 


### PR DESCRIPTION
The return type of `read_raw` was changed so that it conforms to the std::io::Read trait. This also fixes a bug in the `read_full_blocking` code.
