### PR TITLE
Added pin function documentation from the datasheet to rp-pico

### DIFF
--- a/boards/rp-pico/src/lib.rs
+++ b/boards/rp-pico/src/lib.rs
@@ -19,23 +19,23 @@ pub use hal::pac;
 
 hal::bsp_pins!(
     /// GPIO 0 supports following functions:
-    /// - `SPI0 RX  `
-    /// - `UART0 TX `
+    /// - `SPI0 RX`
+    /// - `UART0 TX`
     /// - `I2C0 SDA`
     /// - `PWM0 A`
     /// - `SIO`, `PIO0`, `PIO1`
     Gpio0 { name: gpio0 },
 
     /// GPIO 1 supports following functions:
-    /// - `SPI0 CSn `
-    /// - `UART0 RX `
+    /// - `SPI0 CSn`
+    /// - `UART0 RX`
     /// - `I2C0 SCL`
     /// - `PWM0 B`
     /// - `SIO`, `PIO0`, `PIO1`
     Gpio1 { name: gpio1 },
 
     /// GPIO 2 supports following functions:
-    /// - `SPI0 SCK `
+    /// - `SPI0 SCK`
     /// - `UART0 CTS`
     /// - `I2C1 SDA`
     /// - `PWM1 A`
@@ -43,7 +43,7 @@ hal::bsp_pins!(
     Gpio2 { name: gpio2 },
 
     /// GPIO 3 supports following functions:
-    /// - `SPI0 TX  `
+    /// - `SPI0 TX`
     /// - `UART0 RTS`
     /// - `I2C1 SCL`
     /// - `PWM1 B`
@@ -51,23 +51,23 @@ hal::bsp_pins!(
     Gpio3 { name: gpio3 },
 
     /// GPIO 4 supports following functions:
-    /// - `SPI0 RX  `
-    /// - `UART1 TX `
+    /// - `SPI0 RX`
+    /// - `UART1 TX`
     /// - `I2C0 SDA`
     /// - `PWM2 A`
     /// - `SIO`, `PIO0`, `PIO1`
     Gpio4 { name: gpio4 },
 
     /// GPIO 5 supports following functions:
-    /// - `SPI0 CSn `
-    /// - `UART1 RX `
+    /// - `SPI0 CSn`
+    /// - `UART1 RX`
     /// - `I2C0 SCL`
     /// - `PWM2 B`
     /// - `SIO`, `PIO0`, `PIO1`
     Gpio5 { name: gpio5 },
 
     /// GPIO 6 supports following functions:
-    /// - `SPI0 SCK `
+    /// - `SPI0 SCK`
     /// - `UART1 CTS`
     /// - `I2C1 SDA`
     /// - `PWM3 A`
@@ -75,7 +75,7 @@ hal::bsp_pins!(
     Gpio6 { name: gpio6 },
 
     /// GPIO 7 supports following functions:
-    /// - `SPI0 TX  `
+    /// - `SPI0 TX`
     /// - `UART1 RTS`
     /// - `I2C1 SCL`
     /// - `PWM3 B`
@@ -83,16 +83,16 @@ hal::bsp_pins!(
     Gpio7 { name: gpio7 },
 
     /// GPIO 8 supports following functions:
-    /// - `SPI1 RX  `
-    /// - `UART1 TX `
+    /// - `SPI1 RX`
+    /// - `UART1 TX`
     /// - `I2C0 SDA`
     /// - `PWM4 A`
     /// - `SIO`, `PIO0`, `PIO1`
     Gpio8 { name: gpio8 },
 
     /// GPIO 9 supports following functions:
-    /// - `SPI1 CSn `
-    /// - `UART1 RX `
+    /// - `SPI1 CSn`
+    /// - `UART1 RX`
     /// - `I2C0 SCL`
     /// - `PWM4 B`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -107,7 +107,7 @@ hal::bsp_pins!(
     Gpio10 { name: gpio10 },
 
     /// GPIO 11 supports following functions:
-    /// - `SPI1 TX `
+    /// - `SPI1 TX`
     /// - `UART1 RTS`
     /// - `I2C1 SCL`
     /// - `PWM5 B`
@@ -115,8 +115,8 @@ hal::bsp_pins!(
     Gpio11 { name: gpio11 },
 
     /// GPIO 12 supports following functions:
-    /// - `SPI1 RX `
-    /// - `UART0 TX `
+    /// - `SPI1 RX`
+    /// - `UART0 TX`
     /// - `I2C0 SDA`
     /// - `PWM6 A`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -124,7 +124,7 @@ hal::bsp_pins!(
 
     /// GPIO 13 supports following functions:
     /// - `SPI1 CSn`
-    /// - `UART0 RX `
+    /// - `UART0 RX`
     /// - `I2C0 SCL`
     /// - `PWM6 B`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -139,7 +139,7 @@ hal::bsp_pins!(
     Gpio14 { name: gpio14 },
 
     /// GPIO 15 supports following functions:
-    /// - `SPI1 TX `
+    /// - `SPI1 TX`
     /// - `UART0 RTS`
     /// - `I2C1 SCL`
     /// - `PWM7 B`
@@ -147,8 +147,8 @@ hal::bsp_pins!(
     Gpio15 { name: gpio15 },
 
     /// GPIO 16 supports following functions:
-    /// - `SPI0 RX `
-    /// - `UART0 TX `
+    /// - `SPI0 RX`
+    /// - `UART0 TX`
     /// - `I2C0 SDA`
     /// - `PWM0 A`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -156,7 +156,7 @@ hal::bsp_pins!(
 
     /// GPIO 17 supports following functions:
     /// - `SPI0 CSn`
-    /// - `UART0 RX `
+    /// - `UART0 RX`
     /// - `I2C0 SCL`
     /// - `PWM0 B`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -171,7 +171,7 @@ hal::bsp_pins!(
     Gpio18 { name: gpio18 },
 
     /// GPIO 19 supports following functions:
-    /// - `SPI0 TX `
+    /// - `SPI0 TX`
     /// - `UART0 RTS`
     /// - `I2C1 SCL`
     /// - `PWM1 B`
@@ -179,8 +179,8 @@ hal::bsp_pins!(
     Gpio19 { name: gpio19 },
 
     /// GPIO 20 supports following functions:
-    /// - `SPI0 RX `
-    /// - `UART1 TX `
+    /// - `SPI0 RX`
+    /// - `UART1 TX`
     /// - `I2C0 SDA`
     /// - `PWM2 A`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -188,7 +188,7 @@ hal::bsp_pins!(
 
     /// GPIO 21 supports following functions:
     /// - `SPI0 CSn`
-    /// - `UART1 RX `
+    /// - `UART1 RX`
     /// - `I2C0 SCL`
     /// - `PWM2 B`
     /// - `SIO`, `PIO0`, `PIO1`
@@ -220,7 +220,7 @@ hal::bsp_pins!(
     Gpio26 { name: gpio26 },
 
     /// GPIO 27 supports following functions:
-    /// - `SPI1 TX `
+    /// - `SPI1 TX`
     /// - `UART1 RTS`
     /// - `I2C1 SCL`
     /// - `PWM5 B`
@@ -228,8 +228,8 @@ hal::bsp_pins!(
     Gpio27 { name: gpio27 },
 
     /// GPIO 28 supports following functions:
-    /// - `SPI1 RX `
-    /// - `UART0 TX `
+    /// - `SPI1 RX`
+    /// - `UART0 TX`
     /// - `I2C0 SDA`
     /// - `PWM6 A`
     /// - `SIO`, `PIO0`, `PIO1`

--- a/boards/rp-pico/src/lib.rs
+++ b/boards/rp-pico/src/lib.rs
@@ -18,38 +18,225 @@ pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 pub use hal::pac;
 
 hal::bsp_pins!(
+    /// GPIO 0 supports following functions:
+    /// - `SPI0 RX  `
+    /// - `UART0 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM0 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio0 { name: gpio0 },
+
+    /// GPIO 1 supports following functions:
+    /// - `SPI0 CSn `
+    /// - `UART0 RX `
+    /// - `I2C0 SCL`
+    /// - `PWM0 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio1 { name: gpio1 },
+
+    /// GPIO 2 supports following functions:
+    /// - `SPI0 SCK `
+    /// - `UART0 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM1 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio2 { name: gpio2 },
+
+    /// GPIO 3 supports following functions:
+    /// - `SPI0 TX  `
+    /// - `UART0 RTS`
+    /// - `I2C1 SCL`
+    /// - `PWM1 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio3 { name: gpio3 },
+
+    /// GPIO 4 supports following functions:
+    /// - `SPI0 RX  `
+    /// - `UART1 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM2 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio4 { name: gpio4 },
+
+    /// GPIO 5 supports following functions:
+    /// - `SPI0 CSn `
+    /// - `UART1 RX `
+    /// - `I2C0 SCL`
+    /// - `PWM2 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio5 { name: gpio5 },
+
+    /// GPIO 6 supports following functions:
+    /// - `SPI0 SCK `
+    /// - `UART1 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM3 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio6 { name: gpio6 },
+
+    /// GPIO 7 supports following functions:
+    /// - `SPI0 TX  `
+    /// - `UART1 RTS`
+    /// - `I2C1 SCL`
+    /// - `PWM3 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio7 { name: gpio7 },
+
+    /// GPIO 8 supports following functions:
+    /// - `SPI1 RX  `
+    /// - `UART1 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM4 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio8 { name: gpio8 },
+
+    /// GPIO 9 supports following functions:
+    /// - `SPI1 CSn `
+    /// - `UART1 RX `
+    /// - `I2C0 SCL`
+    /// - `PWM4 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio9 { name: gpio9 },
+
+    /// GPIO 10 supports following functions:
+    /// - `SPI1 SCK`
+    /// - `UART1 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM5 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio10 { name: gpio10 },
+
+    /// GPIO 11 supports following functions:
+    /// - `SPI1 TX `
+    /// - `UART1 RTS`
+    /// - `I2C1 SCL`
+    /// - `PWM5 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio11 { name: gpio11 },
+
+    /// GPIO 12 supports following functions:
+    /// - `SPI1 RX `
+    /// - `UART0 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM6 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio12 { name: gpio12 },
+
+    /// GPIO 13 supports following functions:
+    /// - `SPI1 CSn`
+    /// - `UART0 RX `
+    /// - `I2C0 SCL`
+    /// - `PWM6 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio13 { name: gpio13 },
+
+    /// GPIO 14 supports following functions:
+    /// - `SPI1 SCK`
+    /// - `UART0 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM7 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio14 { name: gpio14 },
+
+    /// GPIO 15 supports following functions:
+    /// - `SPI1 TX `
+    /// - `UART0 RTS`
+    /// - `I2C1 SCL`
+    /// - `PWM7 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio15 { name: gpio15 },
+
+    /// GPIO 16 supports following functions:
+    /// - `SPI0 RX `
+    /// - `UART0 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM0 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio16 { name: gpio16 },
+
+    /// GPIO 17 supports following functions:
+    /// - `SPI0 CSn`
+    /// - `UART0 RX `
+    /// - `I2C0 SCL`
+    /// - `PWM0 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio17 { name: gpio17 },
+
+    /// GPIO 18 supports following functions:
+    /// - `SPI0 SCK`
+    /// - `UART0 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM1 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio18 { name: gpio18 },
+
+    /// GPIO 19 supports following functions:
+    /// - `SPI0 TX `
+    /// - `UART0 RTS`
+    /// - `I2C1 SCL`
+    /// - `PWM1 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio19 { name: gpio19 },
+
+    /// GPIO 20 supports following functions:
+    /// - `SPI0 RX `
+    /// - `UART1 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM2 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio20 { name: gpio20 },
+
+    /// GPIO 21 supports following functions:
+    /// - `SPI0 CSn`
+    /// - `UART1 RX `
+    /// - `I2C0 SCL`
+    /// - `PWM2 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio21 { name: gpio21 },
+
+    /// GPIO 22 supports following functions:
+    /// - `SPI0 SCK`
+    /// - `UART1 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM3 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio22 { name: gpio22 },
+
+    /// GPIO 23 is connected to b_power_save of the Raspberry Pi Pico board.
     Gpio23 { name: b_power_save },
+
+    /// GPIO 24 is connected to vbus_detect of the Raspberry Pi Pico board.
     Gpio24 { name: vbus_detect },
+
+    /// GPIO 25 is connected to the LED of the Raspberry Pi Pico board.
     Gpio25 { name: led },
+
+    /// GPIO 26 supports following functions:
+    /// - `SPI1 SCK`
+    /// - `UART1 CTS`
+    /// - `I2C1 SDA`
+    /// - `PWM5 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio26 { name: gpio26 },
+
+    /// GPIO 27 supports following functions:
+    /// - `SPI1 TX `
+    /// - `UART1 RTS`
+    /// - `I2C1 SCL`
+    /// - `PWM5 B`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio27 { name: gpio27 },
+
+    /// GPIO 28 supports following functions:
+    /// - `SPI1 RX `
+    /// - `UART0 TX `
+    /// - `I2C0 SDA`
+    /// - `PWM6 A`
+    /// - `SIO`, `PIO0`, `PIO1`
     Gpio28 { name: gpio28 },
-    Gpio29 {
-        name: voltage_monitor
-    },
+
+    /// GPIO 29 is connected to voltage_monitor of the Raspberry Pi Pico board.
+    Gpio29 { name: voltage_monitor },
 );
 
 pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;

--- a/boards/rp-pico/src/lib.rs
+++ b/boards/rp-pico/src/lib.rs
@@ -19,224 +19,752 @@ pub use hal::pac;
 
 hal::bsp_pins!(
     /// GPIO 0 supports following functions:
-    /// - `SPI0 RX`
-    /// - `UART0 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM0 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio0 { name: gpio0 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 RX` | [crate::Gp0Spi0Rx] |
+    /// | `UART0 TX` | [crate::Gp0Uart0Tx] |
+    /// | `I2C0 SDA` | [crate::Gp0I2C0Sda] |
+    /// | `PWM0 A` | [crate::Gp0Pwm0A] |
+    /// | `PIO0` | [crate::Gp0Pio0] |
+    /// | `PIO1` | [crate::Gp0Pio1] |
+    Gpio0 {
+        name: gpio0,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio0].
+            FunctionUart: Gp0Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio0].
+            FunctionSpi: Gp0Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio0].
+            FunctionI2C: Gp0I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio0].
+            FunctionPwm: Gp0Pwm0A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio0: Gp0Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio1: Gp0Pio1
+        }
+    },
 
     /// GPIO 1 supports following functions:
-    /// - `SPI0 CSn`
-    /// - `UART0 RX`
-    /// - `I2C0 SCL`
-    /// - `PWM0 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio1 { name: gpio1 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 CSn` | [crate::Gp1Spi0Csn] |
+    /// | `UART0 RX` | [crate::Gp1Uart0Rx] |
+    /// | `I2C0 SCL` | [crate::Gp1I2C0Scl] |
+    /// | `PWM0 B` | [crate::Gp1Pwm0B] |
+    /// | `PIO0` | [crate::Gp1Pio0] |
+    /// | `PIO1` | [crate::Gp1Pio1] |
+    Gpio1 {
+        name: gpio1,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio1].
+            FunctionUart: Gp1Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio1].
+            FunctionSpi: Gp1Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio1].
+            FunctionI2C: Gp1I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio1].
+            FunctionPwm: Gp1Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio0: Gp1Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio1: Gp1Pio1
+        }
+    },
 
     /// GPIO 2 supports following functions:
-    /// - `SPI0 SCK`
-    /// - `UART0 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM1 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio2 { name: gpio2 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 SCK` | [crate::Gp2Spi0Sck] |
+    /// | `UART0 CTS` | [crate::Gp2Uart0Cts] |
+    /// | `I2C1 SDA` | [crate::Gp2I2C1Sda] |
+    /// | `PWM1 A` | [crate::Gp2Pwm1A] |
+    /// | `PIO0` | [crate::Gp2Pio0] |
+    /// | `PIO1` | [crate::Gp2Pio1] |
+    Gpio2 {
+        name: gpio2,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio2].
+            FunctionUart: Gp2Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio2].
+            FunctionSpi: Gp2Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio2].
+            FunctionI2C: Gp2I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio2].
+            FunctionPwm: Gp2Pwm1A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio2].
+            FunctionPio0: Gp2Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio2].
+            FunctionPio1: Gp2Pio1
+        }
+    },
 
     /// GPIO 3 supports following functions:
-    /// - `SPI0 TX`
-    /// - `UART0 RTS`
-    /// - `I2C1 SCL`
-    /// - `PWM1 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio3 { name: gpio3 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 TX` | [crate::Gp3Spi0Tx] |
+    /// | `UART0 RTS` | [crate::Gp3Uart0Rts] |
+    /// | `I2C1 SCL` | [crate::Gp3I2C1Scl] |
+    /// | `PWM1 B` | [crate::Gp3Pwm1B] |
+    /// | `PIO0` | [crate::Gp3Pio0] |
+    /// | `PIO1` | [crate::Gp3Pio1] |
+    Gpio3 {
+        name: gpio3,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio3].
+            FunctionUart: Gp3Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio3].
+            FunctionSpi: Gp3Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio3].
+            FunctionI2C: Gp3I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio3].
+            FunctionPwm: Gp3Pwm1B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio3].
+            FunctionPio0: Gp3Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio3].
+            FunctionPio1: Gp3Pio1
+        }
+    },
 
     /// GPIO 4 supports following functions:
-    /// - `SPI0 RX`
-    /// - `UART1 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM2 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio4 { name: gpio4 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 RX` | [crate::Gp4Spi0Rx] |
+    /// | `UART1 TX` | [crate::Gp4Uart1Tx] |
+    /// | `I2C0 SDA` | [crate::Gp4I2C0Sda] |
+    /// | `PWM2 A` | [crate::Gp4Pwm2A] |
+    /// | `PIO0` | [crate::Gp4Pio0] |
+    /// | `PIO1` | [crate::Gp4Pio1] |
+    Gpio4 {
+        name: gpio4,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio4].
+            FunctionUart: Gp4Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio4].
+            FunctionSpi: Gp4Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio4].
+            FunctionI2C: Gp4I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio4].
+            FunctionPwm: Gp4Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio0: Gp4Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio1: Gp4Pio1
+        }
+    },
 
     /// GPIO 5 supports following functions:
-    /// - `SPI0 CSn`
-    /// - `UART1 RX`
-    /// - `I2C0 SCL`
-    /// - `PWM2 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio5 { name: gpio5 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 CSn` | [crate::Gp5Spi0Csn] |
+    /// | `UART1 RX` | [crate::Gp5Uart1Rx] |
+    /// | `I2C0 SCL` | [crate::Gp5I2C0Scl] |
+    /// | `PWM2 B` | [crate::Gp5Pwm2B] |
+    /// | `PIO0` | [crate::Gp5Pio0] |
+    /// | `PIO1` | [crate::Gp5Pio1] |
+    Gpio5 {
+        name: gpio5,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio5].
+            FunctionUart: Gp5Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio5].
+            FunctionSpi: Gp5Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio5].
+            FunctionI2C: Gp5I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio5].
+            FunctionPwm: Gp5Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio0: Gp5Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio1: Gp5Pio1
+        }
+    },
 
     /// GPIO 6 supports following functions:
-    /// - `SPI0 SCK`
-    /// - `UART1 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM3 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio6 { name: gpio6 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 SCK` | [crate::Gp6Spi0Sck] |
+    /// | `UART1 CTS` | [crate::Gp6Uart1Cts] |
+    /// | `I2C1 SDA` | [crate::Gp6I2C1Sda] |
+    /// | `PWM3 A` | [crate::Gp6Pwm3A] |
+    /// | `PIO0` | [crate::Gp6Pio0] |
+    /// | `PIO1` | [crate::Gp6Pio1] |
+    Gpio6 {
+        name: gpio6,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio6].
+            FunctionUart: Gp6Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio6].
+            FunctionSpi: Gp6Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio6].
+            FunctionI2C: Gp6I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio6].
+            FunctionPwm: Gp6Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio0: Gp6Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio1: Gp6Pio1
+        }
+    },
 
     /// GPIO 7 supports following functions:
-    /// - `SPI0 TX`
-    /// - `UART1 RTS`
-    /// - `I2C1 SCL`
-    /// - `PWM3 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio7 { name: gpio7 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 TX` | [crate::Gp7Spi0Tx] |
+    /// | `UART1 RTS` | [crate::Gp7Uart1Rts] |
+    /// | `I2C1 SCL` | [crate::Gp7I2C1Scl] |
+    /// | `PWM3 B` | [crate::Gp7Pwm3B] |
+    /// | `PIO0` | [crate::Gp7Pio0] |
+    /// | `PIO1` | [crate::Gp7Pio1] |
+    Gpio7 {
+        name: gpio7,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio7].
+            FunctionUart: Gp7Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio7].
+            FunctionSpi: Gp7Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio7].
+            FunctionI2C: Gp7I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio7].
+            FunctionPwm: Gp7Pwm3B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio0: Gp7Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio1: Gp7Pio1
+        }
+    },
 
     /// GPIO 8 supports following functions:
-    /// - `SPI1 RX`
-    /// - `UART1 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM4 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio8 { name: gpio8 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 RX` | [crate::Gp8Spi1Rx] |
+    /// | `UART1 TX` | [crate::Gp8Uart1Tx] |
+    /// | `I2C0 SDA` | [crate::Gp8I2C0Sda] |
+    /// | `PWM4 A` | [crate::Gp8Pwm4A] |
+    /// | `PIO0` | [crate::Gp8Pio0] |
+    /// | `PIO1` | [crate::Gp8Pio1] |
+    Gpio8 {
+        name: gpio8,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio8].
+            FunctionUart: Gp8Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio8].
+            FunctionSpi: Gp8Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio8].
+            FunctionI2C: Gp8I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio8].
+            FunctionPwm: Gp8Pwm4A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio0: Gp8Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio1: Gp8Pio1
+        }
+    },
 
     /// GPIO 9 supports following functions:
-    /// - `SPI1 CSn`
-    /// - `UART1 RX`
-    /// - `I2C0 SCL`
-    /// - `PWM4 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio9 { name: gpio9 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 CSn` | [crate::Gp9Spi1Csn] |
+    /// | `UART1 RX` | [crate::Gp9Uart1Rx] |
+    /// | `I2C0 SCL` | [crate::Gp9I2C0Scl] |
+    /// | `PWM4 B` | [crate::Gp9Pwm4B] |
+    /// | `PIO0` | [crate::Gp9Pio0] |
+    /// | `PIO1` | [crate::Gp9Pio1] |
+    Gpio9 {
+        name: gpio9,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio9].
+            FunctionUart: Gp9Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio9].
+            FunctionSpi: Gp9Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio9].
+            FunctionI2C: Gp9I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio9].
+            FunctionPwm: Gp9Pwm4B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio0: Gp9Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio1: Gp9Pio1
+        }
+    },
 
     /// GPIO 10 supports following functions:
-    /// - `SPI1 SCK`
-    /// - `UART1 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM5 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio10 { name: gpio10 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 SCK` | [crate::Gp10Spi1Sck] |
+    /// | `UART1 CTS` | [crate::Gp10Uart1Cts] |
+    /// | `I2C1 SDA` | [crate::Gp10I2C1Sda] |
+    /// | `PWM5 A` | [crate::Gp10Pwm5A] |
+    /// | `PIO0` | [crate::Gp10Pio0] |
+    /// | `PIO1` | [crate::Gp10Pio1] |
+    Gpio10 {
+        name: gpio10,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio10].
+            FunctionUart: Gp10Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio10].
+            FunctionSpi: Gp10Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio10].
+            FunctionI2C: Gp10I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio10].
+            FunctionPwm: Gp10Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio10].
+            FunctionPio0: Gp10Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio10].
+            FunctionPio1: Gp10Pio1
+        }
+    },
 
     /// GPIO 11 supports following functions:
-    /// - `SPI1 TX`
-    /// - `UART1 RTS`
-    /// - `I2C1 SCL`
-    /// - `PWM5 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio11 { name: gpio11 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 TX` | [crate::Gp11Spi1Tx] |
+    /// | `UART1 RTS` | [crate::Gp11Uart1Rts] |
+    /// | `I2C1 SCL` | [crate::Gp11I2C1Scl] |
+    /// | `PWM5 B` | [crate::Gp11Pwm5B] |
+    /// | `PIO0` | [crate::Gp11Pio0] |
+    /// | `PIO1` | [crate::Gp11Pio1] |
+    Gpio11 {
+        name: gpio11,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio11].
+            FunctionUart: Gp11Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio11].
+            FunctionSpi: Gp11Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio11].
+            FunctionI2C: Gp11I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio11].
+            FunctionPwm: Gp11Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio11].
+            FunctionPio0: Gp11Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio11].
+            FunctionPio1: Gp11Pio1
+        }
+    },
 
     /// GPIO 12 supports following functions:
-    /// - `SPI1 RX`
-    /// - `UART0 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM6 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio12 { name: gpio12 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 RX` | [crate::Gp12Spi1Rx] |
+    /// | `UART0 TX` | [crate::Gp12Uart0Tx] |
+    /// | `I2C0 SDA` | [crate::Gp12I2C0Sda] |
+    /// | `PWM6 A` | [crate::Gp12Pwm6A] |
+    /// | `PIO0` | [crate::Gp12Pio0] |
+    /// | `PIO1` | [crate::Gp12Pio1] |
+    Gpio12 {
+        name: gpio12,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio12].
+            FunctionUart: Gp12Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio12].
+            FunctionSpi: Gp12Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio12].
+            FunctionI2C: Gp12I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio12].
+            FunctionPwm: Gp12Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio12].
+            FunctionPio0: Gp12Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio12].
+            FunctionPio1: Gp12Pio1
+        }
+    },
 
     /// GPIO 13 supports following functions:
-    /// - `SPI1 CSn`
-    /// - `UART0 RX`
-    /// - `I2C0 SCL`
-    /// - `PWM6 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio13 { name: gpio13 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 CSn` | [crate::Gp13Spi1Csn] |
+    /// | `UART0 RX` | [crate::Gp13Uart0Rx] |
+    /// | `I2C0 SCL` | [crate::Gp13I2C0Scl] |
+    /// | `PWM6 B` | [crate::Gp13Pwm6B] |
+    /// | `PIO0` | [crate::Gp13Pio0] |
+    /// | `PIO1` | [crate::Gp13Pio1] |
+    Gpio13 {
+        name: gpio13,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio13].
+            FunctionUart: Gp13Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio13].
+            FunctionSpi: Gp13Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio13].
+            FunctionI2C: Gp13I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio13].
+            FunctionPwm: Gp13Pwm6B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio13].
+            FunctionPio0: Gp13Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio13].
+            FunctionPio1: Gp13Pio1
+        }
+    },
 
     /// GPIO 14 supports following functions:
-    /// - `SPI1 SCK`
-    /// - `UART0 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM7 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio14 { name: gpio14 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 SCK` | [crate::Gp14Spi1Sck] |
+    /// | `UART0 CTS` | [crate::Gp14Uart0Cts] |
+    /// | `I2C1 SDA` | [crate::Gp14I2C1Sda] |
+    /// | `PWM7 A` | [crate::Gp14Pwm7A] |
+    /// | `PIO0` | [crate::Gp14Pio0] |
+    /// | `PIO1` | [crate::Gp14Pio1] |
+    Gpio14 {
+        name: gpio14,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio14].
+            FunctionUart: Gp14Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio14].
+            FunctionSpi: Gp14Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio14].
+            FunctionI2C: Gp14I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio14].
+            FunctionPwm: Gp14Pwm7A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio14].
+            FunctionPio0: Gp14Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio14].
+            FunctionPio1: Gp14Pio1
+        }
+    },
 
     /// GPIO 15 supports following functions:
-    /// - `SPI1 TX`
-    /// - `UART0 RTS`
-    /// - `I2C1 SCL`
-    /// - `PWM7 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio15 { name: gpio15 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 TX` | [crate::Gp15Spi1Tx] |
+    /// | `UART0 RTS` | [crate::Gp15Uart0Rts] |
+    /// | `I2C1 SCL` | [crate::Gp15I2C1Scl] |
+    /// | `PWM7 B` | [crate::Gp15Pwm7B] |
+    /// | `PIO0` | [crate::Gp15Pio0] |
+    /// | `PIO1` | [crate::Gp15Pio1] |
+    Gpio15 {
+        name: gpio15,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio15].
+            FunctionUart: Gp15Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio15].
+            FunctionSpi: Gp15Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio15].
+            FunctionI2C: Gp15I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio15].
+            FunctionPwm: Gp15Pwm7B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio15].
+            FunctionPio0: Gp15Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio15].
+            FunctionPio1: Gp15Pio1
+        }
+    },
 
     /// GPIO 16 supports following functions:
-    /// - `SPI0 RX`
-    /// - `UART0 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM0 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio16 { name: gpio16 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 RX` | [crate::Gp16Spi0Rx] |
+    /// | `UART0 TX` | [crate::Gp16Uart0Tx] |
+    /// | `I2C0 SDA` | [crate::Gp16I2C0Sda] |
+    /// | `PWM0 A` | [crate::Gp16Pwm0A] |
+    /// | `PIO0` | [crate::Gp16Pio0] |
+    /// | `PIO1` | [crate::Gp16Pio1] |
+    Gpio16 {
+        name: gpio16,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio16].
+            FunctionUart: Gp16Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio16].
+            FunctionSpi: Gp16Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio16].
+            FunctionI2C: Gp16I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio16].
+            FunctionPwm: Gp16Pwm0A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio16].
+            FunctionPio0: Gp16Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio16].
+            FunctionPio1: Gp16Pio1
+        }
+    },
 
     /// GPIO 17 supports following functions:
-    /// - `SPI0 CSn`
-    /// - `UART0 RX`
-    /// - `I2C0 SCL`
-    /// - `PWM0 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio17 { name: gpio17 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 CSn` | [crate::Gp17Spi0Csn] |
+    /// | `UART0 RX` | [crate::Gp17Uart0Rx] |
+    /// | `I2C0 SCL` | [crate::Gp17I2C0Scl] |
+    /// | `PWM0 B` | [crate::Gp17Pwm0B] |
+    /// | `PIO0` | [crate::Gp17Pio0] |
+    /// | `PIO1` | [crate::Gp17Pio1] |
+    Gpio17 {
+        name: gpio17,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio17].
+            FunctionUart: Gp17Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio17].
+            FunctionSpi: Gp17Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio17].
+            FunctionI2C: Gp17I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio17].
+            FunctionPwm: Gp17Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio0: Gp17Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio1: Gp17Pio1
+        }
+    },
 
     /// GPIO 18 supports following functions:
-    /// - `SPI0 SCK`
-    /// - `UART0 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM1 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio18 { name: gpio18 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 SCK` | [crate::Gp18Spi0Sck] |
+    /// | `UART0 CTS` | [crate::Gp18Uart0Cts] |
+    /// | `I2C1 SDA` | [crate::Gp18I2C1Sda] |
+    /// | `PWM1 A` | [crate::Gp18Pwm1A] |
+    /// | `PIO0` | [crate::Gp18Pio0] |
+    /// | `PIO1` | [crate::Gp18Pio1] |
+    Gpio18 {
+        name: gpio18,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio18].
+            FunctionUart: Gp18Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio18].
+            FunctionSpi: Gp18Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio18].
+            FunctionI2C: Gp18I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio18].
+            FunctionPwm: Gp18Pwm1A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio18].
+            FunctionPio0: Gp18Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio18].
+            FunctionPio1: Gp18Pio1
+        }
+    },
 
     /// GPIO 19 supports following functions:
-    /// - `SPI0 TX`
-    /// - `UART0 RTS`
-    /// - `I2C1 SCL`
-    /// - `PWM1 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio19 { name: gpio19 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 TX` | [crate::Gp19Spi0Tx] |
+    /// | `UART0 RTS` | [crate::Gp19Uart0Rts] |
+    /// | `I2C1 SCL` | [crate::Gp19I2C1Scl] |
+    /// | `PWM1 B` | [crate::Gp19Pwm1B] |
+    /// | `PIO0` | [crate::Gp19Pio0] |
+    /// | `PIO1` | [crate::Gp19Pio1] |
+    Gpio19 {
+        name: gpio19,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio19].
+            FunctionUart: Gp19Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio19].
+            FunctionSpi: Gp19Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio19].
+            FunctionI2C: Gp19I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio19].
+            FunctionPwm: Gp19Pwm1B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio19].
+            FunctionPio0: Gp19Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio19].
+            FunctionPio1: Gp19Pio1
+        }
+    },
 
     /// GPIO 20 supports following functions:
-    /// - `SPI0 RX`
-    /// - `UART1 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM2 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio20 { name: gpio20 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 RX` | [crate::Gp20Spi0Rx] |
+    /// | `UART1 TX` | [crate::Gp20Uart1Tx] |
+    /// | `I2C0 SDA` | [crate::Gp20I2C0Sda] |
+    /// | `PWM2 A` | [crate::Gp20Pwm2A] |
+    /// | `PIO0` | [crate::Gp20Pio0] |
+    /// | `PIO1` | [crate::Gp20Pio1] |
+    Gpio20 {
+        name: gpio20,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio20].
+            FunctionUart: Gp20Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio20].
+            FunctionSpi: Gp20Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio20].
+            FunctionI2C: Gp20I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio20].
+            FunctionPwm: Gp20Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio0: Gp20Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio1: Gp20Pio1
+        }
+    },
 
     /// GPIO 21 supports following functions:
-    /// - `SPI0 CSn`
-    /// - `UART1 RX`
-    /// - `I2C0 SCL`
-    /// - `PWM2 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio21 { name: gpio21 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 CSn` | [crate::Gp21Spi0Csn] |
+    /// | `UART1 RX` | [crate::Gp21Uart1Rx] |
+    /// | `I2C0 SCL` | [crate::Gp21I2C0Scl] |
+    /// | `PWM2 B` | [crate::Gp21Pwm2B] |
+    /// | `PIO0` | [crate::Gp21Pio0] |
+    /// | `PIO1` | [crate::Gp21Pio1] |
+    Gpio21 {
+        name: gpio21,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio21].
+            FunctionUart: Gp21Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio21].
+            FunctionSpi: Gp21Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio21].
+            FunctionI2C: Gp21I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio21].
+            FunctionPwm: Gp21Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio0: Gp21Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio1: Gp21Pio1
+        }
+    },
 
     /// GPIO 22 supports following functions:
-    /// - `SPI0 SCK`
-    /// - `UART1 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM3 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio22 { name: gpio22 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI0 SCK` | [crate::Gp22Spi0Sck] |
+    /// | `UART1 CTS` | [crate::Gp22Uart1Cts] |
+    /// | `I2C1 SDA` | [crate::Gp22I2C1Sda] |
+    /// | `PWM3 A` | [crate::Gp22Pwm3A] |
+    /// | `PIO0` | [crate::Gp22Pio0] |
+    /// | `PIO1` | [crate::Gp22Pio1] |
+    Gpio22 {
+        name: gpio22,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio22].
+            FunctionUart: Gp22Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio22].
+            FunctionSpi: Gp22Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio22].
+            FunctionI2C: Gp22I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio22].
+            FunctionPwm: Gp22Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio0: Gp22Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio1: Gp22Pio1
+        }
+    },
 
     /// GPIO 23 is connected to b_power_save of the Raspberry Pi Pico board.
-    Gpio23 { name: b_power_save },
+    Gpio23 {
+        name: b_power_save,
+    },
 
     /// GPIO 24 is connected to vbus_detect of the Raspberry Pi Pico board.
-    Gpio24 { name: vbus_detect },
+    Gpio24 {
+        name: vbus_detect,
+    },
 
-    /// GPIO 25 is connected to the LED of the Raspberry Pi Pico board.
-    Gpio25 { name: led },
+    /// GPIO 25 is connected to led of the Raspberry Pi Pico board.
+    Gpio25 {
+        name: led,
+    },
 
     /// GPIO 26 supports following functions:
-    /// - `SPI1 SCK`
-    /// - `UART1 CTS`
-    /// - `I2C1 SDA`
-    /// - `PWM5 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio26 { name: gpio26 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 SCK` | [crate::Gp26Spi1Sck] |
+    /// | `UART1 CTS` | [crate::Gp26Uart1Cts] |
+    /// | `I2C1 SDA` | [crate::Gp26I2C1Sda] |
+    /// | `PWM5 A` | [crate::Gp26Pwm5A] |
+    /// | `PIO0` | [crate::Gp26Pio0] |
+    /// | `PIO1` | [crate::Gp26Pio1] |
+    Gpio26 {
+        name: gpio26,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio26].
+            FunctionUart: Gp26Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio26].
+            FunctionSpi: Gp26Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio26].
+            FunctionI2C: Gp26I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio26].
+            FunctionPwm: Gp26Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio0: Gp26Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio1: Gp26Pio1
+        }
+    },
 
     /// GPIO 27 supports following functions:
-    /// - `SPI1 TX`
-    /// - `UART1 RTS`
-    /// - `I2C1 SCL`
-    /// - `PWM5 B`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio27 { name: gpio27 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 TX` | [crate::Gp27Spi1Tx] |
+    /// | `UART1 RTS` | [crate::Gp27Uart1Rts] |
+    /// | `I2C1 SCL` | [crate::Gp27I2C1Scl] |
+    /// | `PWM5 B` | [crate::Gp27Pwm5B] |
+    /// | `PIO0` | [crate::Gp27Pio0] |
+    /// | `PIO1` | [crate::Gp27Pio1] |
+    Gpio27 {
+        name: gpio27,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio27].
+            FunctionUart: Gp27Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio27].
+            FunctionSpi: Gp27Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio27].
+            FunctionI2C: Gp27I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio27].
+            FunctionPwm: Gp27Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio0: Gp27Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio1: Gp27Pio1
+        }
+    },
 
     /// GPIO 28 supports following functions:
-    /// - `SPI1 RX`
-    /// - `UART0 TX`
-    /// - `I2C0 SDA`
-    /// - `PWM6 A`
-    /// - `SIO`, `PIO0`, `PIO1`
-    Gpio28 { name: gpio28 },
+    ///
+    /// | Function | Alias with applied function |
+    /// |-|-|
+    /// | `SPI1 RX` | [crate::Gp28Spi1Rx] |
+    /// | `UART0 TX` | [crate::Gp28Uart0Tx] |
+    /// | `I2C0 SDA` | [crate::Gp28I2C0Sda] |
+    /// | `PWM6 A` | [crate::Gp28Pwm6A] |
+    /// | `PIO0` | [crate::Gp28Pio0] |
+    /// | `PIO1` | [crate::Gp28Pio1] |
+    Gpio28 {
+        name: gpio28,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio28].
+            FunctionUart: Gp28Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio28].
+            FunctionSpi: Gp28Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio28].
+            FunctionI2C: Gp28I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio28].
+            FunctionPwm: Gp28Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio0: Gp28Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio1: Gp28Pio1
+        }
+    },
 
     /// GPIO 29 is connected to voltage_monitor of the Raspberry Pi Pico board.
-    Gpio29 { name: voltage_monitor },
+    Gpio29 {
+        name: voltage_monitor,
+    },
 );
 
 pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;

--- a/boards/rp-pico/src/lib.rs
+++ b/boards/rp-pico/src/lib.rs
@@ -20,14 +20,14 @@ pub use hal::pac;
 hal::bsp_pins!(
     /// GPIO 0 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 RX` | [crate::Gp0Spi0Rx] |
-    /// | `UART0 TX` | [crate::Gp0Uart0Tx] |
-    /// | `I2C0 SDA` | [crate::Gp0I2C0Sda] |
-    /// | `PWM0 A` | [crate::Gp0Pwm0A] |
-    /// | `PIO0` | [crate::Gp0Pio0] |
-    /// | `PIO1` | [crate::Gp0Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp0Spi0Rx]          |
+    /// | `UART0 TX`   | [crate::Gp0Uart0Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp0I2C0Sda]         |
+    /// | `PWM0 A`     | [crate::Gp0Pwm0A]           |
+    /// | `PIO0`       | [crate::Gp0Pio0]            |
+    /// | `PIO1`       | [crate::Gp0Pio1]            |
     Gpio0 {
         name: gpio0,
         aliases: {
@@ -48,14 +48,14 @@ hal::bsp_pins!(
 
     /// GPIO 1 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 CSn` | [crate::Gp1Spi0Csn] |
-    /// | `UART0 RX` | [crate::Gp1Uart0Rx] |
-    /// | `I2C0 SCL` | [crate::Gp1I2C0Scl] |
-    /// | `PWM0 B` | [crate::Gp1Pwm0B] |
-    /// | `PIO0` | [crate::Gp1Pio0] |
-    /// | `PIO1` | [crate::Gp1Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp1Spi0Csn]         |
+    /// | `UART0 RX`   | [crate::Gp1Uart0Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp1I2C0Scl]         |
+    /// | `PWM0 B`     | [crate::Gp1Pwm0B]           |
+    /// | `PIO0`       | [crate::Gp1Pio0]            |
+    /// | `PIO1`       | [crate::Gp1Pio1]            |
     Gpio1 {
         name: gpio1,
         aliases: {
@@ -76,14 +76,14 @@ hal::bsp_pins!(
 
     /// GPIO 2 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 SCK` | [crate::Gp2Spi0Sck] |
-    /// | `UART0 CTS` | [crate::Gp2Uart0Cts] |
-    /// | `I2C1 SDA` | [crate::Gp2I2C1Sda] |
-    /// | `PWM1 A` | [crate::Gp2Pwm1A] |
-    /// | `PIO0` | [crate::Gp2Pio0] |
-    /// | `PIO1` | [crate::Gp2Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp2Spi0Sck]         |
+    /// | `UART0 CTS`  | [crate::Gp2Uart0Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp2I2C1Sda]         |
+    /// | `PWM1 A`     | [crate::Gp2Pwm1A]           |
+    /// | `PIO0`       | [crate::Gp2Pio0]            |
+    /// | `PIO1`       | [crate::Gp2Pio1]            |
     Gpio2 {
         name: gpio2,
         aliases: {
@@ -104,14 +104,14 @@ hal::bsp_pins!(
 
     /// GPIO 3 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 TX` | [crate::Gp3Spi0Tx] |
-    /// | `UART0 RTS` | [crate::Gp3Uart0Rts] |
-    /// | `I2C1 SCL` | [crate::Gp3I2C1Scl] |
-    /// | `PWM1 B` | [crate::Gp3Pwm1B] |
-    /// | `PIO0` | [crate::Gp3Pio0] |
-    /// | `PIO1` | [crate::Gp3Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp3Spi0Tx]          |
+    /// | `UART0 RTS`  | [crate::Gp3Uart0Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp3I2C1Scl]         |
+    /// | `PWM1 B`     | [crate::Gp3Pwm1B]           |
+    /// | `PIO0`       | [crate::Gp3Pio0]            |
+    /// | `PIO1`       | [crate::Gp3Pio1]            |
     Gpio3 {
         name: gpio3,
         aliases: {
@@ -132,14 +132,14 @@ hal::bsp_pins!(
 
     /// GPIO 4 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 RX` | [crate::Gp4Spi0Rx] |
-    /// | `UART1 TX` | [crate::Gp4Uart1Tx] |
-    /// | `I2C0 SDA` | [crate::Gp4I2C0Sda] |
-    /// | `PWM2 A` | [crate::Gp4Pwm2A] |
-    /// | `PIO0` | [crate::Gp4Pio0] |
-    /// | `PIO1` | [crate::Gp4Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp4Spi0Rx]          |
+    /// | `UART1 TX`   | [crate::Gp4Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp4I2C0Sda]         |
+    /// | `PWM2 A`     | [crate::Gp4Pwm2A]           |
+    /// | `PIO0`       | [crate::Gp4Pio0]            |
+    /// | `PIO1`       | [crate::Gp4Pio1]            |
     Gpio4 {
         name: gpio4,
         aliases: {
@@ -160,14 +160,14 @@ hal::bsp_pins!(
 
     /// GPIO 5 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 CSn` | [crate::Gp5Spi0Csn] |
-    /// | `UART1 RX` | [crate::Gp5Uart1Rx] |
-    /// | `I2C0 SCL` | [crate::Gp5I2C0Scl] |
-    /// | `PWM2 B` | [crate::Gp5Pwm2B] |
-    /// | `PIO0` | [crate::Gp5Pio0] |
-    /// | `PIO1` | [crate::Gp5Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp5Spi0Csn]         |
+    /// | `UART1 RX`   | [crate::Gp5Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp5I2C0Scl]         |
+    /// | `PWM2 B`     | [crate::Gp5Pwm2B]           |
+    /// | `PIO0`       | [crate::Gp5Pio0]            |
+    /// | `PIO1`       | [crate::Gp5Pio1]            |
     Gpio5 {
         name: gpio5,
         aliases: {
@@ -188,14 +188,14 @@ hal::bsp_pins!(
 
     /// GPIO 6 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 SCK` | [crate::Gp6Spi0Sck] |
-    /// | `UART1 CTS` | [crate::Gp6Uart1Cts] |
-    /// | `I2C1 SDA` | [crate::Gp6I2C1Sda] |
-    /// | `PWM3 A` | [crate::Gp6Pwm3A] |
-    /// | `PIO0` | [crate::Gp6Pio0] |
-    /// | `PIO1` | [crate::Gp6Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp6Spi0Sck]         |
+    /// | `UART1 CTS`  | [crate::Gp6Uart1Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp6I2C1Sda]         |
+    /// | `PWM3 A`     | [crate::Gp6Pwm3A]           |
+    /// | `PIO0`       | [crate::Gp6Pio0]            |
+    /// | `PIO1`       | [crate::Gp6Pio1]            |
     Gpio6 {
         name: gpio6,
         aliases: {
@@ -216,14 +216,14 @@ hal::bsp_pins!(
 
     /// GPIO 7 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 TX` | [crate::Gp7Spi0Tx] |
-    /// | `UART1 RTS` | [crate::Gp7Uart1Rts] |
-    /// | `I2C1 SCL` | [crate::Gp7I2C1Scl] |
-    /// | `PWM3 B` | [crate::Gp7Pwm3B] |
-    /// | `PIO0` | [crate::Gp7Pio0] |
-    /// | `PIO1` | [crate::Gp7Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp7Spi0Tx]          |
+    /// | `UART1 RTS`  | [crate::Gp7Uart1Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp7I2C1Scl]         |
+    /// | `PWM3 B`     | [crate::Gp7Pwm3B]           |
+    /// | `PIO0`       | [crate::Gp7Pio0]            |
+    /// | `PIO1`       | [crate::Gp7Pio1]            |
     Gpio7 {
         name: gpio7,
         aliases: {
@@ -244,14 +244,14 @@ hal::bsp_pins!(
 
     /// GPIO 8 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 RX` | [crate::Gp8Spi1Rx] |
-    /// | `UART1 TX` | [crate::Gp8Uart1Tx] |
-    /// | `I2C0 SDA` | [crate::Gp8I2C0Sda] |
-    /// | `PWM4 A` | [crate::Gp8Pwm4A] |
-    /// | `PIO0` | [crate::Gp8Pio0] |
-    /// | `PIO1` | [crate::Gp8Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp8Spi1Rx]          |
+    /// | `UART1 TX`   | [crate::Gp8Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp8I2C0Sda]         |
+    /// | `PWM4 A`     | [crate::Gp8Pwm4A]           |
+    /// | `PIO0`       | [crate::Gp8Pio0]            |
+    /// | `PIO1`       | [crate::Gp8Pio1]            |
     Gpio8 {
         name: gpio8,
         aliases: {
@@ -272,14 +272,14 @@ hal::bsp_pins!(
 
     /// GPIO 9 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 CSn` | [crate::Gp9Spi1Csn] |
-    /// | `UART1 RX` | [crate::Gp9Uart1Rx] |
-    /// | `I2C0 SCL` | [crate::Gp9I2C0Scl] |
-    /// | `PWM4 B` | [crate::Gp9Pwm4B] |
-    /// | `PIO0` | [crate::Gp9Pio0] |
-    /// | `PIO1` | [crate::Gp9Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp9Spi1Csn]         |
+    /// | `UART1 RX`   | [crate::Gp9Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp9I2C0Scl]         |
+    /// | `PWM4 B`     | [crate::Gp9Pwm4B]           |
+    /// | `PIO0`       | [crate::Gp9Pio0]            |
+    /// | `PIO1`       | [crate::Gp9Pio1]            |
     Gpio9 {
         name: gpio9,
         aliases: {
@@ -300,14 +300,14 @@ hal::bsp_pins!(
 
     /// GPIO 10 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 SCK` | [crate::Gp10Spi1Sck] |
-    /// | `UART1 CTS` | [crate::Gp10Uart1Cts] |
-    /// | `I2C1 SDA` | [crate::Gp10I2C1Sda] |
-    /// | `PWM5 A` | [crate::Gp10Pwm5A] |
-    /// | `PIO0` | [crate::Gp10Pio0] |
-    /// | `PIO1` | [crate::Gp10Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp10Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp10Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp10I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp10Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp10Pio0]           |
+    /// | `PIO1`       | [crate::Gp10Pio1]           |
     Gpio10 {
         name: gpio10,
         aliases: {
@@ -328,14 +328,14 @@ hal::bsp_pins!(
 
     /// GPIO 11 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 TX` | [crate::Gp11Spi1Tx] |
-    /// | `UART1 RTS` | [crate::Gp11Uart1Rts] |
-    /// | `I2C1 SCL` | [crate::Gp11I2C1Scl] |
-    /// | `PWM5 B` | [crate::Gp11Pwm5B] |
-    /// | `PIO0` | [crate::Gp11Pio0] |
-    /// | `PIO1` | [crate::Gp11Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp11Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp11Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp11I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp11Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp11Pio0]           |
+    /// | `PIO1`       | [crate::Gp11Pio1]           |
     Gpio11 {
         name: gpio11,
         aliases: {
@@ -356,14 +356,14 @@ hal::bsp_pins!(
 
     /// GPIO 12 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 RX` | [crate::Gp12Spi1Rx] |
-    /// | `UART0 TX` | [crate::Gp12Uart0Tx] |
-    /// | `I2C0 SDA` | [crate::Gp12I2C0Sda] |
-    /// | `PWM6 A` | [crate::Gp12Pwm6A] |
-    /// | `PIO0` | [crate::Gp12Pio0] |
-    /// | `PIO1` | [crate::Gp12Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp12Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp12Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp12I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp12Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp12Pio0]           |
+    /// | `PIO1`       | [crate::Gp12Pio1]           |
     Gpio12 {
         name: gpio12,
         aliases: {
@@ -384,14 +384,14 @@ hal::bsp_pins!(
 
     /// GPIO 13 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 CSn` | [crate::Gp13Spi1Csn] |
-    /// | `UART0 RX` | [crate::Gp13Uart0Rx] |
-    /// | `I2C0 SCL` | [crate::Gp13I2C0Scl] |
-    /// | `PWM6 B` | [crate::Gp13Pwm6B] |
-    /// | `PIO0` | [crate::Gp13Pio0] |
-    /// | `PIO1` | [crate::Gp13Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp13Spi1Csn]        |
+    /// | `UART0 RX`   | [crate::Gp13Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp13I2C0Scl]        |
+    /// | `PWM6 B`     | [crate::Gp13Pwm6B]          |
+    /// | `PIO0`       | [crate::Gp13Pio0]           |
+    /// | `PIO1`       | [crate::Gp13Pio1]           |
     Gpio13 {
         name: gpio13,
         aliases: {
@@ -412,14 +412,14 @@ hal::bsp_pins!(
 
     /// GPIO 14 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 SCK` | [crate::Gp14Spi1Sck] |
-    /// | `UART0 CTS` | [crate::Gp14Uart0Cts] |
-    /// | `I2C1 SDA` | [crate::Gp14I2C1Sda] |
-    /// | `PWM7 A` | [crate::Gp14Pwm7A] |
-    /// | `PIO0` | [crate::Gp14Pio0] |
-    /// | `PIO1` | [crate::Gp14Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp14Spi1Sck]        |
+    /// | `UART0 CTS`  | [crate::Gp14Uart0Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp14I2C1Sda]        |
+    /// | `PWM7 A`     | [crate::Gp14Pwm7A]          |
+    /// | `PIO0`       | [crate::Gp14Pio0]           |
+    /// | `PIO1`       | [crate::Gp14Pio1]           |
     Gpio14 {
         name: gpio14,
         aliases: {
@@ -440,14 +440,14 @@ hal::bsp_pins!(
 
     /// GPIO 15 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 TX` | [crate::Gp15Spi1Tx] |
-    /// | `UART0 RTS` | [crate::Gp15Uart0Rts] |
-    /// | `I2C1 SCL` | [crate::Gp15I2C1Scl] |
-    /// | `PWM7 B` | [crate::Gp15Pwm7B] |
-    /// | `PIO0` | [crate::Gp15Pio0] |
-    /// | `PIO1` | [crate::Gp15Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp15Spi1Tx]         |
+    /// | `UART0 RTS`  | [crate::Gp15Uart0Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp15I2C1Scl]        |
+    /// | `PWM7 B`     | [crate::Gp15Pwm7B]          |
+    /// | `PIO0`       | [crate::Gp15Pio0]           |
+    /// | `PIO1`       | [crate::Gp15Pio1]           |
     Gpio15 {
         name: gpio15,
         aliases: {
@@ -468,14 +468,14 @@ hal::bsp_pins!(
 
     /// GPIO 16 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 RX` | [crate::Gp16Spi0Rx] |
-    /// | `UART0 TX` | [crate::Gp16Uart0Tx] |
-    /// | `I2C0 SDA` | [crate::Gp16I2C0Sda] |
-    /// | `PWM0 A` | [crate::Gp16Pwm0A] |
-    /// | `PIO0` | [crate::Gp16Pio0] |
-    /// | `PIO1` | [crate::Gp16Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp16Spi0Rx]         |
+    /// | `UART0 TX`   | [crate::Gp16Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp16I2C0Sda]        |
+    /// | `PWM0 A`     | [crate::Gp16Pwm0A]          |
+    /// | `PIO0`       | [crate::Gp16Pio0]           |
+    /// | `PIO1`       | [crate::Gp16Pio1]           |
     Gpio16 {
         name: gpio16,
         aliases: {
@@ -496,14 +496,14 @@ hal::bsp_pins!(
 
     /// GPIO 17 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 CSn` | [crate::Gp17Spi0Csn] |
-    /// | `UART0 RX` | [crate::Gp17Uart0Rx] |
-    /// | `I2C0 SCL` | [crate::Gp17I2C0Scl] |
-    /// | `PWM0 B` | [crate::Gp17Pwm0B] |
-    /// | `PIO0` | [crate::Gp17Pio0] |
-    /// | `PIO1` | [crate::Gp17Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp17Spi0Csn]        |
+    /// | `UART0 RX`   | [crate::Gp17Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp17I2C0Scl]        |
+    /// | `PWM0 B`     | [crate::Gp17Pwm0B]          |
+    /// | `PIO0`       | [crate::Gp17Pio0]           |
+    /// | `PIO1`       | [crate::Gp17Pio1]           |
     Gpio17 {
         name: gpio17,
         aliases: {
@@ -524,14 +524,14 @@ hal::bsp_pins!(
 
     /// GPIO 18 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 SCK` | [crate::Gp18Spi0Sck] |
-    /// | `UART0 CTS` | [crate::Gp18Uart0Cts] |
-    /// | `I2C1 SDA` | [crate::Gp18I2C1Sda] |
-    /// | `PWM1 A` | [crate::Gp18Pwm1A] |
-    /// | `PIO0` | [crate::Gp18Pio0] |
-    /// | `PIO1` | [crate::Gp18Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp18Spi0Sck]        |
+    /// | `UART0 CTS`  | [crate::Gp18Uart0Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp18I2C1Sda]        |
+    /// | `PWM1 A`     | [crate::Gp18Pwm1A]          |
+    /// | `PIO0`       | [crate::Gp18Pio0]           |
+    /// | `PIO1`       | [crate::Gp18Pio1]           |
     Gpio18 {
         name: gpio18,
         aliases: {
@@ -552,14 +552,14 @@ hal::bsp_pins!(
 
     /// GPIO 19 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 TX` | [crate::Gp19Spi0Tx] |
-    /// | `UART0 RTS` | [crate::Gp19Uart0Rts] |
-    /// | `I2C1 SCL` | [crate::Gp19I2C1Scl] |
-    /// | `PWM1 B` | [crate::Gp19Pwm1B] |
-    /// | `PIO0` | [crate::Gp19Pio0] |
-    /// | `PIO1` | [crate::Gp19Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp19Spi0Tx]         |
+    /// | `UART0 RTS`  | [crate::Gp19Uart0Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp19I2C1Scl]        |
+    /// | `PWM1 B`     | [crate::Gp19Pwm1B]          |
+    /// | `PIO0`       | [crate::Gp19Pio0]           |
+    /// | `PIO1`       | [crate::Gp19Pio1]           |
     Gpio19 {
         name: gpio19,
         aliases: {
@@ -580,14 +580,14 @@ hal::bsp_pins!(
 
     /// GPIO 20 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 RX` | [crate::Gp20Spi0Rx] |
-    /// | `UART1 TX` | [crate::Gp20Uart1Tx] |
-    /// | `I2C0 SDA` | [crate::Gp20I2C0Sda] |
-    /// | `PWM2 A` | [crate::Gp20Pwm2A] |
-    /// | `PIO0` | [crate::Gp20Pio0] |
-    /// | `PIO1` | [crate::Gp20Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp20Spi0Rx]         |
+    /// | `UART1 TX`   | [crate::Gp20Uart1Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp20I2C0Sda]        |
+    /// | `PWM2 A`     | [crate::Gp20Pwm2A]          |
+    /// | `PIO0`       | [crate::Gp20Pio0]           |
+    /// | `PIO1`       | [crate::Gp20Pio1]           |
     Gpio20 {
         name: gpio20,
         aliases: {
@@ -608,14 +608,14 @@ hal::bsp_pins!(
 
     /// GPIO 21 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 CSn` | [crate::Gp21Spi0Csn] |
-    /// | `UART1 RX` | [crate::Gp21Uart1Rx] |
-    /// | `I2C0 SCL` | [crate::Gp21I2C0Scl] |
-    /// | `PWM2 B` | [crate::Gp21Pwm2B] |
-    /// | `PIO0` | [crate::Gp21Pio0] |
-    /// | `PIO1` | [crate::Gp21Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp21Spi0Csn]        |
+    /// | `UART1 RX`   | [crate::Gp21Uart1Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp21I2C0Scl]        |
+    /// | `PWM2 B`     | [crate::Gp21Pwm2B]          |
+    /// | `PIO0`       | [crate::Gp21Pio0]           |
+    /// | `PIO1`       | [crate::Gp21Pio1]           |
     Gpio21 {
         name: gpio21,
         aliases: {
@@ -636,14 +636,14 @@ hal::bsp_pins!(
 
     /// GPIO 22 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI0 SCK` | [crate::Gp22Spi0Sck] |
-    /// | `UART1 CTS` | [crate::Gp22Uart1Cts] |
-    /// | `I2C1 SDA` | [crate::Gp22I2C1Sda] |
-    /// | `PWM3 A` | [crate::Gp22Pwm3A] |
-    /// | `PIO0` | [crate::Gp22Pio0] |
-    /// | `PIO1` | [crate::Gp22Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp22Spi0Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp22Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp22I2C1Sda]        |
+    /// | `PWM3 A`     | [crate::Gp22Pwm3A]          |
+    /// | `PIO0`       | [crate::Gp22Pio0]           |
+    /// | `PIO1`       | [crate::Gp22Pio1]           |
     Gpio22 {
         name: gpio22,
         aliases: {
@@ -679,14 +679,14 @@ hal::bsp_pins!(
 
     /// GPIO 26 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 SCK` | [crate::Gp26Spi1Sck] |
-    /// | `UART1 CTS` | [crate::Gp26Uart1Cts] |
-    /// | `I2C1 SDA` | [crate::Gp26I2C1Sda] |
-    /// | `PWM5 A` | [crate::Gp26Pwm5A] |
-    /// | `PIO0` | [crate::Gp26Pio0] |
-    /// | `PIO1` | [crate::Gp26Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp26Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp26Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp26I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp26Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp26Pio0]           |
+    /// | `PIO1`       | [crate::Gp26Pio1]           |
     Gpio26 {
         name: gpio26,
         aliases: {
@@ -707,14 +707,14 @@ hal::bsp_pins!(
 
     /// GPIO 27 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 TX` | [crate::Gp27Spi1Tx] |
-    /// | `UART1 RTS` | [crate::Gp27Uart1Rts] |
-    /// | `I2C1 SCL` | [crate::Gp27I2C1Scl] |
-    /// | `PWM5 B` | [crate::Gp27Pwm5B] |
-    /// | `PIO0` | [crate::Gp27Pio0] |
-    /// | `PIO1` | [crate::Gp27Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp27Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp27Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp27I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp27Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp27Pio0]           |
+    /// | `PIO1`       | [crate::Gp27Pio1]           |
     Gpio27 {
         name: gpio27,
         aliases: {
@@ -735,14 +735,14 @@ hal::bsp_pins!(
 
     /// GPIO 28 supports following functions:
     ///
-    /// | Function | Alias with applied function |
-    /// |-|-|
-    /// | `SPI1 RX` | [crate::Gp28Spi1Rx] |
-    /// | `UART0 TX` | [crate::Gp28Uart0Tx] |
-    /// | `I2C0 SDA` | [crate::Gp28I2C0Sda] |
-    /// | `PWM6 A` | [crate::Gp28Pwm6A] |
-    /// | `PIO0` | [crate::Gp28Pio0] |
-    /// | `PIO1` | [crate::Gp28Pio1] |
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp28Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp28Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp28I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp28Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp28Pio0]           |
+    /// | `PIO1`       | [crate::Gp28Pio1]           |
     Gpio28 {
         name: gpio28,
         aliases: {

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -1102,9 +1102,15 @@ macro_rules! bsp_pins {
             ///
             /// like this:
             ///```no_run
-            /// let _spi_sclk = pins.gpio2.into_mode::<gpio::FunctionSpi>();
-            /// let _spi_mosi = pins.gpio3.into_mode::<gpio::FunctionSpi>();
-            /// let _spi_miso = pins.gpio4.into_mode::<gpio::FunctionSpi>();
+            /// use rp2040_hal::{pac, gpio::{bank0::Gpio12, Pin, Pins, PushPullOutput}, sio::Sio};
+            ///
+            /// let mut peripherals = pac::Peripherals::take().unwrap();
+            /// let sio = Sio::new(peripherals.SIO);
+            /// let pins = Pins::new(peripherals.IO_BANK0,peripherals.PADS_BANK0,sio.gpio_bank0, &mut peripherals.RESETS);
+            ///
+            /// let _spi_sclk = pins.gpio2.into_mode::<rp2040_hal::gpio::FunctionSpi>();
+            /// let _spi_mosi = pins.gpio3.into_mode::<rp2040_hal::gpio::FunctionSpi>();
+            /// let _spi_miso = pins.gpio4.into_mode::<rp2040_hal::gpio::FunctionSpi>();
             ///```
             ///
             /// **See also [rp2040_hal::gpio::pin] for more in depth information

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -1088,6 +1088,27 @@ macro_rules! bsp_pins {
             ///
             /// This type is intended to provide more meaningful names for the
             /// given pins.
+            ///
+            /// To enable specific functions of the pins you can use the
+            /// [rp2040_hal::gpio::pin::Pin::into_mode] function with
+            /// one of:
+            /// - [rp2040_hal::gpio::pin::FunctionI2C]
+            /// - [rp2040_hal::gpio::pin::FunctionPwm]
+            /// - [rp2040_hal::gpio::pin::FunctionSpi]
+            /// - [rp2040_hal::gpio::pin::FunctionXip]
+            /// - [rp2040_hal::gpio::pin::FunctionPio0]
+            /// - [rp2040_hal::gpio::pin::FunctionPio1]
+            /// - [rp2040_hal::gpio::pin::FunctionUart]
+            ///
+            /// like this:
+            ///```no_run
+            /// let _spi_sclk = pins.gpio2.into_mode::<gpio::FunctionSpi>();
+            /// let _spi_mosi = pins.gpio3.into_mode::<gpio::FunctionSpi>();
+            /// let _spi_miso = pins.gpio4.into_mode::<gpio::FunctionSpi>();
+            ///```
+            ///
+            /// **See also [rp2040_hal::gpio::pin] for more in depth information
+            /// about this**!
             pub struct Pins {
                 $(
                     $( #[$id_cfg] )*


### PR DESCRIPTION
I don't know if this is useful or if it is out of scope of the board specific documentation, but I quickly (half automatically via script) converted the rp2040 datasheet section 1.4.3 to board specific pin documentation.

Like I already wrote on Matrix, I would love to do this for `rp2040_hal::gpio::pin::bank0` too, but the macro does not support documentation meta information and I don't know how to add it.