### PR TITLE
Add safety docs from atsamd-rs to GPIO traits to make CI happy

### DIFF
--- a/rp2040-hal/src/gpio/reg.rs
+++ b/rp2040-hal/src/gpio/reg.rs
@@ -109,6 +109,13 @@ impl From<DynPinMode> for ModeFields {
         fields
     }
 }
+
+/// # Safety
+///
+/// Users should only implement the [`id`] function. No default function
+/// implementations should be overridden. The implementing type must also have
+/// "control" over the corresponding pin ID, i.e. it must guarantee that each
+/// pin ID is a singleton
 pub(super) unsafe trait RegisterInterface {
     /// Provide a [`DynPinId`] identifying the set of registers controlled by
     /// this type.

--- a/rp2040-hal/src/pwm/reg.rs
+++ b/rp2040-hal/src/pwm/reg.rs
@@ -1,5 +1,12 @@
 use super::dyn_slice::{DynSliceId, DynSliceMode};
 use pac::pwm::CH;
+
+/// # Safety
+///
+/// Users should only implement the [`id`] function. No default function
+/// implementations should be overridden. The implementing type must also have
+/// "control" over the corresponding slice ID, i.e. it must guarantee that each
+/// slice ID is a singleton
 pub(super) unsafe trait RegisterInterface {
     /// Provide a [`DynSliceId`] identifying the set of registers controlled by
     /// this type.


### PR DESCRIPTION
Rust 1.57 clippy triggers warnings that were not present on 1.56, breaking CI
```
warning: docs for unsafe trait missing `# Safety` section
```

Since we borrowed these traits from atsamd-rs's pin abstraction, I've copied the safety docs from there.
https://github.com/atsamd-rs/atsamd/blob/16ff6e0afd3e5e01084149ad033ac04f5eb9fd82/hal/src/gpio/v2/reg.rs#L213