### PR TITLE
Rename set_instruction to exec_instruction

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -525,13 +525,13 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
         self.exec_instruction(instruction);
     }
 
-    ///Execute the instruction immediately.
+    /// Execute the instruction immediately.
+    /// 
+    /// While this is allowed even when the state machine is running, the datasheet says:
+    /// > If EXEC instructions are used, instructions written to INSTR must not stall.
+    /// It's unclear what happens if this is violated.
     pub fn exec_instruction(&mut self, instruction: u16) {
-        // This is allowed even if the state machine is running.
-        //
-        // However, the datasheet says:
-        // "If EXEC instructions are used, instructions written to INSTR must not stall"
-        // It's unclear what happens if this is violated.
+        // TODO: clarify what happens if the instruction stalls.
         self.sm.exec_instruction(instruction);
     }
 

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -473,11 +473,11 @@ impl<SM: ValidStateMachine> UninitStateMachine<SM> {
         });
     }
 
-    /// Set the current instruction.
+    /// Execute the instruction immediately.
     // Safety: The Send trait assumes this is the only write to sm_instr while uninitialized. The
     // initialized `StateMachine` may also use this register. The `UnintStateMachine` is consumed
     // by `PIOBuilder.build` to create `StateMachine`
-    fn set_instruction(&mut self, instruction: u16) {
+    fn exec_instruction(&mut self, instruction: u16) {
         self.sm()
             .sm_instr
             .write(|w| unsafe { w.sm0_instr().bits(instruction) })
@@ -519,10 +519,14 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
         self.sm.sm().sm_addr.read().bits()
     }
 
-    /// Set the current instruction.
-    pub fn set_instruction(&mut self, instruction: u16) {
-        // TODO: Check if this function is safe to call while the state machine is running.
-        self.sm.set_instruction(instruction);
+    ///Execute the instruction immediately.
+    pub fn exec_instruction(&mut self, instruction: u16) {
+        // This is allowed even if the state machine is running.
+        //
+        // However, the datasheet says:
+        // "If EXEC instructions are used, instructions written to INSTR must not stall"
+        // It's unclear what happens if this is violated.
+        self.sm.exec_instruction(instruction);
     }
 
     /// Check if the current instruction is stalled.
@@ -564,7 +568,7 @@ impl<SM: ValidStateMachine> StateMachine<SM, Stopped> {
                 .sm()
                 .sm_pinctrl
                 .write(|w| unsafe { w.set_base().bits(pin_num).set_count().bits(1) });
-            self.set_instruction(
+            self.exec_instruction(
                 pio::InstructionOperands::SET {
                     destination: pio::SetDestination::PINS,
                     data: if PinState::High == pin_state { 1 } else { 0 },
@@ -593,7 +597,7 @@ impl<SM: ValidStateMachine> StateMachine<SM, Stopped> {
                 .sm()
                 .sm_pinctrl
                 .write(|w| unsafe { w.set_base().bits(pinnum).set_count().bits(1) });
-            self.set_instruction(
+            self.exec_instruction(
                 pio::InstructionOperands::SET {
                     destination: pio::SetDestination::PINDIRS,
                     data: if PinDir::Output == pin_dir { 1 } else { 0 },
@@ -680,7 +684,7 @@ impl<SM: ValidStateMachine> StateMachine<SM, Running> {
         // pause the state machine
         self.sm.set_enabled(false);
         // revert it to its wrap target
-        self.sm.set_instruction(
+        self.sm.exec_instruction(
             pio::InstructionOperands::JMP {
                 condition: pio::JmpCondition::Always,
                 address: self.program.wrap_target(),
@@ -829,7 +833,7 @@ impl<SM: ValidStateMachine> Tx<SM> {
         }
         .encode();
         // Safety: The only other place this register is written is
-        // `UninitStatemachine.set_instruction`, `Tx` is only created after init.
+        // `UninitStatemachine.exec_instruction`, `Tx` is only created after init.
         let mask = 1 << SM::id();
         while self.register_block().fstat.read().txempty().bits() & mask != mask {
             self.register_block().sm[SM::id()]
@@ -1429,9 +1433,9 @@ impl<P: PIOExt> PIOBuilder<P> {
         sm.restart();
         sm.reset_clock();
 
-        // Set starting location by setting the state machine to execute a jmp
+        // Set starting location by forcing the state machine to execute a jmp
         // to the beginning of the program we loaded in.
-        sm.set_instruction(
+        sm.exec_instruction(
             pio::InstructionOperands::JMP {
                 condition: pio::JmpCondition::Always,
                 address: offset as u8,

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -519,6 +519,12 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
         self.sm.sm().sm_addr.read().bits()
     }
 
+    #[deprecated(note = "Renamed to exec_instruction")]
+    ///Execute the instruction immediately.
+    pub fn set_instruction(&mut self, instruction: u16) {
+        self.exec_instruction(instruction);
+    }
+
     ///Execute the instruction immediately.
     pub fn exec_instruction(&mut self, instruction: u16) {
         // This is allowed even if the state machine is running.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -526,7 +526,7 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
     }
 
     /// Execute the instruction immediately.
-    /// 
+    ///
     /// While this is allowed even when the state machine is running, the datasheet says:
     /// > If EXEC instructions are used, instructions written to INSTR must not stall.
     /// It's unclear what happens if this is violated.


### PR DESCRIPTION
This is meant to make the action caused by the function call more obvious. (Better suggestions are welcome!)

set_instruction sounds a little bit like it would somehow change the instruction memory of the state machine, which is not the case. All it does is forcing the state machine to immediately execute the specified instruction.

Also, update the comment regarding calling this function while the state machine is running with information from datasheet section 3.5.7.

@ithinuel, if this is merged, i2c-pio-rs needs to be updated as well, as it calls set_instruction.