### PR TITLE
Draft: DMA

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -17,7 +17,8 @@ embedded-time = "0.12.0"
 embedded-dma = "0.1.2"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
-rp2040-pac = "0.1.5"
+#rp2040-pac = "0.1.5"
+rp2040-pac = { path = "../../rp2040-pac" }
 paste = "1.0"
 pio = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }
 pio-proc = { git = "https://github.com/rp-rs/pio-rs.git", branch = "main" }

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -14,6 +14,7 @@ cortex-m = "0.7.2"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 eh1_0_alpha = { version = "=1.0.0-alpha.5", package="embedded-hal", optional=true }
 embedded-time = "0.12.0"
+embedded-dma = "0.1.2"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
 rp2040-pac = "0.1.5"

--- a/rp2040-hal/examples/pio_dma.rs
+++ b/rp2040-hal/examples/pio_dma.rs
@@ -1,0 +1,146 @@
+//! This example shows how to read from and write to PIO using DMA.
+//!
+//! If a LED is connected to that pin, like on a Pico board, it will continously output "HELLO
+//! WORLD" in morse code. The example also tries to read the data back. If reading the data fails,
+//! the message will only be shown once, and then the LED remains dark.
+#![no_std]
+#![no_main]
+
+use cortex_m::singleton;
+use cortex_m_rt::entry;
+use hal::dma::{DMAExt, TransferConfig};
+use hal::gpio::{FunctionPio0, Pin};
+use hal::pac;
+use hal::pio::PIOExt;
+use hal::sio::Sio;
+use panic_halt as _;
+use rp2040_hal as hal;
+
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+
+    let sio = Sio::new(pac.SIO);
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // configure LED pin for Pio0.
+    let _led: Pin<_, FunctionPio0> = pins.gpio25.into_mode();
+    // PIN id for use inside of PIO
+    let led_pin_id = 25;
+
+    // HELLO WORLD in morse code:
+    // .... . .-.. .-.. --- / .-- --- .-. .-.. -..
+    let message = [
+        0b10101010_00100010_11101010_00101110,
+        0b10100011_10111011_10000000_10111011,
+        0b10001110_11101110_00101110_10001011,
+        0b10101000_11101010_00000000_00000000,
+    ];
+
+    // Define a PIO program which reads data from the TX FIFO bit by bit, configures the LED
+    // according to the data, and then writes the data back to the RX FIFO.
+    let program = pio_proc::pio!(
+        32,
+        "
+.wrap_target
+    out x, 1
+    mov pins, x
+    in x, 1 [13]
+.wrap
+        "
+    );
+
+    // Initialize and start PIO
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+    let installed = pio.install(&program.program).unwrap();
+    let div = 0f32; // as slow as possible (0 is interpreted as 65536)
+    let (mut sm, rx, tx) = rp2040_hal::pio::PIOBuilder::from_program(installed)
+        .out_pins(led_pin_id, 1)
+        .clock_divisor(div)
+        .autopull(true)
+        .autopush(true)
+        .build(sm0);
+    // The GPIO pin needs to be configured as an output.
+    sm.set_pindirs_with_mask(1 << led_pin_id, 1 << led_pin_id);
+    sm.start();
+
+    // Read and write without DMA.
+    /*let mut failure = false;
+    for i in 0..message.len() {
+        tx.write(message[i]);
+        let mut value = None;
+        while value.is_none() {
+            value = rx.read();
+        }
+        if value.unwrap() != message[i] {
+            failure = true;
+        }
+    }
+    if failure {
+        // Abort.
+        #[allow(clippy::empty_loop)]
+        loop {}
+    }*/
+
+    let dma = pac.DMA.split(&mut pac.RESETS);
+
+    // Transfer a single message via DMA.
+    let tx_buf = singleton!(: [u32; 4] = message).unwrap();
+    let rx_buf = singleton!(: [u32; 4] = [0; 4]).unwrap();
+    let tx_transfer = TransferConfig::new(dma.ch0, tx_buf, tx).start();
+    let rx_transfer = TransferConfig::new(dma.ch1, rx, rx_buf).start();
+    let (ch0, tx_buf, tx) = tx_transfer.wait();
+    let (ch1, rx, rx_buf) = rx_transfer.wait();
+    for i in 0..rx_buf.len() {
+        if rx_buf[i] != tx_buf[i] {
+            // The data did not match, abort.
+            #[allow(clippy::empty_loop)]
+            loop {}
+        }
+    }
+
+    // Chain three buffers together.
+    /*let tx_buf1 = singleton!(: [u32; 4] = message).unwrap();
+    let tx_buf2 = singleton!(: [u32; 4] = message).unwrap();
+    let rx_buf1 = singleton!(: [u32; 4] = [0; 4]).unwrap();
+    let rx_buf2 = singleton!(: [u32; 4] = [0; 4]).unwrap();
+    let tx_transfer = Transfer::new((dma.ch0, dma.ch1), tx_buf1, tx)
+        .read_next(tx_buf2)
+        .start();
+    let rx_transfer = Transfer::new((dma.ch2, dma.ch3), rx, rx_buf)
+        .write_next(rx_buf2)
+        .start();
+    let (_ch0, _tx_buf, next_tx_transfer) = tx_transfer.wait();
+    let (_ch1, _tx_buf, _tx) = next_tx_transfer.wait();
+    let (_ch2, _rx_buf, next_rx_transfer) = rx_transfer.wait();
+    let (_ch3, _rx_buf, _tx) = next_rx_transfer.wait();*/
+    // TODO: Check the received data.
+
+    // Endless transfer from a ring buffer via DMA - note that unaligned ring buffers require three
+    // (!) DMA channels, one for each buffer and one to control the other two channels.
+    // TODO: The API should use two buffers, so that the transfer can then return one half of the
+    // buffer while the other one is in progress of being transferred.
+    let tx_buf = singleton!(: AlignedBuffer = AlignedBuffer(message)).unwrap();
+    let rx_buf = singleton!(: AlignedBuffer = AlignedBuffer([0; 4])).unwrap();
+    TransferConfig::new((ch0, ch1), &tx_buf.0, tx)
+        .start_ring()
+        .unwrap();
+    TransferConfig::new((dma.ch2, dma.ch3), rx, &mut rx_buf.0)
+        .start_ring()
+        .unwrap();
+
+    #[allow(clippy::empty_loop)]
+    loop {}
+}
+
+#[repr(align(16))]
+struct AlignedBuffer([u32; 4]);

--- a/rp2040-hal/examples/spi_dma.rs
+++ b/rp2040-hal/examples/spi_dma.rs
@@ -1,0 +1,93 @@
+//! # SPI DMA Example
+//!
+//! This application demonstrates how to use DMA for SPI transfers.
+//!
+//! The application expects the MISO and MOSI pins to be wired together so that it is able to check
+//! whether the data was sent and received correctly.
+//!
+//! See the `Cargo.toml` file for Copyright and licence details.
+#![no_std]
+#![no_main]
+
+use cortex_m::singleton;
+use cortex_m_rt::entry;
+use embedded_time::rate::Extensions;
+use hal::dma::{BidirectionalConfig, DMAExt};
+use hal::pac;
+use panic_halt as _;
+use rp2040_hal as hal;
+use rp2040_hal::clocks::Clock;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER;
+
+/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+/// if your board has a different frequency
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+
+    // Setup clocks and the watchdog.
+    let mut watchdog = hal::watchdog::Watchdog::new(pac.WATCHDOG);
+    let clocks = hal::clocks::init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // Setup the pins.
+    let sio = hal::sio::Sio::new(pac.SIO);
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // These are implicitly used by the spi driver if they are in the correct mode
+    let _spi_sclk = pins.gpio6.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_mosi = pins.gpio7.into_mode::<hal::gpio::FunctionSpi>();
+    let _spi_miso = pins.gpio4.into_mode::<hal::gpio::FunctionSpi>();
+    let spi = hal::spi::Spi::<_, _, 8>::new(pac.SPI0);
+
+    // Exchange the uninitialised SPI driver for an initialised one
+    let spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        16_000_000u32.Hz(),
+        &embedded_hal::spi::MODE_0,
+    );
+
+    // Initialize DMA.
+    let dma = pac.DMA.split(&mut pac.RESETS);
+
+    // Use DMA to transfer some bytes (single buffering).
+    let tx_buf = singleton!(: [u8; 16] = [0x42; 16]).unwrap();
+    let rx_buf = singleton!(: [u8; 16] = [0; 16]).unwrap();
+    let transfer = BidirectionalConfig::new((dma.ch0, dma.ch1), tx_buf, spi, rx_buf).start();
+    let ((_ch0, _ch1), tx_buf, _spi, rx_buf) = transfer.wait();
+    for i in 0..rx_buf.len() {
+        if rx_buf[i] != tx_buf[i] {
+            // TODO: Signal failure using an LED.
+        }
+    }
+
+    // Use DMA to continuously transfer data (double buffering).
+    // TODO
+
+    #[allow(clippy::empty_loop)]
+    loop {
+        // Empty loop
+    }
+}

--- a/rp2040-hal/src/dma.rs
+++ b/rp2040-hal/src/dma.rs
@@ -1,0 +1,653 @@
+//! Direct memory acces (DMA).
+//!
+//! The DMA unit of the RP2040 seems very simplistic at first when compared to other MCUs. For
+//! example, the individual DMA channels do not support chaining multiple buffers. However, within
+//! certain limits, the DMA engine supports a wide range of transfer and buffer types, often by
+//! combining multiple DMA channels:
+//!
+//! * Simple RX/TX transfers filling a single buffer or transferring data from one peripheral to
+//!   another.
+//! * RX/TX transfers that use multiple chained buffers: These transfers require two channels to
+//!   be combined, where the first DMA channel configures the second DMA channel. An example for
+//!   this transfer type can be found in the datasheet.
+//! * Repeated transfers from/to a set of buffers: By allocating one channel per buffer and
+//!   chaining the channels together, continuous transfers to a set of ring buffers can be
+//!   achieved. Note, however, that the MCU manually needs to reconfigure the DMA units unless the
+//!   buffer addresses and sizes are aligned, in which case the ring buffer functionality of the
+//!   DMA engine can be used. Even then, however, at least two DMA channels are required as a
+//!   channel cannot be chained to itself.
+//!
+//! This API tries to provide three types of buffers: Single buffers, double-buffered transfers
+//! where the user can specify the next buffer while the previous is being transferred, and
+//! automatic continous ring buffers consisting of two aligned buffers being read or written
+//! alternatingly.
+
+use crate::resets::SubsystemReset;
+use core::marker::PhantomData;
+use core::mem;
+use core::sync::atomic::{compiler_fence, Ordering};
+use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
+use rp2040_pac::DMA;
+
+/// DMA unit.
+pub trait DMAExt {
+    /// Splits the DMA unit into its individual channels.
+    fn split(self, resets: &mut pac::RESETS) -> Channels;
+}
+
+/// DMA channel.
+pub struct Channel<CH: ChannelIndex> {
+    _phantom: PhantomData<CH>,
+}
+
+/// DMA channel identifier.
+pub trait ChannelIndex {
+    /// Numerical index of the DMA channel (0..11).
+    fn id() -> u8;
+}
+
+macro_rules! channels {
+    (
+        $($CHX:ident: ($chX:ident, $x:expr),)+
+    ) => {
+        impl DMAExt for DMA {
+            fn split(self, resets: &mut pac::RESETS) -> Channels {
+                self.reset_bring_up(resets);
+
+                Channels {
+                    $(
+                        $chX: Channel {
+                            _phantom: PhantomData,
+                        },
+                    )+
+                }
+            }
+        }
+
+        /// Set of DMA channels.
+        pub struct Channels {
+            $(
+                /// DMA channel.
+                pub $chX: Channel<$CHX>,
+            )+
+        }
+        $(
+            /// DMA channel identifier.
+            pub struct $CHX;
+            impl ChannelIndex for $CHX {
+                fn id() -> u8 {
+                    $x
+                }
+            }
+        )+
+    }
+}
+
+channels! {
+    CH0: (ch0, 0),
+    CH1: (ch1, 1),
+    CH2: (ch2, 2),
+    CH3: (ch3, 3),
+    CH4: (ch4, 4),
+    CH5: (ch5, 5),
+    CH6: (ch6, 6),
+    CH7: (ch7, 7),
+    CH8: (ch8, 8),
+    CH9: (ch9, 9),
+    CH10:(ch10, 10),
+    CH11:(ch11, 11),
+}
+
+trait ChannelRegs {
+    unsafe fn ptr() -> *const rp2040_pac::dma::CH;
+    fn regs(&self) -> &rp2040_pac::dma::CH;
+}
+
+impl<CH: ChannelIndex> ChannelRegs for Channel<CH> {
+    unsafe fn ptr() -> *const rp2040_pac::dma::CH {
+        &(*rp2040_pac::DMA::ptr()).ch[CH::id() as usize] as *const _
+    }
+
+    fn regs(&self) -> &rp2040_pac::dma::CH {
+        unsafe { &*Self::ptr() }
+    }
+}
+
+/// Trait which implements low-level functionality for transfers using a single DMA channel.
+pub trait SingleChannel {
+    /// Returns the registers associated with this DMA channel.
+    ///
+    /// In the case of channel pairs, this returns the first channel.
+    fn ch(&self) -> &rp2040_pac::dma::CH;
+    fn id() -> u8;
+}
+
+// TODO: ChannelPair is not actually required, we can just implement SingleChannel on a tuple.
+
+/// Trait which implements low-level functionality for transfers requiring two DMA channels.
+///
+/// Anything that requires more than a single buffer exactly once requires two channels to be
+/// combined.
+pub trait ChannelPair: SingleChannel {
+    /// Returns the registers associated with the second DMA channel associated with this channel
+    /// pair.
+    fn ch2(&self) -> &rp2040_pac::dma::CH;
+    fn id2() -> u8;
+}
+
+impl<CH: ChannelIndex> SingleChannel for Channel<CH> {
+    fn ch(&self) -> &rp2040_pac::dma::CH {
+        self.regs()
+    }
+
+    fn id() -> u8 {
+        CH::id()
+    }
+}
+
+impl<CH1: ChannelIndex, CH2: ChannelIndex> SingleChannel for (Channel<CH1>, Channel<CH2>) {
+    fn ch(&self) -> &rp2040_pac::dma::CH {
+        self.0.regs()
+    }
+
+    fn id() -> u8 {
+        CH1::id()
+    }
+}
+
+impl<CH1: ChannelIndex, CH2: ChannelIndex> ChannelPair for (Channel<CH1>, Channel<CH2>) {
+    fn ch2(&self) -> &rp2040_pac::dma::CH {
+        self.1.regs()
+    }
+
+    fn id2() -> u8 {
+        CH2::id()
+    }
+}
+
+/// Trait which is implemented by anything that can be read via DMA.
+pub trait ReadTarget {
+    /// Type which is transferred in a single DMA transfer.
+    type ReceivedWord;
+
+    /// Returns the DREQ number for this data source (`None` for memory buffers).
+    fn rx_treq() -> Option<u8>;
+
+    /// Returns the address and the maximum number of words that can be transferred from this data
+    /// source in a single DMA operation.
+    ///
+    /// For peripherals, the cound should likely be u32::MAX. If a data source implements
+    /// EndlessReadTarget, it is suitable for infinite transfers from or to ring buffers. Note that
+    /// ring buffers designated for endless transfers, but with a finite buffer size, should return
+    /// the size of their individual buffers here.
+    ///
+    /// # Safety
+    ///
+    /// This function has the same safety guarantees as `StaticReadBuffer::static_read_buffer`.
+    fn rx_address_count(&self) -> (u32, u32);
+
+    /// Returns whether the address shall be incremented after each transfer.
+    fn rx_increment(&self) -> bool;
+}
+
+/// Marker which signals that `rx_address_count()` can be called multiple times.
+///
+/// The DMA code will never call `rx_address_count()` to request more than two buffers to configure
+/// two DMA channels. In the case of peripherals, the function can always return the same values.
+pub trait EndlessReadTarget: ReadTarget {}
+
+impl<B: StaticReadBuffer> ReadTarget for B {
+    type ReceivedWord = <B as StaticReadBuffer>::Word;
+
+    fn rx_treq() -> Option<u8> {
+        None
+    }
+
+    fn rx_address_count(&self) -> (u32, u32) {
+        // Safety: We only call the function once per buffer.
+        let (ptr, len) = unsafe { self.static_read_buffer() };
+        (ptr as u32, len as u32)
+    }
+
+    fn rx_increment(&self) -> bool {
+        true
+    }
+}
+
+/// Trait which is implemented by anything that can be written via DMA.
+pub trait WriteTarget {
+    /// Type which is transferred in a single DMA transfer.
+    type TransmittedWord;
+
+    /// Returns the DREQ number for this data sink (`None` for memory buffers).
+    fn tx_treq() -> Option<u8>;
+
+    /// Returns the address and the maximum number of words that can be transferred from this data
+    /// source in a single DMA operation.
+    ///
+    /// See `ReadTarget::rx_address_count` for a complete description of the semantics of this
+    /// function.
+    fn tx_address_count(&mut self) -> (u32, u32);
+
+    /// Returns whether the address shall be incremented after each transfer.
+    fn tx_increment(&self) -> bool;
+}
+
+/// Marker which signals that `tx_address_count()` can be called multiple times.
+///
+/// The DMA code will never call `tx_address_count()` to request more than two buffers to configure
+/// two DMA channels. In the case of peripherals, the function can always return the same values.
+pub trait EndlessWriteTarget: WriteTarget {}
+
+impl<B: StaticWriteBuffer> WriteTarget for B {
+    type TransmittedWord = <B as StaticWriteBuffer>::Word;
+
+    fn tx_treq() -> Option<u8> {
+        None
+    }
+
+    fn tx_address_count(&mut self) -> (u32, u32) {
+        // Safety: We only call the function once per buffer.
+        let (ptr, len) = unsafe { self.static_write_buffer() };
+        (ptr as u32, len as u32)
+    }
+
+    fn tx_increment(&self) -> bool {
+        true
+    }
+}
+
+/*/// Ring buffer consisting of two aligned memory regions.
+///
+/// We require buffers to have a power-of-two size and to be aligned to their size, as otherwise
+/// the RP2040 would require an additional DMA channel as well as an additional aligned buffer to
+/// implement operations on the ring buffer.
+///
+/// The two buffers do not have to have the same size.
+pub struct ReadRingBuffer<TYPE, BUF1, BUF2> {
+    buf1: BUF1,
+    buf2: BUF2,
+    _phantom: PhantomData<TYPE>,
+}
+
+impl<TYPE, BUF1, BUF2> ReadRingBuffer<TYPE, BUF1, BUF2>
+where
+    BUF1: StaticReadBuffer<Word = TYPE>,
+    BUF2: StaticReadBuffer<Word = TYPE>,
+{
+    /// Creates a new ring buffer from the two buffers, checking their size and alignment.
+    pub fn new(buf1: BUF1, buf2: BUF2) -> Result<Self, DMAError> {
+        // We check the alignment of the buffers before creating
+        // Safety: We do not actually access the pointers returned by the function. According to
+        // the documentation, later calls are required to return identical values.
+        let (ptr1, len1) = unsafe { buf1.static_read_buffer() };
+        let (ptr2, len2) = unsafe { buf2.static_read_buffer() };
+        let len1 = len1 * mem::size_of::<TYPE>();
+        let len2 = len2 * mem::size_of::<TYPE>();
+        if !len1.is_power_of_two() || !len2.is_power_of_two() {
+            return Err(DMAError::Alignment);
+        }
+        if (ptr1 as usize & (len1 - 1)) != 0 {
+            return Err(DMAError::Alignment);
+        }
+        if (ptr2 as usize & (len2 - 1)) != 0 {
+            return Err(DMAError::Alignment);
+        }
+
+        Ok(Self {
+            buf1,
+            buf2,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<TYPE, BUF1, BUF2> ReadTarget for ReadRingBuffer<TYPE, BUF1, BUF2>
+where
+    BUF1: StaticReadBuffer<Word = TYPE>,
+    BUF2: StaticReadBuffer<Word = TYPE>,
+{
+    type ReceivedWord = TYPE;
+
+    fn rx_treq() -> Option<u8> {
+        None
+    }
+
+    fn rx_address_count(&self) -> (u32, u32) {
+        // TODO
+        (0, 0)
+    }
+
+    fn rx_increment(&self) -> bool {
+        true
+    }
+}
+
+impl<TYPE, BUF1, BUF2> EndlessReadTarget for ReadRingBuffer<TYPE, BUF1, BUF2>
+where
+    BUF1: StaticReadBuffer<Word = TYPE>,
+    BUF2: StaticReadBuffer<Word = TYPE>,
+{
+}
+
+pub struct WriteRingBuffer<TYPE, BUF1, BUF2> {
+    buf1: BUF1,
+    buf2: BUF2,
+    _phantom: PhantomData<TYPE>,
+}
+
+impl<TYPE, BUF1, BUF2> WriteRingBuffer<TYPE, BUF1, BUF2>
+where
+    BUF1: StaticWriteBuffer<Word = TYPE>,
+    BUF2: StaticWriteBuffer<Word = TYPE>,
+{
+    pub fn new(buf1: BUF1, buf2: BUF2) -> Result<Self, DMAError> {
+        // TODO: Check alignment.
+        Ok(Self {
+            buf1,
+            buf2,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<TYPE, BUF1, BUF2> WriteTarget for WriteRingBuffer<TYPE, BUF1, BUF2>
+where
+    BUF1: StaticWriteBuffer<Word = TYPE>,
+    BUF2: StaticWriteBuffer<Word = TYPE>,
+{
+    type TransmittedWord = TYPE;
+
+    fn tx_treq() -> Option<u8> {
+        None
+    }
+
+    fn tx_address_count(&mut self) -> (u32, u32) {
+        // TODO
+        (0, 0)
+    }
+
+    fn tx_increment(&self) -> bool {
+        true
+    }
+}
+
+impl<TYPE, BUF1, BUF2> EndlessWriteTarget for WriteRingBuffer<TYPE, BUF1, BUF2>
+where
+    BUF1: StaticWriteBuffer<Word = TYPE>,
+    BUF2: StaticWriteBuffer<Word = TYPE>,
+{
+}*/
+
+// TODO: Drop for Transfer and TransferConfig?
+
+pub struct TransferConfig<CH: SingleChannel, FROM: ReadTarget, TO: WriteTarget> {
+    ch: CH,
+    from: FROM,
+    to: TO,
+    pace: Pace,
+}
+
+impl<WORD, CH, FROM, TO> TransferConfig<CH, FROM, TO>
+where
+    CH: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn new(ch: CH, from: FROM, to: TO) -> TransferConfig<CH, FROM, TO> {
+        TransferConfig {
+            ch,
+            from,
+            to,
+            pace: Pace::PreferSource,
+        }
+    }
+
+    /// Sets the (preferred) pace for the DMA transfers.
+    ///
+    /// Usually, the code will automatically configure the correct pace, but
+    /// peripheral-to-peripheral transfers require the user to manually select whether the source
+    /// or the sink shall be queried for the pace signal.
+    pub fn pace(&mut self, pace: Pace) {
+        self.pace = pace;
+    }
+
+    pub fn start(mut self) -> Transfer<CH, FROM, TO> {
+        // TODO: Do we want to call any callbacks to configure source/sink?
+
+        // Make sure that memory contents reflect what the user intended.
+        // TODO: How much of the following is necessary?
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // Configure the DMA channel.
+        let (src, src_count) = self.from.rx_address_count();
+        let src_incr = self.from.rx_increment();
+        let (dest, dest_count) = self.to.tx_address_count();
+        let dest_incr = self.to.tx_increment();
+        const TREQ_UNPACED: u8 = 0x3f;
+        let treq = match self.pace {
+            Pace::PreferSource => FROM::rx_treq().or(TO::tx_treq()).unwrap_or(TREQ_UNPACED),
+            Pace::PreferDest => TO::tx_treq().or(FROM::rx_treq()).unwrap_or(TREQ_UNPACED),
+        };
+        let len = u32::min(src_count, dest_count);
+        self.ch.ch().ch_read_addr.write(|w| unsafe { w.bits(src) });
+        self.ch
+            .ch()
+            .ch_trans_count
+            .write(|w| unsafe { w.bits(len) });
+        self.ch
+            .ch()
+            .ch_write_addr
+            .write(|w| unsafe { w.bits(dest) });
+        // The following access starts the transfer.
+        self.ch.ch().ch_ctrl_trig.write(|w| unsafe {
+            w.data_size()
+                .bits(mem::size_of::<WORD>() as u8 >> 1)
+                .incr_read()
+                .bit(src_incr)
+                .incr_write()
+                .bit(dest_incr)
+                .treq_sel()
+                .bits(treq)
+                .en()
+                .bit(true)
+        });
+
+        Transfer {
+            ch: self.ch,
+            from: self.from,
+            to: self.to,
+        }
+    }
+}
+
+impl<WORD, CH, FROM, TO> TransferConfig<CH, FROM, TO>
+where
+    CH: ChannelPair,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn start_ring(mut self) -> Result<RingTransfer<CH, FROM, TO>, DMAError> {
+        // TODO: Fix the code for src_count/dest_count == 1.
+        let (src, src_count) = self.from.rx_address_count();
+        let src_incr = self.from.rx_increment();
+        let dest_incr = self.to.tx_increment();
+        let (dest, dest_count) = self.to.tx_address_count();
+        let transfer_size = mem::size_of::<WORD>() as u32;
+
+        // Buffers with increment need to be aligned.
+        if src_incr && !Self::check_alignment(src, src_count * transfer_size) {
+            return Err(DMAError::Alignment);
+        }
+        if dest_incr && !Self::check_alignment(dest, dest_count * transfer_size) {
+            return Err(DMAError::Alignment);
+        }
+        // Memory-to-memory copies are not supported.
+        if src_incr && dest_incr {
+            return Err(DMAError::IllegalConfig);
+        }
+        // Additional sanity checks - we have to completely transfer all memory buffers.
+        if src_incr && src_count > dest_count {
+            return Err(DMAError::IllegalConfig);
+        }
+        if dest_incr && dest_count > src_count {
+            return Err(DMAError::IllegalConfig);
+        }
+
+        const TREQ_UNPACED: u8 = 0x3f;
+        let treq = match self.pace {
+            Pace::PreferSource => FROM::rx_treq().or(TO::tx_treq()).unwrap_or(TREQ_UNPACED),
+            Pace::PreferDest => TO::tx_treq().or(FROM::rx_treq()).unwrap_or(TREQ_UNPACED),
+        };
+
+        // We split buffers in two halves for the two DMA channels.
+        let (src1, src2) = if src_incr {
+            (src, src + src_count * transfer_size)
+        } else {
+            (src, src)
+        };
+        let (dest1, dest2, wrap_dest) = if src_incr {
+            (dest, dest + dest_count * transfer_size, true)
+        } else {
+            (dest, dest, false)
+        };
+        let len = u32::min(src_count, dest_count);
+        let ring_size = if src_incr || dest_incr {
+            (len * transfer_size / 2).trailing_zeros() as u8
+        } else {
+            0
+        };
+        // Configure the second DMA channel - we do not write any trigger register as we do not
+        // want to immediately start the transfer.
+        self.ch
+            .ch2()
+            .ch_read_addr
+            .write(|w| unsafe { w.bits(src2) });
+        self.ch
+            .ch2()
+            .ch_trans_count
+            .write(|w| unsafe { w.bits(len / 2) });
+        self.ch
+            .ch2()
+            .ch_write_addr
+            .write(|w| unsafe { w.bits(dest2) });
+        self.ch.ch2().ch_al1_ctrl.write(|w| unsafe {
+            w.data_size()
+                .bits(mem::size_of::<WORD>() as u8 >> 1)
+                .incr_read()
+                .bit(src_incr)
+                .incr_write()
+                .bit(dest_incr)
+                .treq_sel()
+                .bits(treq)
+                .en()
+                .bit(true)
+                .chain_to()
+                .bits(CH::id())
+                .ring_sel()
+                .bit(wrap_dest)
+                .ring_size()
+                .bits(ring_size)
+        });
+        // Configure the first DMA channel - the access to CTRL_TRIG starts the transfer.
+        self.ch.ch().ch_read_addr.write(|w| unsafe { w.bits(src1) });
+        self.ch
+            .ch()
+            .ch_trans_count
+            .write(|w| unsafe { w.bits(len / 2) });
+        self.ch
+            .ch()
+            .ch_write_addr
+            .write(|w| unsafe { w.bits(dest1) });
+        self.ch.ch().ch_ctrl_trig.write(|w| unsafe {
+            w.data_size()
+                .bits(mem::size_of::<WORD>() as u8 >> 1)
+                .incr_read()
+                .bit(src_incr)
+                .incr_write()
+                .bit(dest_incr)
+                .treq_sel()
+                .bits(treq)
+                .en()
+                .bit(true)
+                .chain_to()
+                .bits(CH::id2())
+                .ring_sel()
+                .bit(wrap_dest)
+                .ring_size()
+                .bits(ring_size)
+        });
+
+        Ok(RingTransfer {
+            ch: self.ch,
+            from: self.from,
+            to: self.to,
+        })
+    }
+
+    fn check_alignment(addr: u32, len: u32) -> bool {
+        if !len.is_power_of_two() {
+            return false;
+        }
+        if (addr & (len - 1)) != 0 {
+            return false;
+        }
+        true
+    }
+}
+
+pub struct Transfer<CH: SingleChannel, FROM: ReadTarget, TO: WriteTarget> {
+    ch: CH,
+    from: FROM,
+    to: TO,
+}
+
+impl<CH, FROM, TO, WORD> Transfer<CH, FROM, TO>
+where
+    CH: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    /// Returns whether the transfer has completed.
+    pub fn is_done(&self) -> bool {
+        !self.ch.ch().ch_ctrl_trig.read().busy().bit_is_set()
+    }
+
+    pub fn wait(self) -> (CH, FROM, TO) {
+        while !self.is_done() {}
+
+        // Make sure that memory contents reflect what the user intended.
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        (self.ch, self.from, self.to)
+    }
+}
+
+pub struct RingTransfer<CH: ChannelPair, FROM: ReadTarget, TO: WriteTarget> {
+    ch: CH,
+    from: FROM,
+    to: TO,
+}
+
+impl<CH, FROM, TO> RingTransfer<CH, FROM, TO>
+where
+    CH: ChannelPair,
+    FROM: ReadTarget,
+    TO: WriteTarget,
+{
+    // TODO
+}
+
+pub enum Pace {
+    PreferSource,
+    PreferDest,
+    // TODO: Timers?
+}
+
+#[derive(Debug)]
+pub enum DMAError {
+    Alignment,
+    IllegalConfig,
+}

--- a/rp2040-hal/src/dma.rs
+++ b/rp2040-hal/src/dma.rs
@@ -119,10 +119,9 @@ pub trait SingleChannel {
     ///
     /// In the case of channel pairs, this returns the first channel.
     fn ch(&self) -> &rp2040_pac::dma::CH;
-    fn id() -> u8;
+    /// Returns the index of the DMA channel.
+    fn id(&self) -> u8;
 }
-
-// TODO: ChannelPair is not actually required, we can just implement SingleChannel on a tuple.
 
 /// Trait which implements low-level functionality for transfers requiring two DMA channels.
 ///
@@ -132,7 +131,8 @@ pub trait ChannelPair: SingleChannel {
     /// Returns the registers associated with the second DMA channel associated with this channel
     /// pair.
     fn ch2(&self) -> &rp2040_pac::dma::CH;
-    fn id2() -> u8;
+    /// Returns the index of the second DMA channel.
+    fn id2(&self) -> u8;
 }
 
 impl<CH: ChannelIndex> SingleChannel for Channel<CH> {
@@ -140,7 +140,7 @@ impl<CH: ChannelIndex> SingleChannel for Channel<CH> {
         self.regs()
     }
 
-    fn id() -> u8 {
+    fn id(&self) -> u8 {
         CH::id()
     }
 }
@@ -150,18 +150,104 @@ impl<CH1: ChannelIndex, CH2: ChannelIndex> SingleChannel for (Channel<CH1>, Chan
         self.0.regs()
     }
 
-    fn id() -> u8 {
+    fn id(&self) -> u8 {
         CH1::id()
     }
 }
 
-impl<CH1: ChannelIndex, CH2: ChannelIndex> ChannelPair for (Channel<CH1>, Channel<CH2>) {
-    fn ch2(&self) -> &rp2040_pac::dma::CH {
-        self.1.regs()
+trait ChannelConfig {
+    fn config<WORD, FROM, TO>(
+        &mut self,
+        from: &FROM,
+        to: &mut TO,
+        pace: Pace,
+        chain_to: Option<u8>,
+        start: bool,
+    ) where
+        FROM: ReadTarget<ReceivedWord = WORD>,
+        TO: WriteTarget<TransmittedWord = WORD>;
+
+    fn set_chain_to_enabled<CH: SingleChannel>(&mut self, other: &mut CH);
+    fn start(&mut self);
+}
+
+impl<CH: SingleChannel> ChannelConfig for CH {
+    fn config<WORD, FROM, TO>(
+        &mut self,
+        from: &FROM,
+        to: &mut TO,
+        pace: Pace,
+        chain_to: Option<u8>,
+        start: bool,
+    ) where
+        FROM: ReadTarget<ReceivedWord = WORD>,
+        TO: WriteTarget<TransmittedWord = WORD>,
+    {
+        // Configure the DMA channel.
+        let (src, src_count) = from.rx_address_count();
+        let src_incr = from.rx_increment();
+        let (dest, dest_count) = to.tx_address_count();
+        let dest_incr = to.tx_increment();
+        const TREQ_UNPACED: u8 = 0x3f;
+        let treq = match pace {
+            Pace::PreferSource => FROM::rx_treq().or(TO::tx_treq()).unwrap_or(TREQ_UNPACED),
+            Pace::PreferSink => TO::tx_treq().or(FROM::rx_treq()).unwrap_or(TREQ_UNPACED),
+        };
+        let len = u32::min(src_count, dest_count);
+        self.ch().ch_al1_ctrl.write(|w| unsafe {
+            w.data_size()
+                .bits(mem::size_of::<WORD>() as u8 >> 1)
+                .incr_read()
+                .bit(src_incr)
+                .incr_write()
+                .bit(dest_incr)
+                .treq_sel()
+                .bits(treq)
+                .chain_to()
+                .bits(chain_to.unwrap_or(self.id()))
+                .en()
+                .bit(true)
+        });
+        self.ch().ch_read_addr.write(|w| unsafe { w.bits(src) });
+        self.ch().ch_trans_count.write(|w| unsafe { w.bits(len) });
+        if start {
+            self.ch()
+                .ch_al2_write_addr_trig
+                .write(|w| unsafe { w.bits(dest) });
+        } else {
+            self.ch().ch_write_addr.write(|w| unsafe { w.bits(dest) });
+        }
     }
 
-    fn id2() -> u8 {
-        CH2::id()
+    fn set_chain_to_enabled<CH2: SingleChannel>(&mut self, other: &mut CH2) {
+        // We temporarily pause the channel when setting CHAIN_TO, to prevent any race condition
+        // that could occur, as we need to check afterwards whether the channel was successfully
+        // chained to this channel or whether this channel was already completed. If we did not
+        // pause this channel, we could get into a situation where both channels completed in quick
+        // succession, yet we did not notice, as the situation is not distinguishable from one
+        // where the second channel was not started at all.
+
+        self.ch()
+            .ch_al1_ctrl
+            .modify(|_, w| unsafe { w.chain_to().bits(other.id()).en().clear_bit() });
+        if self.ch().ch_al1_ctrl.read().busy().bit_is_set() {
+            // This channel is still active, so just continue.
+            self.ch()
+                .ch_al1_ctrl
+                .modify(|_, w| unsafe { w.en().set_bit() });
+            return;
+        } else {
+            // This channel has already finished, so just start the other channel directly.
+            other.start();
+        }
+    }
+
+    fn start(&mut self) {
+        // Safety: The write does not interfere with any other writes, it only affects this
+        // channel.
+        unsafe { &*rp2040_pac::DMA::ptr() }
+            .multi_chan_trigger
+            .write(|w| unsafe { w.bits(1 << self.id()) });
     }
 }
 
@@ -176,7 +262,7 @@ pub trait ReadTarget {
     /// Returns the address and the maximum number of words that can be transferred from this data
     /// source in a single DMA operation.
     ///
-    /// For peripherals, the cound should likely be u32::MAX. If a data source implements
+    /// For peripherals, the count should likely be u32::MAX. If a data source implements
     /// EndlessReadTarget, it is suitable for infinite transfers from or to ring buffers. Note that
     /// ring buffers designated for endless transfers, but with a finite buffer size, should return
     /// the size of their individual buffers here.
@@ -257,145 +343,65 @@ impl<B: StaticWriteBuffer> WriteTarget for B {
     }
 }
 
-/*/// Ring buffer consisting of two aligned memory regions.
-///
-/// We require buffers to have a power-of-two size and to be aligned to their size, as otherwise
-/// the RP2040 would require an additional DMA channel as well as an additional aligned buffer to
-/// implement operations on the ring buffer.
-///
-/// The two buffers do not have to have the same size.
-pub struct ReadRingBuffer<TYPE, BUF1, BUF2> {
-    buf1: BUF1,
-    buf2: BUF2,
-    _phantom: PhantomData<TYPE>,
+/*SingleBuffered<CH, RX, TX> {
+    config(...) -> SingleBufferedConfig;
+    is_done() -> bool
+    wait() -> (CH1, RX, TX)
 }
 
-impl<TYPE, BUF1, BUF2> ReadRingBuffer<TYPE, BUF1, BUF2>
-where
-    BUF1: StaticReadBuffer<Word = TYPE>,
-    BUF2: StaticReadBuffer<Word = TYPE>,
-{
-    /// Creates a new ring buffer from the two buffers, checking their size and alignment.
-    pub fn new(buf1: BUF1, buf2: BUF2) -> Result<Self, DMAError> {
-        // We check the alignment of the buffers before creating
-        // Safety: We do not actually access the pointers returned by the function. According to
-        // the documentation, later calls are required to return identical values.
-        let (ptr1, len1) = unsafe { buf1.static_read_buffer() };
-        let (ptr2, len2) = unsafe { buf2.static_read_buffer() };
-        let len1 = len1 * mem::size_of::<TYPE>();
-        let len2 = len2 * mem::size_of::<TYPE>();
-        if !len1.is_power_of_two() || !len2.is_power_of_two() {
-            return Err(DMAError::Alignment);
-        }
-        if (ptr1 as usize & (len1 - 1)) != 0 {
-            return Err(DMAError::Alignment);
-        }
-        if (ptr2 as usize & (len2 - 1)) != 0 {
-            return Err(DMAError::Alignment);
-        }
-
-        Ok(Self {
-            buf1,
-            buf2,
-            _phantom: PhantomData,
-        })
-    }
+DoubleBuffered<(CH1, CH2), RX, TX, ()> {
+    config(...) -> SingleBufferedConfig;
+    is_done() -> bool
+    read_next(BUF) -> DoubleReadBuffer<CH, RX, TX, BUF>
+    write_next(BUF) -> DoubleWriteBuffer<CH, RX, TX, BUF>
+    wait() -> ((CH1, CH2), RX, TX)
+}
+DoubleBuffered<CH, RX, TX, ReadNext<RX2>> {
+    is_done() -> bool
+    wait() -> (DoubleBuffered<CH, RX2, TX>, RX)
+}
+DoubleBuffered<CH, RX, TX, WriteNext<TX2>> {
+    is_done() -> bool
+    wait() -> (DoubleBuffered<CH, RX2, TX>, RX)
 }
 
-impl<TYPE, BUF1, BUF2> ReadTarget for ReadRingBuffer<TYPE, BUF1, BUF2>
-where
-    BUF1: StaticReadBuffer<Word = TYPE>,
-    BUF2: StaticReadBuffer<Word = TYPE>,
-{
-    type ReceivedWord = TYPE;
-
-    fn rx_treq() -> Option<u8> {
-        None
-    }
-
-    fn rx_address_count(&self) -> (u32, u32) {
-        // TODO
-        (0, 0)
-    }
-
-    fn rx_increment(&self) -> bool {
-        true
-    }
+Bidirectional<(CH1, CH2), FROM, BIDI, TO> {
+    config(...) -> BidirectionalConfig;
+    from_is_done() -> bool
+    to_is_done() -> bool
+    is_done() -> bool
+    from_wait() -> (CH1, FROM, SingleBuffered<CH2, BIDI, TO>)
+    to_wait() -> (CH2, SingleBuffered<CH2, FROM, BIDI>, TO)
+    wait() -> (CH1, CH2, FROM, BIDI, TO)
 }
 
-impl<TYPE, BUF1, BUF2> EndlessReadTarget for ReadRingBuffer<TYPE, BUF1, BUF2>
-where
-    BUF1: StaticReadBuffer<Word = TYPE>,
-    BUF2: StaticReadBuffer<Word = TYPE>,
-{
+BidiDoubleBuffered<(CH1, CH2), FROM, BIDI, TO, (), ()> {
+    config(...) -> BidirectionalConfig;
+    from_is_done() -> bool
+    to_is_done() -> bool
+    is_done() -> bool
+    wait() -> (CH1, CH2, FROM, BIDI, TO)
 }
 
-pub struct WriteRingBuffer<TYPE, BUF1, BUF2> {
-    buf1: BUF1,
-    buf2: BUF2,
-    _phantom: PhantomData<TYPE>,
-}
-
-impl<TYPE, BUF1, BUF2> WriteRingBuffer<TYPE, BUF1, BUF2>
-where
-    BUF1: StaticWriteBuffer<Word = TYPE>,
-    BUF2: StaticWriteBuffer<Word = TYPE>,
-{
-    pub fn new(buf1: BUF1, buf2: BUF2) -> Result<Self, DMAError> {
-        // TODO: Check alignment.
-        Ok(Self {
-            buf1,
-            buf2,
-            _phantom: PhantomData,
-        })
-    }
-}
-
-impl<TYPE, BUF1, BUF2> WriteTarget for WriteRingBuffer<TYPE, BUF1, BUF2>
-where
-    BUF1: StaticWriteBuffer<Word = TYPE>,
-    BUF2: StaticWriteBuffer<Word = TYPE>,
-{
-    type TransmittedWord = TYPE;
-
-    fn tx_treq() -> Option<u8> {
-        None
-    }
-
-    fn tx_address_count(&mut self) -> (u32, u32) {
-        // TODO
-        (0, 0)
-    }
-
-    fn tx_increment(&self) -> bool {
-        true
-    }
-}
-
-impl<TYPE, BUF1, BUF2> EndlessWriteTarget for WriteRingBuffer<TYPE, BUF1, BUF2>
-where
-    BUF1: StaticWriteBuffer<Word = TYPE>,
-    BUF2: StaticWriteBuffer<Word = TYPE>,
-{
+Endless<(CH1, CH2), RX, TX> {
+    stop() -> bool
 }*/
 
-// TODO: Drop for Transfer and TransferConfig?
-
-pub struct TransferConfig<CH: SingleChannel, FROM: ReadTarget, TO: WriteTarget> {
+pub struct SingleBufferingConfig<CH: SingleChannel, FROM: ReadTarget, TO: WriteTarget> {
     ch: CH,
     from: FROM,
     to: TO,
     pace: Pace,
 }
 
-impl<WORD, CH, FROM, TO> TransferConfig<CH, FROM, TO>
+impl<CH, FROM, TO, WORD> SingleBufferingConfig<CH, FROM, TO>
 where
     CH: SingleChannel,
     FROM: ReadTarget<ReceivedWord = WORD>,
     TO: WriteTarget<TransmittedWord = WORD>,
 {
-    pub fn new(ch: CH, from: FROM, to: TO) -> TransferConfig<CH, FROM, TO> {
-        TransferConfig {
+    pub fn new(ch: CH, from: FROM, to: TO) -> SingleBufferingConfig<CH, FROM, TO> {
+        SingleBufferingConfig {
             ch,
             from,
             to,
@@ -412,7 +418,7 @@ where
         self.pace = pace;
     }
 
-    pub fn start(mut self) -> Transfer<CH, FROM, TO> {
+    pub fn start(mut self) -> SingleBuffering<CH, FROM, TO> {
         // TODO: Do we want to call any callbacks to configure source/sink?
 
         // Make sure that memory contents reflect what the user intended.
@@ -420,41 +426,11 @@ where
         cortex_m::asm::dsb();
         compiler_fence(Ordering::SeqCst);
 
-        // Configure the DMA channel.
-        let (src, src_count) = self.from.rx_address_count();
-        let src_incr = self.from.rx_increment();
-        let (dest, dest_count) = self.to.tx_address_count();
-        let dest_incr = self.to.tx_increment();
-        const TREQ_UNPACED: u8 = 0x3f;
-        let treq = match self.pace {
-            Pace::PreferSource => FROM::rx_treq().or(TO::tx_treq()).unwrap_or(TREQ_UNPACED),
-            Pace::PreferDest => TO::tx_treq().or(FROM::rx_treq()).unwrap_or(TREQ_UNPACED),
-        };
-        let len = u32::min(src_count, dest_count);
-        self.ch.ch().ch_read_addr.write(|w| unsafe { w.bits(src) });
+        // Configure the DMA channel and start it.
         self.ch
-            .ch()
-            .ch_trans_count
-            .write(|w| unsafe { w.bits(len) });
-        self.ch
-            .ch()
-            .ch_write_addr
-            .write(|w| unsafe { w.bits(dest) });
-        // The following access starts the transfer.
-        self.ch.ch().ch_ctrl_trig.write(|w| unsafe {
-            w.data_size()
-                .bits(mem::size_of::<WORD>() as u8 >> 1)
-                .incr_read()
-                .bit(src_incr)
-                .incr_write()
-                .bit(dest_incr)
-                .treq_sel()
-                .bits(treq)
-                .en()
-                .bit(true)
-        });
+            .config(&self.from, &mut self.to, self.pace, None, true);
 
-        Transfer {
+        SingleBuffering {
             ch: self.ch,
             from: self.from,
             to: self.to,
@@ -462,7 +438,379 @@ where
     }
 }
 
-impl<WORD, CH, FROM, TO> TransferConfig<CH, FROM, TO>
+// TODO: Drop for most of these structs
+
+pub struct SingleBuffering<CH: SingleChannel, FROM: ReadTarget, TO: WriteTarget> {
+    ch: CH,
+    from: FROM,
+    to: TO,
+}
+
+impl<CH, FROM, TO, WORD> SingleBuffering<CH, FROM, TO>
+where
+    CH: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    /// Returns whether the transfer has completed.
+    pub fn is_done(&self) -> bool {
+        !self.ch.ch().ch_ctrl_trig.read().busy().bit_is_set()
+    }
+
+    pub fn wait(self) -> (CH, FROM, TO) {
+        while !self.is_done() {}
+
+        // Make sure that memory contents reflect what the user intended.
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        (self.ch, self.from, self.to)
+    }
+}
+
+pub struct DoubleBufferingConfig<
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget,
+    TO: WriteTarget,
+> {
+    ch: (CH1, CH2),
+    from: FROM,
+    to: TO,
+    pace: Pace,
+}
+
+impl<CH1, CH2, FROM, TO, WORD> DoubleBufferingConfig<CH1, CH2, FROM, TO>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn new(ch: (CH1, CH2), from: FROM, to: TO) -> DoubleBufferingConfig<CH1, CH2, FROM, TO> {
+        DoubleBufferingConfig {
+            ch,
+            from,
+            to,
+            pace: Pace::PreferSource,
+        }
+    }
+
+    /// Sets the (preferred) pace for the DMA transfers.
+    ///
+    /// Usually, the code will automatically configure the correct pace, but
+    /// peripheral-to-peripheral transfers require the user to manually select whether the source
+    /// or the sink shall be queried for the pace signal.
+    pub fn pace(&mut self, pace: Pace) {
+        self.pace = pace;
+    }
+
+    pub fn start(mut self) -> DoubleBuffering<CH1, CH2, FROM, TO, ()> {
+        // TODO: Do we want to call any callbacks to configure source/sink?
+
+        // Make sure that memory contents reflect what the user intended.
+        // TODO: How much of the following is necessary?
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // Configure the DMA channel and start it.
+        self.ch
+            .0
+            .config(&self.from, &mut self.to, self.pace, None, true);
+
+        DoubleBuffering {
+            ch: self.ch,
+            from: self.from,
+            to: self.to,
+            pace: self.pace,
+            state: (),
+            second_ch: false,
+        }
+    }
+}
+
+pub struct ReadNext<BUF: ReadTarget>(BUF);
+pub struct WriteNext<BUF: WriteTarget>(BUF);
+
+pub struct DoubleBuffering<CH1, CH2, FROM, TO, STATE>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget,
+    TO: WriteTarget,
+{
+    ch: (CH1, CH2),
+    from: FROM,
+    to: TO,
+    pace: Pace,
+    state: STATE,
+    second_ch: bool,
+}
+
+impl<CH1, CH2, FROM, TO, WORD, STATE> DoubleBuffering<CH1, CH2, FROM, TO, STATE>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn is_done(&self) -> bool {
+        if self.second_ch {
+            !self.ch.1.ch().ch_ctrl_trig.read().busy().bit_is_set()
+        } else {
+            !self.ch.0.ch().ch_ctrl_trig.read().busy().bit_is_set()
+        }
+    }
+}
+
+impl<CH1, CH2, FROM, TO, WORD> DoubleBuffering<CH1, CH2, FROM, TO, ()>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD> + EndlessWriteTarget,
+{
+    pub fn wait(self) -> (CH1, CH2, FROM, TO) {
+        while !self.is_done() {}
+
+        // Make sure that memory contents reflect what the user intended.
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // TODO: Use a tuple type?
+        (self.ch.0, self.ch.1, self.from, self.to)
+    }
+}
+
+impl<CH1, CH2, FROM, TO, WORD> DoubleBuffering<CH1, CH2, FROM, TO, ()>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD> + EndlessWriteTarget,
+{
+    pub fn read_next<BUF: ReadTarget<ReceivedWord = WORD>>(
+        mut self,
+        buf: BUF,
+    ) -> DoubleBuffering<CH1, CH2, FROM, TO, ReadNext<BUF>> {
+        // Make sure that memory contents reflect what the user intended.
+        // TODO: How much of the following is necessary?
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // Configure the _other_ DMA channel, but do not start it yet.
+        if self.second_ch {
+            self.ch.0.config(&buf, &mut self.to, self.pace, None, false);
+        } else {
+            self.ch.1.config(&buf, &mut self.to, self.pace, None, false);
+        }
+
+        // Chain the first channel to the second.
+        if self.second_ch {
+            self.ch.1.set_chain_to_enabled(&mut self.ch.0);
+        } else {
+            self.ch.0.set_chain_to_enabled(&mut self.ch.1);
+        }
+
+        DoubleBuffering {
+            ch: self.ch,
+            from: self.from,
+            to: self.to,
+            pace: self.pace,
+            state: ReadNext(buf),
+            second_ch: self.second_ch,
+        }
+    }
+}
+
+impl<CH1, CH2, FROM, TO, WORD> DoubleBuffering<CH1, CH2, FROM, TO, ()>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD> + EndlessReadTarget,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn write_next<BUF: WriteTarget<TransmittedWord = WORD>>(
+        mut self,
+        mut buf: BUF,
+    ) -> DoubleBuffering<CH1, CH2, FROM, TO, WriteNext<BUF>> {
+        // Make sure that memory contents reflect what the user intended.
+        // TODO: How much of the following is necessary?
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // Configure the _other_ DMA channel, but do not start it yet.
+        if self.second_ch {
+            self.ch
+                .0
+                .config(&self.from, &mut buf, self.pace, None, false);
+        } else {
+            self.ch
+                .1
+                .config(&self.from, &mut buf, self.pace, None, false);
+        }
+
+        // Chain the first channel to the second.
+        if self.second_ch {
+            self.ch.1.set_chain_to_enabled(&mut self.ch.0);
+        } else {
+            self.ch.0.set_chain_to_enabled(&mut self.ch.1);
+        }
+
+        DoubleBuffering {
+            ch: self.ch,
+            from: self.from,
+            to: self.to,
+            pace: self.pace,
+            state: WriteNext(buf),
+            second_ch: self.second_ch,
+        }
+    }
+}
+
+impl<CH1, CH2, FROM, TO, NEXT, WORD> DoubleBuffering<CH1, CH2, FROM, TO, ReadNext<NEXT>>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD> + EndlessWriteTarget,
+    NEXT: ReadTarget<ReceivedWord = WORD>,
+{
+    pub fn wait(self) -> (FROM, DoubleBuffering<CH1, CH2, NEXT, TO, ()>) {
+        while !self.is_done() {}
+
+        // Make sure that memory contents reflect what the user intended.
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // Invert second_ch as now the other channel is the "active" channel.
+        (
+            self.from,
+            DoubleBuffering {
+                ch: self.ch,
+                from: self.state.0,
+                to: self.to,
+                pace: self.pace,
+                state: (),
+                second_ch: !self.second_ch,
+            },
+        )
+    }
+}
+
+impl<CH1, CH2, FROM, TO, NEXT, WORD> DoubleBuffering<CH1, CH2, FROM, TO, WriteNext<NEXT>>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD> + EndlessReadTarget,
+    TO: WriteTarget<TransmittedWord = WORD>,
+    NEXT: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn wait(self) -> (TO, DoubleBuffering<CH1, CH2, FROM, NEXT, ()>) {
+        while !self.is_done() {}
+
+        // Make sure that memory contents reflect what the user intended.
+        cortex_m::asm::dsb();
+        compiler_fence(Ordering::SeqCst);
+
+        // Invert second_ch as now the other channel is the "active" channel.
+        (
+            self.to,
+            DoubleBuffering {
+                ch: self.ch,
+                from: self.from,
+                to: self.state.0,
+                pace: self.pace,
+                state: (),
+                second_ch: !self.second_ch,
+            },
+        )
+    }
+}
+
+pub struct BidirectionalConfig<CH1, CH2, FROM, BIDI, TO>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget,
+    BIDI: ReadTarget + WriteTarget,
+    TO: WriteTarget,
+{
+    ch: (CH1, CH2),
+    from: FROM,
+    bidi: BIDI,
+    to: TO,
+    from_pace: Pace,
+    to_pace: Pace,
+}
+
+impl<CH1, CH2, FROM, BIDI, TO, WORD> BidirectionalConfig<CH1, CH2, FROM, BIDI, TO>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    BIDI: ReadTarget<ReceivedWord = WORD> + WriteTarget<TransmittedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn new(
+        ch: (CH1, CH2),
+        from: FROM,
+        bidi: BIDI,
+        to: TO,
+    ) -> BidirectionalConfig<CH1, CH2, FROM, BIDI, TO> {
+        BidirectionalConfig {
+            ch,
+            from,
+            bidi,
+            to,
+            from_pace: Pace::PreferSink,
+            to_pace: Pace::PreferSink,
+        }
+    }
+
+    pub fn from_pace(&mut self, pace: Pace) {
+        self.from_pace = pace;
+    }
+
+    pub fn to_pace(&mut self, pace: Pace) {
+        self.to_pace = pace;
+    }
+
+    pub fn start(mut self) -> Bidirectional<CH1, CH2, FROM, BIDI, TO> {
+        // TODO
+        panic!("Not yet implemented.");
+    }
+}
+
+pub struct Bidirectional<CH1, CH2, FROM, BIDI, TO>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget,
+    BIDI: ReadTarget + WriteTarget,
+    TO: WriteTarget,
+{
+    ch: (CH1, CH2),
+    from: FROM,
+    bidi: BIDI,
+    to: TO,
+}
+
+impl<CH1, CH2, FROM, BIDI, TO, WORD> Bidirectional<CH1, CH2, FROM, BIDI, TO>
+where
+    CH1: SingleChannel,
+    CH2: SingleChannel,
+    FROM: ReadTarget<ReceivedWord = WORD>,
+    BIDI: ReadTarget<ReceivedWord = WORD> + WriteTarget<TransmittedWord = WORD>,
+    TO: WriteTarget<TransmittedWord = WORD>,
+{
+    pub fn wait(self) -> ((CH1, CH2), FROM, BIDI, TO) {
+        // TODO
+        panic!("Not yet implemented.");
+    }
+}
+
+/*impl<WORD, CH, FROM, TO> SingleBufferingConfig<CH, FROM, TO>
 where
     CH: ChannelPair,
     FROM: ReadTarget<ReceivedWord = WORD>,
@@ -498,7 +846,7 @@ where
         const TREQ_UNPACED: u8 = 0x3f;
         let treq = match self.pace {
             Pace::PreferSource => FROM::rx_treq().or(TO::tx_treq()).unwrap_or(TREQ_UNPACED),
-            Pace::PreferDest => TO::tx_treq().or(FROM::rx_treq()).unwrap_or(TREQ_UNPACED),
+            Pace::PreferSink => TO::tx_treq().or(FROM::rx_treq()).unwrap_or(TREQ_UNPACED),
         };
 
         // We split buffers in two halves for the two DMA channels.
@@ -544,7 +892,7 @@ where
                 .en()
                 .bit(true)
                 .chain_to()
-                .bits(CH::id())
+                .bits(self.ch.id())
                 .ring_sel()
                 .bit(wrap_dest)
                 .ring_size()
@@ -572,7 +920,7 @@ where
                 .en()
                 .bit(true)
                 .chain_to()
-                .bits(CH::id2())
+                .bits(self.ch.id2())
                 .ring_sel()
                 .bit(wrap_dest)
                 .ring_size()
@@ -597,34 +945,6 @@ where
     }
 }
 
-pub struct Transfer<CH: SingleChannel, FROM: ReadTarget, TO: WriteTarget> {
-    ch: CH,
-    from: FROM,
-    to: TO,
-}
-
-impl<CH, FROM, TO, WORD> Transfer<CH, FROM, TO>
-where
-    CH: SingleChannel,
-    FROM: ReadTarget<ReceivedWord = WORD>,
-    TO: WriteTarget<TransmittedWord = WORD>,
-{
-    /// Returns whether the transfer has completed.
-    pub fn is_done(&self) -> bool {
-        !self.ch.ch().ch_ctrl_trig.read().busy().bit_is_set()
-    }
-
-    pub fn wait(self) -> (CH, FROM, TO) {
-        while !self.is_done() {}
-
-        // Make sure that memory contents reflect what the user intended.
-        cortex_m::asm::dsb();
-        compiler_fence(Ordering::SeqCst);
-
-        (self.ch, self.from, self.to)
-    }
-}
-
 pub struct RingTransfer<CH: ChannelPair, FROM: ReadTarget, TO: WriteTarget> {
     ch: CH,
     from: FROM,
@@ -638,16 +958,31 @@ where
     TO: WriteTarget,
 {
     // TODO
-}
+}*/
 
+/// Pacing for DMA transfers.
+///
+/// Generally, while memory-to-memory DMA transfers can operate at maximum possible throughput,
+/// transfers involving peripherals commonly have to wait for data to be available or for available
+/// space in write queues. This type defines whether the sink or the source shall pace the transfer
+/// for peripheral-to-peripheral transfers.
+#[derive(Clone, Copy)]
 pub enum Pace {
+    /// The DREQ signal from the source is used, if available. If not, the sink's DREQ signal is
+    /// used.
     PreferSource,
-    PreferDest,
+    /// The DREQ signal from the sink is used, if available. If not, the source's DREQ signal is
+    /// used.
+    PreferSink,
     // TODO: Timers?
 }
 
+/// Error during DMA configuration.
 #[derive(Debug)]
 pub enum DMAError {
+    /// Buffers were not aligned to their size even though they needed to be.
     Alignment,
+    /// An illegal configuration (i.e., buffer sizes not suitable for a memory-to-memory transfer)
+    /// was specified.
     IllegalConfig,
 }

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -15,6 +15,7 @@ pub extern crate rp2040_pac as pac;
 
 pub mod adc;
 pub mod clocks;
+pub mod dma;
 pub mod gpio;
 pub mod i2c;
 pub mod pio;

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1,5 +1,6 @@
 //! Programmable IO (PIO)
-/// See [Chapter 3](https://rptl.io/pico-datasheet) for more details.
+//! See [Chapter 3](https://rptl.io/pico-datasheet) for more details.
+use crate::dma::{EndlessReadTarget, EndlessWriteTarget, ReadTarget, WriteTarget};
 use crate::resets::SubsystemReset;
 use pio::{Program, SideSet, Wrap};
 use rp2040_pac::{PIO0, PIO1};
@@ -67,10 +68,21 @@ pub trait PIOExt:
             sm3,
         )
     }
+
+    /// Number of this PIO (0..1).
+    fn id() -> usize;
 }
 
-impl PIOExt for PIO0 {}
-impl PIOExt for PIO1 {}
+impl PIOExt for PIO0 {
+    fn id() -> usize {
+        0
+    }
+}
+impl PIOExt for PIO1 {
+    fn id() -> usize {
+        0
+    }
+}
 
 /// Programmable IO Block
 pub struct PIO<P: PIOExt> {
@@ -334,6 +346,10 @@ pub trait ValidStateMachine {
 
     /// The index of this state machine (between 0 and 3).
     fn id() -> usize;
+    /// The DREQ number for which TX DMA requests are triggered.
+    fn tx_dreq() -> u8;
+    /// The DREQ number for which RX DMA requests are triggered.
+    fn rx_dreq() -> u8;
 }
 
 /// First state machine of the first PIO block.
@@ -357,6 +373,12 @@ impl<P: PIOExt, SM: StateMachineIndex> ValidStateMachine for (P, SM) {
     type PIO = P;
     fn id() -> usize {
         SM::id()
+    }
+    fn tx_dreq() -> u8 {
+        ((P::id() << 3) | SM::id()) as u8
+    }
+    fn rx_dreq() -> u8 {
+        ((P::id() << 3) | SM::id() | 0x4) as u8
     }
 }
 
@@ -649,6 +671,27 @@ impl<SM: ValidStateMachine> Rx<SM> {
     }
 }
 
+impl<SM: ValidStateMachine> ReadTarget for Rx<SM> {
+    type ReceivedWord = u32;
+
+    fn rx_treq() -> Option<u8> {
+        Some(SM::rx_dreq())
+    }
+
+    fn rx_address_count(&self) -> (u32, u32) {
+        (
+            &unsafe { &*self.block }.rxf[SM::id()] as *const _ as u32,
+            u32::MAX,
+        )
+    }
+
+    fn rx_increment(&self) -> bool {
+        false
+    }
+}
+
+impl<SM: ValidStateMachine> EndlessReadTarget for Rx<SM> {}
+
 /// PIO TX FIFO handle.
 pub struct Tx<SM: ValidStateMachine> {
     block: *const rp2040_pac::pio0::RegisterBlock,
@@ -673,6 +716,27 @@ impl<SM: ValidStateMachine> Tx<SM> {
         true
     }
 }
+
+impl<SM: ValidStateMachine> WriteTarget for Tx<SM> {
+    type TransmittedWord = u32;
+
+    fn tx_treq() -> Option<u8> {
+        Some(SM::tx_dreq())
+    }
+
+    fn tx_address_count(&mut self) -> (u32, u32) {
+        (
+            &unsafe { &*self.block }.txf[SM::id()] as *const _ as u32,
+            u32::MAX,
+        )
+    }
+
+    fn tx_increment(&self) -> bool {
+        false
+    }
+}
+
+impl<SM: ValidStateMachine> EndlessWriteTarget for Tx<SM> {}
 
 /// PIO Interrupt controller.
 #[derive(Debug)]
@@ -1078,6 +1142,7 @@ impl<P: PIOExt> PIOBuilder<P> {
         self.side_set_base = base;
         self
     }
+    // TODO: Update documentation above.
 
     /// Set buffer sharing.
     ///


### PR DESCRIPTION
*Since I probably do not have much time for this during the next weeks, I'll put it here as a draft PR. I'll pick it up eventually, but if anybody needs DMA right now, feel free to test the code and/or fix the shortcomings listed below.*

# Introduction

This PR adds support for the DMA engine of the RP2040. The DMA engine has shown to be very different to other DMA engines I have previously worked with and has some interesting "features" which inevitably affect the abstraction layer:

* Individual DMA channels do not have any method to chain buffers. Instead, linked lists of buffers are implemented either by chaining multiple DMA channels together (one per buffer) or via an additional auxiliary channel. This implementation so far only supports the former, and only for double-buffered transfers - as soon as one buffer has finished, the user has to use the now-unused DMA channel to chain another buffer to the channel.
* The DMA engine only supports ring buffers when they are aligned to power-of-two addresses and sizes. The code currently does not support endless transfers to such buffers - instead, the user has to manually set up a double-buffered transfer and has to manually add buffers as described above.
* The DMA engine does not support any interrupt at the mid-point of a buffer, which makes ringbuffers rather difficult to use anyways unless the HAL chains two ringbuffers together.

As these points show, some simple DMA transfers can be implemented using one channel, whereas others require a tuple of two channels, which is reflected in the API.

Note that the code explicitly supports transfers directly between different peripherals - peripherals and buffers implement the same traits. SPI is a special case in that it always receives as much data as it sends - the DMA code therefore has a special type which implements transfers for such peripherals using twice the number of DMA channels. Other peripherals such as UART should provide a method to split the peripheral into a RX and a TX part as done by many other HALs.

# Example

See `rp2040-hal/examples/pio_dma.rs` for a complete usage example. Some relevant parts from that file:

```
    // Transfer a single message via DMA.
    let tx_buf = singleton!(: [u32; 4] = message).unwrap();
    let rx_buf = singleton!(: [u32; 4] = [0; 4]).unwrap();
    let tx_transfer = SingleBufferingConfig::new(dma.ch0, tx_buf, tx).start();
    let rx_transfer = SingleBufferingConfig::new(dma.ch1, rx, rx_buf).start();
    let (ch0, tx_buf, tx) = tx_transfer.wait();
    let (ch1, rx, rx_buf) = rx_transfer.wait();
   // Here, the channels as well as the buffers can be reused.
```

Chained transfers require a tuple of two channels, as described above:

```
let tx_buf2 = singleton!(: [u32; 4] = message).unwrap();
    let rx_buf2 = singleton!(: [u32; 4] = [0; 4]).unwrap();
    let tx_transfer = DoubleBufferingConfig::new((ch0, ch1), tx_buf, tx).start();
    let mut tx_transfer = tx_transfer.read_next(tx_buf2);
    let rx_transfer = DoubleBufferingConfig::new((dma.ch2, dma.ch3), rx, rx_buf).start();
    let mut rx_transfer = rx_transfer.write_next(rx_buf2);
    loop {
        // We simply immediately enqueue the buffers again.
        if tx_transfer.is_done() {
            let (tx_buf, next_tx_transfer) = tx_transfer.wait();
            tx_transfer = next_tx_transfer.read_next(tx_buf);
        }
        if rx_transfer.is_done() {
            let (rx_buf, next_rx_transfer) = rx_transfer.wait();
            // Do something with rx_buf here!
            rx_transfer = next_rx_transfer.write_next(rx_buf);
        }
    }
```

# Memory Safety

The code uses the `embedded-dma` traits and assumes that it gets `static` references to memory. Implementations of `Drop` should make sure that a buffer is not used anymore once the corresponding DMA object is destructed (see below, this is currently missing). The API is unsafe in the presence of leaks where `drop()` is not called, e.g., `mem::forget()`.

# Known Defects

- The code still contains many notes I wrote down while designing the API, those can just be thrown out.
- The DMA types are all still missing implementations of `Drop`, which is absolutely essential for memory safety.
- Other types of transfers (ring buffers?) are not implemented yet.
- Currently, only PIO and SPI are supported. Some other peripherals require refactoring to be usable with DMA - for example, the UART code should be refactored to provide a method to split the UART into a RX and a TX object to allow for parallel operations on both.


