### PR TITLE
pin ws2812-pio to a specific sha

### DIFF
--- a/boards/feather_rp2040/Cargo.toml
+++ b/boards/feather_rp2040/Cargo.toml
@@ -22,7 +22,7 @@ rp2040-boot2 = "0.2"
 nb = "1.0.0"
 smart-leds = "0.3.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
 
 [features]
 default = ["rt"]

--- a/boards/itsy_bitsy_rp2040/Cargo.toml
+++ b/boards/itsy_bitsy_rp2040/Cargo.toml
@@ -22,7 +22,7 @@ rp2040-boot2 = "0.2"
 smart-leds = "0.3"
 nb = "1.0.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
 
 [features]
 default = ["rt"]

--- a/boards/pro_micro_rp2040/Cargo.toml
+++ b/boards/pro_micro_rp2040/Cargo.toml
@@ -26,4 +26,4 @@ smart-leds = "0.3.0"
 embedded-time = "0.12.0"
 nb = "1.0.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }

--- a/boards/qt_py_rp2040/Cargo.toml
+++ b/boards/qt_py_rp2040/Cargo.toml
@@ -22,7 +22,7 @@ rp2040-boot2 = "0.2"
 smart-leds = "0.3"
 nb = "1.0.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
 
 [features]
 default = ["rt"]


### PR DESCRIPTION
This will help future update of the driver without breaking rp-hal's main branch.

The expected flow would then be:
* Update rp-hal/rp2040-hal with new API & deprecation of the current API
* Update the affected dependencies (ws2812-pio/i2c-pio)
* Update the examples using those dependencies & bump the pinned revs
* Remove deprecated API when deemed appropriate for the community

A short term example will be easing the integration of:
- https://github.com/rp-rs/rp-hal/pull/193
- https://github.com/ithinuel/i2c-pio-rs/pull/1
- https://github.com/ithinuel/ws2812-pio-rs/pull/4

