### PR TITLE
WIP: alternative to passing PeripheralClock freq to I2C/SPI as generic Into<Hertz<u32>>

### DIFF
--- a/boards/pico_explorer/examples/pico_explorer_showcase.rs
+++ b/boards/pico_explorer/examples/pico_explorer_showcase.rs
@@ -55,6 +55,7 @@ fn main() -> ! {
         sio.gpio_bank0,
         p.SPI0,
         adc,
+        clocks.peripheral_clock,
         &mut p.RESETS,
         &mut delay,
     );

--- a/boards/pico_explorer/examples/pico_explorer_showcase.rs
+++ b/boards/pico_explorer/examples/pico_explorer_showcase.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
         sio.gpio_bank0,
         p.SPI0,
         adc,
-        clocks.peripheral_clock,
+        &clocks.peripheral_clock,
         &mut p.RESETS,
         &mut delay,
     );

--- a/boards/pico_explorer/src/lib.rs
+++ b/boards/pico_explorer/src/lib.rs
@@ -188,7 +188,7 @@ impl PicoExplorer {
         sio: SioGpioBank0,
         spi0: SPI0,
         adc: Adc,
-        peripheral_clock: hal::clocks::PeripheralClock,
+        peripheral_clock: &hal::clocks::PeripheralClock,
         resets: &mut RESETS,
         delay: &mut impl DelayUs<u32>,
     ) -> (Self, Pins) {

--- a/boards/pico_explorer/src/lib.rs
+++ b/boards/pico_explorer/src/lib.rs
@@ -181,12 +181,14 @@ impl OutputPin for DummyPin {
 }
 
 impl PicoExplorer {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
         io: pac::IO_BANK0,
         pads: pac::PADS_BANK0,
         sio: SioGpioBank0,
         spi0: SPI0,
         adc: Adc,
+        peripheral_clock: hal::clocks::PeripheralClock,
         resets: &mut RESETS,
         delay: &mut impl DelayUs<u32>,
     ) -> (Self, Pins) {
@@ -207,12 +209,8 @@ impl PicoExplorer {
         let spi_sclk = internal_pins.spi_sclk.into_mode::<FunctionSpi>();
         let spi_mosi = internal_pins.spi_mosi.into_mode::<FunctionSpi>();
 
-        let spi_screen = Spi::<_, _, 8>::new(spi0).init(
-            resets,
-            125_000_000u32.Hz(),
-            16_000_000u32.Hz(),
-            &MODE_0,
-        );
+        let spi_screen =
+            Spi::<_, _, 8>::new(spi0).init(resets, peripheral_clock, 16_000_000u32.Hz(), &MODE_0);
 
         let spii_screen = SPIInterface::new(spi_screen, dc, cs);
 

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -89,7 +89,7 @@ fn main() -> ! {
         scl_pin, // Try `not_an_scl_pin` here
         400.kHz(),
         &mut pac.RESETS,
-        clocks.peripheral_clock,
+        &clocks.peripheral_clock,
     );
 
     // Write three bytes to the I²C device with 7-bit address 0x2C

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -88,7 +88,7 @@ fn main() -> ! {
     // Exchange the uninitialised SPI driver for an initialised one
     let mut spi = spi.init(
         &mut pac.RESETS,
-        clocks.peripheral_clock,
+        &clocks.peripheral_clock,
         16_000_000u32.Hz(),
         &embedded_hal::spi::MODE_0,
     );

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -25,7 +25,6 @@ use rp2040_hal as hal;
 // Some traits we need
 use cortex_m::prelude::*;
 use embedded_time::rate::Extensions;
-use rp2040_hal::clocks::Clock;
 
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access
@@ -89,7 +88,7 @@ fn main() -> ! {
     // Exchange the uninitialised SPI driver for an initialised one
     let mut spi = spi.init(
         &mut pac.RESETS,
-        clocks.peripheral_clock.freq(),
+        clocks.peripheral_clock,
         16_000_000u32.Hz(),
         &embedded_hal::spi::MODE_0,
     );

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -9,6 +9,19 @@
 //! let mut peripherals = pac::Peripherals::take().unwrap();
 //! let sio = Sio::new(peripherals.SIO);
 //! let pins = Pins::new(peripherals.IO_BANK0, peripherals.PADS_BANK0, sio.gpio_bank0, &mut peripherals.RESETS);
+//! let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+//! const XTAL_FREQ_HZ:u32 = 12_000_000;
+//! let clocks = hal::clocks::init_clocks_and_plls(
+//!         XTAL_FREQ_HZ,
+//!         pac.XOSC,
+//!         pac.CLOCKS,
+//!         pac.PLL_SYS,
+//!         pac.PLL_USB,
+//!         &mut pac.RESETS,
+//!         &mut watchdog,
+//!     )
+//!     .ok()
+//!     .unwrap();
 //!
 //! let mut i2c = I2C::i2c1(
 //!     peripherals.I2C1,
@@ -16,7 +29,7 @@
 //!     pins.gpio19.into_mode(), // scl
 //!     400.kHz(),
 //!     &mut peripherals.RESETS,
-//!     125_000_000.Hz(),
+//!     clocks.peripheral_clock,
 //! );
 //!
 //! // Scan for devices on the bus by attempting to read from them

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -241,18 +241,17 @@ macro_rules! hal {
             impl<Sda: PinId + BankPinId, Scl: PinId + BankPinId>
                 I2C<$I2CX, (Pin<Sda, FunctionI2C>, Pin<Scl, FunctionI2C>)> {
                 /// Configures the I2C peripheral to work in master mode
-                pub fn $i2cX<F, SystemF>(
+                pub fn $i2cX<F>(
                     i2c: $I2CX,
                     sda_pin: Pin<Sda, FunctionI2C>,
                     scl_pin: Pin<Scl, FunctionI2C>,
                     freq: F,
                     resets: &mut RESETS,
-                    system_clock: SystemF) -> Self
+                    system_clock: super::clocks::PeripheralClock) -> Self
                 where
                     F: Into<Hertz<u64>>,
                     Sda: SdaPin<$I2CX>,
                     Scl: SclPin<$I2CX>,
-                    SystemF: Into<Hertz<u32>>,
                 {
                     Self::new_controller(i2c, sda_pin, scl_pin, freq, resets, system_clock)
                 }

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -260,7 +260,7 @@ macro_rules! hal {
                     scl_pin: Pin<Scl, FunctionI2C>,
                     freq: F,
                     resets: &mut RESETS,
-                    system_clock: super::clocks::PeripheralClock) -> Self
+                    system_clock: &super::clocks::PeripheralClock) -> Self
                 where
                     F: Into<Hertz<u64>>,
                     Sda: SdaPin<$I2CX>,

--- a/rp2040-hal/src/i2c/controller.rs
+++ b/rp2040-hal/src/i2c/controller.rs
@@ -1,10 +1,12 @@
 use core::{marker::PhantomData, ops::Deref};
 
 use crate::{
+    clocks::Clock,
     gpio::pin::bank0::BankPinId,
     gpio::pin::{FunctionI2C, Pin, PinId},
     resets::SubsystemReset,
 };
+use embedded_time::fixed_point::FixedPoint;
 use embedded_time::rate::Hertz;
 use hal::blocking::i2c::{Read, Write, WriteRead};
 use pac::{i2c0::RegisterBlock as Block, RESETS};
@@ -21,19 +23,18 @@ impl<T: SubsystemReset + Deref<Target = Block>, Sda: PinId + BankPinId, Scl: Pin
     I2C<T, (Pin<Sda, FunctionI2C>, Pin<Scl, FunctionI2C>), Controller>
 {
     /// Configures the I2C peripheral to work in controller mode
-    pub fn new_controller<F, SystemF>(
+    pub fn new_controller<F>(
         i2c: T,
         sda_pin: Pin<Sda, FunctionI2C>,
         scl_pin: Pin<Scl, FunctionI2C>,
         freq: F,
         resets: &mut RESETS,
-        system_clock: SystemF,
+        system_clock: crate::clocks::PeripheralClock,
     ) -> Self
     where
         F: Into<Hertz<u64>>,
         Sda: SdaPin<T>,
         Scl: SclPin<T>,
-        SystemF: Into<Hertz<u32>>,
     {
         let freq = freq.into().0;
         assert!(freq <= 1_000_000);
@@ -58,7 +59,7 @@ impl<T: SubsystemReset + Deref<Target = Block>, Sda: PinId + BankPinId, Scl: Pin
         i2c.ic_tx_tl.write(|w| unsafe { w.tx_tl().bits(0) });
         i2c.ic_rx_tl.write(|w| unsafe { w.rx_tl().bits(0) });
 
-        let freq_in = system_clock.into().0;
+        let freq_in = system_clock.freq().integer();
 
         // There are some subtleties to I2C timing which we are completely ignoring here
         // See: https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_i2c/i2c.c#L69

--- a/rp2040-hal/src/i2c/controller.rs
+++ b/rp2040-hal/src/i2c/controller.rs
@@ -29,7 +29,7 @@ impl<T: SubsystemReset + Deref<Target = Block>, Sda: PinId + BankPinId, Scl: Pin
         scl_pin: Pin<Scl, FunctionI2C>,
         freq: F,
         resets: &mut RESETS,
-        system_clock: crate::clocks::PeripheralClock,
+        system_clock: &crate::clocks::PeripheralClock,
     ) -> Self
     where
         F: Into<Hertz<u64>>,

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -146,10 +146,10 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
     }
 
     /// Initialize the SPI
-    pub fn init<F: Into<Hertz<u32>>, B: Into<Hertz<u32>>>(
+    pub fn init<B: Into<Hertz<u32>>>(
         mut self,
         resets: &mut RESETS,
-        peri_frequency: F,
+        peri_frequency: super::clocks::PeripheralClock,
         baudrate: B,
         mode: &Mode,
     ) -> Spi<Enabled, D, DS> {

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -163,14 +163,15 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
     pub fn init<B: Into<Hertz<u32>>>(
         mut self,
         resets: &mut RESETS,
-        peri_frequency: super::clocks::PeripheralClock,
+        peri_frequency: &super::clocks::PeripheralClock,
         baudrate: B,
         mode: &Mode,
     ) -> Spi<Enabled, D, DS> {
         self.device.reset_bring_down(resets);
         self.device.reset_bring_up(resets);
-
-        self.set_baudrate(peri_frequency, baudrate);
+        // Converting this so we can accept a &PeripheralClock without changing set_baudrate
+        let freq:Hertz<u32> = crate::Clock::freq(peri_frequency);
+        self.set_baudrate(freq, baudrate);
         self.set_format(DS as u8, mode);
         // Always enable DREQ signals -- harmless if DMA is not listening
         self.device

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -9,9 +9,23 @@
 //! use embedded_time::rate::*;
 //! use rp2040_hal::{spi::Spi, gpio::{Pins, FunctionSpi}, pac, Sio};
 //!
-//! let mut peripherals = pac::Peripherals::take().unwrap();
+//! let mut pac = pac::Peripherals::take().unwrap();
 //! let sio = Sio::new(peripherals.SIO);
 //! let pins = Pins::new(peripherals.IO_BANK0, peripherals.PADS_BANK0, sio.gpio_bank0, &mut peripherals.RESETS);
+//! let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+//!
+//! const XTAL_FREQ_HZ:u32 = 12_000_000;
+//! let clocks = hal::clocks::init_clocks_and_plls(
+//!         XTAL_FREQ_HZ,
+//!         pac.XOSC,
+//!         pac.CLOCKS,
+//!         pac.PLL_SYS,
+//!         pac.PLL_USB,
+//!         &mut pac.RESETS,
+//!         &mut watchdog,
+//!     )
+//!     .ok()
+//!     .unwrap();
 //!
 //! let _ = pins.gpio2.into_mode::<FunctionSpi>();
 //! let _ = pins.gpio3.into_mode::<FunctionSpi>();


### PR DESCRIPTION
After spending time troubleshooting why my I2C peripheral wasn't working (and determining that I fed the wrong clock frequency into the constructor for I2C), I thought it would be worth floating the idea of stripping out the generic constructor with one that takes the Clocks::PeripheralClock struct directly.

Pros:
- Can't feed in the wrong number
- You were probably going to give it the data from this struct anyway, so the conversion goes into the peripheral driver

Cons:
- Any changes to the Clock structures will require changes to the SPI and I2C peripherals drivers
- How to resolve lifetimes?