### PR TITLE
Remove static BOOT2 decl in BSP examples so they build

### DIFF
--- a/boards/adafruit-kb2040/examples/adafruit_kb2040_rainbow.rs
+++ b/boards/adafruit-kb2040/examples/adafruit_kb2040_rainbow.rs
@@ -28,12 +28,6 @@ use adafruit_kb2040::{
 use smart_leds::{brightness, SmartLedsWrite, RGB8};
 use ws2812_pio::Ws2812;
 
-/// The linker will place this boot block at the start of our program image.
-/// We need this to help the ROM bootloader get our code up and running.
-#[link_section = ".boot2"]
-#[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
-
 /// Entry point to our bare-metal application.
 ///
 /// The `#[entry]` macro ensures the Cortex-M start-up code calls this

--- a/boards/rp-pico/examples/pico_uart_irq_buffer.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_buffer.rs
@@ -70,12 +70,6 @@ struct UartQueue {
     interrupt: pac::Interrupt,
 }
 
-/// The linker will place this boot block at the start of our program image. We
-/// need this to help the ROM bootloader get our code up and running.
-#[link_section = ".boot2"]
-#[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
-
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency
 const XTAL_FREQ_HZ: u32 = 12_000_000u32;

--- a/boards/rp-pico/examples/pico_uart_irq_echo.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_echo.rs
@@ -61,12 +61,6 @@ type UartPins = (
 /// Alias the type for our UART to make things clearer.
 type Uart = hal::uart::UartPeripheral<hal::uart::Enabled, pac::UART0, UartPins>;
 
-/// The linker will place this boot block at the start of our program image. We
-/// need this to help the ROM bootloader get our code up and running.
-#[link_section = ".boot2"]
-#[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
-
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency
 const XTAL_FREQ_HZ: u32 = 12_000_000u32;


### PR DESCRIPTION
Fixes #250
Fixes #251