### PR TITLE
Added timer alarms

### DIFF
--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -13,9 +13,6 @@ pub struct Timer {
     alarms: [bool; 4],
 }
 
-// Safety: All access is read-only.
-unsafe impl Sync for Timer {}
-
 impl Timer {
     /// Create a new [`Timer`]
     pub fn new(timer: TIMER, resets: &mut RESETS) -> Self {
@@ -55,42 +52,50 @@ impl Timer {
 
     /// Retrieve a reference to alarm 0. Will only return a value the first time this is called
     pub fn alarm_0(&mut self) -> Option<Alarm0> {
-        if self.alarms[0] {
-            self.alarms[0] = false;
-            Some(Alarm0(PhantomData))
-        } else {
-            None
-        }
+        cortex_m::interrupt::free(|_| {
+            if self.alarms[0] {
+                self.alarms[0] = false;
+                Some(Alarm0(PhantomData))
+            } else {
+                None
+            }
+        })
     }
 
     /// Retrieve a reference to alarm 1. Will only return a value the first time this is called
     pub fn alarm_1(&mut self) -> Option<Alarm1> {
-        if self.alarms[1] {
-            self.alarms[1] = false;
-            Some(Alarm1(PhantomData))
-        } else {
-            None
-        }
+        cortex_m::interrupt::free(|_| {
+            if self.alarms[1] {
+                self.alarms[1] = false;
+                Some(Alarm1(PhantomData))
+            } else {
+                None
+            }
+        })
     }
 
     /// Retrieve a reference to alarm 2. Will only return a value the first time this is called
     pub fn alarm_2(&mut self) -> Option<Alarm2> {
-        if self.alarms[2] {
-            self.alarms[2] = false;
-            Some(Alarm2(PhantomData))
-        } else {
-            None
-        }
+        cortex_m::interrupt::free(|_| {
+            if self.alarms[2] {
+                self.alarms[2] = false;
+                Some(Alarm2(PhantomData))
+            } else {
+                None
+            }
+        })
     }
 
     /// Retrieve a reference to alarm 3. Will only return a value the first time this is called
     pub fn alarm_3(&mut self) -> Option<Alarm3> {
-        if self.alarms[3] {
-            self.alarms[3] = false;
-            Some(Alarm3(PhantomData))
-        } else {
-            None
-        }
+        cortex_m::interrupt::free(|_| {
+            if self.alarms[3] {
+                self.alarms[3] = false;
+                Some(Alarm3(PhantomData))
+            } else {
+                None
+            }
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds an API for the 4 build-in alarms.

To schedule an alarm:

```rust
let mut timer = Timer::new(cx.device.TIMER, &mut cx.device.RESETS);
let mut alarm0 = timer.alarm_0().unwrap();
alarm0.enable_interrupt();
alarm0.schedule(300_000.microseconds()).unwrap();

// interrupt
#[no_mangle]
pub fn TIMER_IRQ_0() {
     alarm0.clear_interrupt();
     led.toggle().unwrap();
     alarm0.schedule(300_000.microseconds()).unwrap();
}
```

Closes #100