### PR TITLE
boards/pico: Remove mention of boot select button

### DIFF
--- a/boards/rp-pico/README.md
+++ b/boards/rp-pico/README.md
@@ -60,7 +60,7 @@ Flashes the Pico's on-board LED on and off.
 
 ### [pico_gpio_in_out](./examples/pico_gpio_in_out.rs)
 
-Reads the 'Boot Select' pin and drives the on-board LED to match it (i.e. on when pressed, off when not pressed).
+Reads a push button attached to GPIO 15 and drives the on-board LED to match it (i.e. on when pressed, off when not pressed).
 
 ### [pico_rtic](./examples/pico_rtic.rs)
 


### PR DESCRIPTION
The boot selector pin is attached to SPI_SS and not easily read (an
example
https://github.com/raspberrypi/pico-examples/blob/master/picoboard/button/button.c),
since the code reading needs to reside in SRAM.

Simply fix the documentation by only mentioning the pin