### PR TITLE
Bump embassy's dependencies

### DIFF
--- a/boards/pico/Cargo.toml
+++ b/boards/pico/Cargo.toml
@@ -22,14 +22,14 @@ futures = { version = "0.3", default-features = false, optional = true }
 
 [dependencies.embassy]
 git = "https://github.com/embassy-rs/embassy"
-rev = "a8797f84f69b7668a3f89b6cba3e39bce5649079"
+rev = "6d6e6f55b8a9ecd38b5a6d3bb11f74b2654afdeb"
 optional = true
 
 # namespaced features will let use use "dep:embassy-traits" in the features rather than using this
 # trick of renaming the crate.
 [dependencies.embassy_traits]
 git = "https://github.com/embassy-rs/embassy"
-rev = "a8797f84f69b7668a3f89b6cba3e39bce5649079"
+rev = "6d6e6f55b8a9ecd38b5a6d3bb11f74b2654afdeb"
 package = "embassy-traits"
 optional = true
 

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4", default-features = false, optional = true }
 # trick of renaming the crate.
 [dependencies.embassy_traits]
 git = "https://github.com/embassy-rs/embassy"
-rev = "3dcf899babff5b735b1f1a5a99a9005ce06f517f"
+rev = "6d6e6f55b8a9ecd38b5a6d3bb11f74b2654afdeb"
 package = "embassy-traits"
 optional = true
 


### PR DESCRIPTION
Newer nightly's of the compiler now detect a missing bound on some embassy traits.
Bump embassy related dependencies to benefit from the fixes.