### PR TITLE
Generate sev in sio.fifo.write()

### DIFF
--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -109,6 +109,9 @@ impl SioFifo {
     pub fn write(&mut self, value: u32) {
         let sio = unsafe { &(*pac::SIO::ptr()) };
         sio.fifo_wr.write(|w| unsafe { w.bits(value) });
+        // Fire off an event to the other core.
+        // This is required as the other core may be `wfe` (waiting for event)
+        cortex_m::asm::sev();
     }
 
     /// Read from the inter-core FIFO.


### PR DESCRIPTION
Generate a send event signal via `sev` in sio.fifo.write() so that sio.fifo.blocking_read() will wake up.
Closes #222