### PR TITLE
Bump versions of HAL and BSPs

### DIFF
--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-feather-rp2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrea Nall <anall@andreanal.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-feather-rp2040"
@@ -13,7 +13,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 [dependencies]
 cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-itsy-bitsy-rp2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit_itsy_bitsy_rp2040"
@@ -13,7 +13,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 [dependencies]
 cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-kb2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-kb2040"
@@ -12,7 +12,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0" }
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0" }
 cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-macropad"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrea Nall <anall@andreanal.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit_macropad"
@@ -13,7 +13,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 [dependencies]
 cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 
 [features]

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-qt-py-rp2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Stephen Onnen <stephen.onnen@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-qt-py-rp2040"
@@ -12,7 +12,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 rp2040-boot2 = { version = "0.2.0", optional = true }

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-pico-explorer"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Hmvp <hmvp@users.noreply.github.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-pico-explorer"
@@ -12,7 +12,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 st7789 = "0.6.1"

--- a/boards/pimoroni-pico-lipo-16mb/Cargo.toml
+++ b/boards/pimoroni-pico-lipo-16mb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-pico-lipo-16mb"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Hmvp <hmvp@users.noreply.github.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-pico-lipo-16mb"
@@ -12,7 +12,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 rp2040-boot2 = { version = "0.2.0", optional = true }
 

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp-pico"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["evan <evanmolder@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pico"
@@ -13,7 +13,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 [dependencies]
 cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0"}
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 usb-device= "0.2.8"

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkfun-pro-micro-rp2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Wilfried Chauveau <wilfried.chauveau@ithinuel.me>"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/sparkfun-pro-micro-rp2040"
@@ -12,7 +12,7 @@ repository = "https://github.com/rp-rs/rp-hal.git"
 
 [dependencies]
 cortex-m = "0.7.2"
-rp2040-hal = { path = "../../rp2040-hal", version = "0.3.0" }
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0" }
 cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 rp2040-boot2 = { version = "0.2.0", optional = true }

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-hal"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"


### PR DESCRIPTION
The change to UartPeripheral in #210 was a breaking change:
Bump the version of the HAL and all dependent BSP crates.