### PR TITLE
Fix ci masking link errors

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,6 +26,14 @@ jobs:
           args: --workspace
       - uses: actions-rs/cargo@v1
         with:
+          command: build
+          args: --release --workspace --examples
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --workspace --examples --features eh1_0_alpha
+      - uses: actions-rs/cargo@v1
+        with:
           command: test
           args: --doc --target x86_64-unknown-linux-gnu
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,8 +4,6 @@ jobs:
   check:
     name: cargo-check
     runs-on: ubuntu-20.04
-    env:
-      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -25,7 +23,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --all
+          args: --workspace
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,23 +15,31 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --examples
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --examples --features eh1_0_alpha
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
           args: --workspace
       - uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --workspace --examples
+      - run: echo "Debug examples built:" && ls target/thumbv6m-none-eabi/debug/examples/ |grep -v '-' |grep -v '\.d'
+      - run: rm target/thumbv6m-none-eabi/debug/examples/ -rf
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace --examples --features eh1_0_alpha
+      - run: echo "Debug eh1_0 examples built:" && ls target/thumbv6m-none-eabi/debug/examples/ |grep -v '-' |grep -v '\.d'
+      - run: rm target/thumbv6m-none-eabi/debug/examples/ -rf
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
           args: --release --workspace --examples
+      - run: echo "Release examples built:" && ls target/thumbv6m-none-eabi/release/examples/ |grep -v '-' |grep -v '\.d'
+      - run: rm target/thumbv6m-none-eabi/release/examples/ -rf
       - uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --workspace --examples --features eh1_0_alpha
+      - run: echo "Release eh1_0 examples built:" && ls target/thumbv6m-none-eabi/release/examples/ |grep -v '-' |grep -v '\.d'
+      - run: rm target/thumbv6m-none-eabi/release/examples/ -rf
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,11 +14,11 @@ jobs:
           profile: minimal
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --workspace --examples
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --workspace --examples --features eh1_0_alpha
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Fix CI BSP examples not generating failure on link errors

#250 exists because CI was not generating errors on failure to link.
This was due to [RUSTFLAGS: "-D warnings" ](https://github.com/9names/rp-hal/blob/c02984b422d3cc12e14a3e17373f7bb3b57e5e58/.github/workflows/build_and_test.yml#L8) suppressing the link errors.

In this PR:
- I remove "-D warnings" from RUSTFLAGS, to ensure we don't mask our warnings like linker error
- switch from `cargo check` to `cargo build` so we test linking, and also add release builds to the workflow in case they get build errors.