### PR TITLE
pio: Fix unsound Send clippy warning

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -11,7 +11,7 @@ const PIO_INSTRUCTION_COUNT: usize = 32;
 
 /// PIO Instance
 pub trait PIOExt:
-    core::ops::Deref<Target = rp2040_pac::pio0::RegisterBlock> + SubsystemReset + Sized
+    core::ops::Deref<Target = rp2040_pac::pio0::RegisterBlock> + SubsystemReset + Sized + Send
 {
     /// Create a new PIO wrapper and split the state machines into individual objects.
     #[allow(clippy::type_complexity)] // Required for symmetry with PIO::free().
@@ -94,7 +94,7 @@ impl<P: PIOExt> core::fmt::Debug for PIO<P> {
 
 // Safety: `PIO` only provides access to those registers which are not directly used by
 // `StateMachine`.
-unsafe impl<P: PIOExt + Send> Send for PIO<P> {}
+unsafe impl<P: PIOExt> Send for PIO<P> {}
 
 // Safety: `PIO` is marked Send so ensure all accesses remain atomic and no new concurrent accesses
 // are added.
@@ -315,7 +315,7 @@ impl<P: PIOExt> InstalledProgram<P> {
 }
 
 /// State machine identifier (without a specified PIO block).
-pub trait StateMachineIndex {
+pub trait StateMachineIndex: Send {
     /// Numerical index of the state machine (0 to 3).
     fn id() -> usize;
 }
@@ -892,7 +892,7 @@ pub struct Interrupt<P: PIOExt> {
 }
 
 // Safety: `Interrupt` provides exclusive access to interrupt registers.
-unsafe impl<P: PIOExt + Send> Send for Interrupt<P> {}
+unsafe impl<P: PIOExt> Send for Interrupt<P> {}
 
 // Safety: `Interrupt` is marked Send so ensure all accesses remain atomic and no new concurrent
 // accesses are added.


### PR DESCRIPTION
Clippy complains about the following line being unsound: [rp2040-hal/src/pio.rs:535](https://github.com/rp-rs/rp-hal/blob/f9b3d8341d9e8e83d6be89ae3692f85646bde97a/rp2040-hal/src/pio.rs#L535)

```
this implementation is unsound, as some fields in `StateMachine<SM, State>` are `!Send`
`#[warn(clippy::non_send_fields_in_send_ty)]` on by default
add bounds on type parameter `SM` that satisfy `InstalledProgram<SM::PIO>: Send`
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#non_send_fields_in_send_ty
```

The warning can be resolved by making PIOExt, StateMachineIndex, and ValidStateMachine be supertraits of Send. This also makes adding the Send bound redundant in a few places.