### PR TITLE
Update Pico RTIC example to use timer alarm HAL

### DIFF
--- a/boards/pico/Cargo.toml
+++ b/boards/pico/Cargo.toml
@@ -36,7 +36,7 @@ optional = true
 [dev-dependencies]
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
-cortex-m-rtic = "0.6.0-alpha.5"
+cortex-m-rtic = "0.6.0-rc.4"
 nb = "1.0"
 i2c-pio = { git = "https://github.com/ithinuel/i2c-pio-rs", rev = "afc2dad0e955da2b712d7f7cd78c7af88ddc6a45" }
 

--- a/boards/pico/examples/pico_rtic.rs
+++ b/boards/pico/examples/pico_rtic.rs
@@ -2,9 +2,8 @@
 #![no_main]
 
 use panic_halt as _;
-use rp2040_hal as hal;
 
-#[rtic::app(device = crate::hal::pac, peripherals = true)]
+#[rtic::app(device = pico::hal::pac, peripherals = true)]
 mod app {
 
     use embedded_hal::digital::v2::OutputPin;


### PR DESCRIPTION
Example now uses pico bsp, RTIC multilock, and rp-hal Timer Alarm HAL. 