### PR TITLE
Bump to latest ws2812 driver's revision.

### DIFF
--- a/boards/feather_rp2040/Cargo.toml
+++ b/boards/feather_rp2040/Cargo.toml
@@ -22,7 +22,7 @@ rp2040-boot2 = "0.2"
 nb = "1.0.0"
 smart-leds = "0.3.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "7a11616f994025f5c99f28b283d2b25d60d46a43" }
 
 [features]
 default = ["rt"]

--- a/boards/feather_rp2040/examples/feather_neopixel_rainbow.rs
+++ b/boards/feather_rp2040/examples/feather_neopixel_rainbow.rs
@@ -13,7 +13,6 @@ use embedded_time::duration::Extensions;
 use feather_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
-        gpio::{FunctionPio0, Pin},
         pac,
         sio::Sio,
         timer::Timer,
@@ -55,8 +54,6 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let _neopixel: Pin<_, FunctionPio0> = pins.neopixel.into_mode();
-
     let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
     let mut delay = timer.count_down();
 
@@ -64,7 +61,7 @@ fn main() -> ! {
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
         // The onboard NeoPixel is attached to GPIO pin #16 on the Feather RP2040.
-        16,
+        pins.neopixel.into_mode(),
         &mut pio,
         sm0,
         clocks.peripheral_clock.freq(),

--- a/boards/itsy_bitsy_rp2040/Cargo.toml
+++ b/boards/itsy_bitsy_rp2040/Cargo.toml
@@ -22,7 +22,7 @@ rp2040-boot2 = "0.2"
 smart-leds = "0.3"
 nb = "1.0.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "7a11616f994025f5c99f28b283d2b25d60d46a43" }
 
 [features]
 default = ["rt"]

--- a/boards/itsy_bitsy_rp2040/examples/itsy_bitsy_rainbow.rs
+++ b/boards/itsy_bitsy_rp2040/examples/itsy_bitsy_rainbow.rs
@@ -15,7 +15,6 @@ use ws2812_pio::Ws2812;
 use itsy_bitsy_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
-        gpio::{FunctionPio0, Pin},
         pac,
         sio::Sio,
         watchdog::Watchdog,
@@ -53,7 +52,7 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let _led: Pin<_, FunctionPio0> = pins.neopixel_data.into_mode();
+    let led = pins.neopixel_data.into_mode();
 
     pins.neopixel_power
         .into_push_pull_output()
@@ -65,7 +64,7 @@ fn main() -> ! {
 
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
-        17,
+        led,
         &mut pio,
         sm0,
         clocks.peripheral_clock.freq(),

--- a/boards/pro_micro_rp2040/Cargo.toml
+++ b/boards/pro_micro_rp2040/Cargo.toml
@@ -26,4 +26,4 @@ smart-leds = "0.3.0"
 embedded-time = "0.12.0"
 nb = "1.0.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "7a11616f994025f5c99f28b283d2b25d60d46a43" }

--- a/boards/pro_micro_rp2040/examples/pro_micro_rainbow.rs
+++ b/boards/pro_micro_rp2040/examples/pro_micro_rainbow.rs
@@ -17,7 +17,6 @@ use panic_halt as _;
 use pro_micro_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
-        gpio::{FunctionPio0, Pin},
         pac,
         sio::Sio,
         timer::Timer,
@@ -70,15 +69,13 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let _led: Pin<_, FunctionPio0> = pins.led.into_mode();
-
     let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
     let mut delay = timer.count_down();
 
     // Configure the addressable LED
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
-        25,
+        pins.led.into_mode(),
         &mut pio,
         sm0,
         clocks.peripheral_clock.freq(),

--- a/boards/qt_py_rp2040/Cargo.toml
+++ b/boards/qt_py_rp2040/Cargo.toml
@@ -22,7 +22,7 @@ rp2040-boot2 = "0.2"
 smart-leds = "0.3"
 nb = "1.0.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "e1cdd475de20697aaa0bc58803512927094f0326" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "7a11616f994025f5c99f28b283d2b25d60d46a43" }
 
 [features]
 default = ["rt"]

--- a/boards/qt_py_rp2040/examples/qt_py_rainbow.rs
+++ b/boards/qt_py_rp2040/examples/qt_py_rainbow.rs
@@ -15,7 +15,6 @@ use ws2812_pio::Ws2812;
 use qt_py_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
-        gpio::{FunctionPio0, Pin},
         pac,
         sio::Sio,
         watchdog::Watchdog,
@@ -53,7 +52,7 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let _led: Pin<_, FunctionPio0> = pins.neopixel_data.into_mode();
+    let led = pins.neopixel_data.into_mode();
 
     pins.neopixel_power
         .into_push_pull_output()
@@ -65,7 +64,7 @@ fn main() -> ! {
 
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let mut ws = Ws2812::new(
-        12,
+        led,
         &mut pio,
         sm0,
         clocks.peripheral_clock.freq(),


### PR DESCRIPTION
This change makes the ws2812 driver take ownership of the pin rather than its id.

This strengthen the relation between the LED driver and the pin used as well as simplifying it integration by letting the compiler resolve the pin id from the pin instance.