### PR TITLE
Refactor uart init

### DIFF
--- a/boards/pico/examples/pico_i2c_pio.rs
+++ b/boards/pico/examples/pico_i2c_pio.rs
@@ -94,13 +94,12 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let mut uart = hal::uart::UartPeripheral::<_, _>::enable(
-        pac.UART0,
-        &mut pac.RESETS,
-        hal::uart::common_configs::_115200_8_N_1,
-        clocks.peripheral_clock.into(),
-    )
-    .unwrap();
+    let mut uart = hal::uart::UartPeripheral::<_, _>::new(pac.UART0, &mut pac.RESETS)
+        .enable(
+            hal::uart::common_configs::_115200_8_N_1,
+            clocks.peripheral_clock.into(),
+        )
+        .unwrap();
 
     // UART TX (characters sent from RP2040) on pin 1 (GPIO0)
     let _tx_pin = pins.gpio0.into_mode::<hal::gpio::FunctionUart>();

--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -85,13 +85,12 @@ fn main() -> ! {
     );
 
     // Create a UART driver
-    let mut uart = hal::uart::UartPeripheral::<_, _>::enable(
-        pac.UART0,
-        &mut pac.RESETS,
-        hal::uart::common_configs::_9600_8_N_1,
-        clocks.peripheral_clock.into(),
-    )
-    .unwrap();
+    let mut uart = hal::uart::UartPeripheral::<_, _>::new(pac.UART0, &mut pac.RESETS)
+        .enable(
+            hal::uart::common_configs::_9600_8_N_1,
+            clocks.peripheral_clock.into(),
+        )
+        .unwrap();
 
     // UART TX (characters sent from pico) on pin 1 (GPIO0) and RX (on pin 2 (GPIO1)
     let _tx_pin = pins.gpio0.into_mode::<hal::gpio::FunctionUart>();

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -80,13 +80,12 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let mut uart = hal::uart::UartPeripheral::<_, _>::enable(
-        pac.UART0,
-        &mut pac.RESETS,
-        hal::uart::common_configs::_9600_8_N_1,
-        clocks.peripheral_clock.into(),
-    )
-    .unwrap();
+    let mut uart = hal::uart::UartPeripheral::<_, _>::new(pac.UART0, &mut pac.RESETS)
+        .enable(
+            hal::uart::common_configs::_9600_8_N_1,
+            clocks.peripheral_clock.into(),
+        )
+        .unwrap();
 
     // UART TX (characters sent from RP2040) on pin 1 (GPIO0)
     let _tx_pin = pins.gpio0.into_mode::<hal::gpio::FunctionUart>();

--- a/rp2040-hal/examples/uart.rs
+++ b/rp2040-hal/examples/uart.rs
@@ -82,13 +82,12 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let mut uart = hal::uart::UartPeripheral::<_, _>::enable(
-        pac.UART0,
-        &mut pac.RESETS,
-        hal::uart::common_configs::_9600_8_N_1,
-        clocks.peripheral_clock.into(),
-    )
-    .unwrap();
+    let mut uart = hal::uart::UartPeripheral::<_, _>::new(pac.UART0, &mut pac.RESETS)
+        .enable(
+            hal::uart::common_configs::_9600_8_N_1,
+            clocks.peripheral_clock.into(),
+        )
+        .unwrap();
 
     // UART TX (characters sent from RP2040) on pin 1 (GPIO0)
     let _tx_pin = pins.gpio0.into_mode::<hal::gpio::FunctionUart>();

--- a/rp2040-hal/src/uart.rs
+++ b/rp2040-hal/src/uart.rs
@@ -17,12 +17,12 @@
 //! let mut clocks = init_clocks_and_plls(XOSC_CRYSTAL_FREQ, peripherals.XOSC, peripherals.CLOCKS, peripherals.PLL_SYS, peripherals.PLL_USB, &mut peripherals.RESETS, &mut watchdog).ok().unwrap();
 //!
 //! // Need to perform clock init before using UART or it will freeze.
-//! let uart = UartPeripheral::<_, _>::enable(
-//!         peripherals.UART0,
-//!         &mut peripherals.RESETS,
+//! let uart = UartPeripheral::<_, _>::new(peripherals.UART0, &mut peripherals.RESETS)
+//!     .enable(
 //!         uart::common_configs::_9600_8_N_1,
 //!         clocks.peripheral_clock.into(),
-//!     ).unwrap();
+//!     )
+//!     .unwrap();
 //!
 //! // Set up UART on GP0 and GP1 (Pico pins 1 and 2)
 //! let _tx_pin = pins.gpio0.into_mode::<FunctionUart>();
@@ -222,15 +222,25 @@ impl<S: State, D: UartDevice> UartPeripheral<S, D> {
 }
 
 impl<D: UartDevice> UartPeripheral<Disabled, D> {
+    /// Creates an UartPeripheral in Disabled state.
+    pub fn new(device: D, resets: &mut pac::RESETS) -> UartPeripheral<Disabled, D> {
+        device.reset_bring_up(resets);
+
+        UartPeripheral {
+            device,
+            config: common_configs::_9600_8_N_1, // placeholder
+            effective_baudrate: Baud(0),
+            _state: Disabled,
+        }
+    }
+
     /// Enables the provided UART device with the given configuration.
     pub fn enable(
-        mut device: D,
-        resets: &mut pac::RESETS,
+        self,
         config: UartConfig,
         frequency: Hertz,
     ) -> Result<UartPeripheral<Enabled, D>, Error> {
-        device.reset_bring_up(resets);
-
+        let mut device = self.free();
         let effective_baudrate = configure_baudrate(&mut device, &config.baudrate, &frequency)?;
 
         device.uartlcr_h.write(|w| {

--- a/rp2040-hal/src/uart.rs
+++ b/rp2040-hal/src/uart.rs
@@ -224,6 +224,7 @@ impl<S: State, D: UartDevice> UartPeripheral<S, D> {
 impl<D: UartDevice> UartPeripheral<Disabled, D> {
     /// Creates an UartPeripheral in Disabled state.
     pub fn new(device: D, resets: &mut pac::RESETS) -> UartPeripheral<Disabled, D> {
+        device.reset_bring_down(resets);
         device.reset_bring_up(resets);
 
         UartPeripheral {


### PR DESCRIPTION
For communicating with an [CH9121](https://www.waveshare.com/wiki/Pico-ETH-CH9121) Ethernet/serial adapter, I need to be able to change the bit rate of an existing UART, as the chip uses the same serial line for both configuration and data transfer, but with different bit rates.

The existing UartPeripheral doesn't allow that. And as the current `disable()` method looks rather useless, as it's not possible to `enable()` an UART after disabling it, I think it would be better to make the API a little bit more symmetrical, so one can do:
```
let disabled_uart = hal::uart::UartPeripheral::<_, _>::new(pac.UART0, &mut pac.RESETS);
let enabled_uart = disabled_uart.enable(config, frequency).unwrap();
let disabled_uart = enabled_uart.disable();
let enabled_uart = disabled_uart.enable(other_config, frequency).unwrap();
```
With the old API this would have been:
```
let enabled_uart = hal::uart::UartPeripheral::<_, _>::enable(pac.UART0, &mut pac.RESETS, config, frequenc).unwrap();
let disabled_uart = enabled_uart.disable();
let uart_device = disabled_uart.free();
let enabled_uart = disabled_uart.enable(uart_device, &mut pac.RESETS, other_config, frequency).unwrap();
```
The most inconvenient part is that every change of configuration would need access to `pac.RESETS`, making it more difficult to encapsulate the UART device inside some driver struct.