### PR TITLE
Set up for 0.3.0 release.

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPI example
 - Watchdog example
 - ADC documentation
+- Lots of bug fixes :)
 
 ### Changed
 

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -18,12 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2021-12-19
 
 ### Added
+
 - A README!
 - Implementation of the `critical-section` API
-- DMA support
-- Embedded HAL 1.0 Alpha support
+- Embedded HAL 1.0-alpha6 support
 - I²C Controller and Peripheral support
-- Multi-core support
+- Multi-core support, including spin-locks and SIO FIFO
+- RTC support
+- USB Device support
+- Timer support
 - PIO support
 - Implementation of `rng_core::RngCore` for `RingOscillator`
 - ADC example
@@ -36,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADC documentation
 
 ### Changed
+
 - Modified PIO API for better ergonomics
 - Updated PAC to 0.2.0
 - Exported common driver structs from top-level (e.g. it's now `Sio`, not `sio::Sio`)
@@ -44,9 +48,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial version with support for Rosc, Xosc, Plls, Watchdog, Clocks, Gpio, Pwm, Adc, Spi, I2C, Resets, Uart
+- Updated version with support for:
+  - Ring Oscillator
+  - Crystal Oscillator
+  - Plls
+  - Watchdog
+  - Clocks
+  - GPIO
+  - PWM
+  - ADC
+  - SPI
+  - I²C
+  - Resets
+  - UART
+  - Hardware divide/modulo
 
-## [0.1.0]
+## [0.1.0] - 2021-01-21
 
 - Initial release
 

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2021-12-19
 
+### MSRV
+
+The Minimum-Supported Rust Version (MSRV) for this release is 1.54.
+
 ### Added
 
 - A README!

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -8,24 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- implement `rng_core::RngCore` for `RingOscillator`
+
+- None
+
+### Changed
+
+- None
+
+## [0.3.0] - 2021-12-19
+
+### Added
+- A README!
+- Implementation of the `critical-section` API
+- DMA support
+- Embedded HAL 1.0 Alpha support
+- I²C Controller and Peripheral support
+- Multi-core support
+- PIO support
+- Implementation of `rng_core::RngCore` for `RingOscillator`
+- ADC example
+- GPIO Interrupt support
+- Multi-core FIFO example
+- PIO LED Blinky example
+- ROM Functions example
+- SPI example
+- Watchdog example
+- ADC documentation
 
 ### Changed
 - Modified PIO API for better ergonomics
-
-## [0.3.0] - 2021-09-20
-
-### Added
-- peripheral drivers: Timer(counter) with EH traits, USB, PIO
-- examples: Watchdog, GPIO, ADC, i2c, rtic blinky, usb (serial echo, mouse)
-- docs: Watchdog
-- bsps: adafruit feather
-- bsp examples: sparkfun pro micro PIO RGB rainbow LED
-
-### Changed
-- i2c fixes
-- spi fixes
-- pwm fixes
+- Updated PAC to 0.2.0
+- Exported common driver structs from top-level (e.g. it's now `Sio`, not `sio::Sio`)
 
 ## [0.2.0] - 2021-08-14
 

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rp2040-hal"
 version = "0.3.0"
-authors = ["evan <evanmolder@gmail.com>"]
+authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"
 description = "A Rust Embeded-HAL impl for the rp2040 microcontroller"

--- a/rp2040-hal/README.md
+++ b/rp2040-hal/README.md
@@ -68,7 +68,7 @@ https://github.com/rp-rs/rp-hal/ for more details.
 To include this crate in your project, amend your `Cargo.toml` file to include
 
 ```toml
-rp2040-hal = "0.3"
+rp2040-hal = "0.3.0"
 ```
 
 To obtain a copy of the source code (e.g. if you want to propose a bug-fix or


### PR DESCRIPTION
Somehow we already had a bunch of commits talking about 0.3.0, but it
was never released. Hence why this maybe doesn't change as many version
numbers as you might expect.