### PR TITLE
Add Solder Party RP2040 Stamp board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "boards/pimoroni-pico-explorer",
     "boards/pimoroni-pico-lipo-16mb",
     "boards/rp-pico",
+    "boards/solderparty-rp2040-stamp",
     "boards/sparkfun-pro-micro-rp2040",
 ]
 

--- a/boards/solderparty-rp2040-stamp/Cargo.toml
+++ b/boards/solderparty-rp2040-stamp/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "solderparty-rp2040-stamp"
+version = "0.1.0"
+authors = ["The rp-rs Developers"]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/solderparty-rp2040-stamp"
+description = "Board Support Package for the Solder Party RP2040 Stamp"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rp-rs/rp-hal.git"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.7.2"
+rp2040-boot2 = { version = "0.2.0", optional = true }
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
+cortex-m-rt = { version = "0.7", optional = true }
+
+[features]
+default = ["rt", "boot2"]
+boot2 = ["rp2040-boot2"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]
+
+[dev-dependencies]
+panic-halt= "0.2.0"
+embedded-hal ="0.2.5"
+nb = "1.0.0"
+smart-leds = "0.3.0"
+pio = "0.1.0"
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+embedded-time = "0.12.0"

--- a/boards/solderparty-rp2040-stamp/README.md
+++ b/boards/solderparty-rp2040-stamp/README.md
@@ -1,0 +1,94 @@
+# [solderparty-rp2040-stamp] - Board Support for the [Solder Party RP2040 Stamp]
+
+You should include this crate if you are writing code that you want to run on
+a [Solder Party RP2040 Stamp]
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Stamp
+
+[Solder Party RP2040 Stamp]: https://www.solder.party/docs/rp2040-stamp/
+[solderparty-rp2040-stamp]: https://github.com/rp-rs/rp-hal/tree/main/boards/solderparty-rp2040-stamp
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+[Raspberry Silicon RP2040]: https://www.raspberrypi.org/products/rp2040/
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+solderparty-rp2040-stamp = { git = "https://github.com/rp-rs/rp-hal.git" }
+```
+
+In your program, you will need to call `solderparty_rp2040_stamp::Pins::new` to create
+a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal_ repository and run:
+
+```console
+rp-hal/boards/solderparty-rp2040-stamp $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal/boards/solderparty-rp2040-stamp $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs, then repeating the `cargo run` command above.
+```
+
+### [solderparty_stamp_neopixel_rainbow](./examples/solderparty_stamp_neopixel_rainbow.rs)
+
+Flows smoothly through various colors on the Feather's onboard NeoPixel LED.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be, learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can chose either the MIT licence or the
+Apache-2.0 licence when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific licence.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/solderparty-rp2040-stamp/examples/solderparty_stamp_neopixel_rainbow.rs
+++ b/boards/solderparty-rp2040-stamp/examples/solderparty_stamp_neopixel_rainbow.rs
@@ -1,0 +1,96 @@
+//! Rainbow effect color wheel using the onboard NeoPixel on an Solder Party Stamp RP2040 board
+//!
+//! This flows smoothly through various colors on the onboard NeoPixel.
+//! Uses the `ws2812_pio` driver to control the NeoPixel, which in turns uses the
+//! RP2040's PIO block.
+#![no_std]
+#![no_main]
+
+use core::iter::once;
+use cortex_m_rt::entry;
+use embedded_hal::timer::CountDown;
+use embedded_time::duration::Extensions;
+use panic_halt as _;
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+use solderparty_rp2040_stamp::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        pio::PIOExt,
+        timer::Timer,
+        watchdog::Watchdog,
+        Sio,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+use ws2812_pio::Ws2812;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
+    let mut delay = timer.count_down();
+
+    // Configure the addressable LED
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+    let mut ws = Ws2812::new(
+        // The onboard NeoPixel is attached to GPIO pin #21 on the RP2040 Stamp.
+        pins.neopixel.into_mode(),
+        &mut pio,
+        sm0,
+        clocks.peripheral_clock.freq(),
+        timer.count_down(),
+    );
+
+    // Infinite colour wheel loop
+    let mut n: u8 = 128;
+    loop {
+        ws.write(brightness(once(wheel(n)), 32)).unwrap();
+        n = n.wrapping_add(1);
+
+        delay.start(25.milliseconds());
+        let _ = nb::block!(delay.wait());
+    }
+}
+
+/// Convert a number from `0..=255` to an RGB color triplet.
+///
+/// The colours are a transition from red, to green, to blue and back to red.
+fn wheel(mut wheel_pos: u8) -> RGB8 {
+    wheel_pos = 255 - wheel_pos;
+    if wheel_pos < 85 {
+        // No green in this sector - red and blue only
+        (255 - (wheel_pos * 3), 0, wheel_pos * 3).into()
+    } else if wheel_pos < 170 {
+        // No red in this sector - green and blue only
+        wheel_pos -= 85;
+        (0, wheel_pos * 3, 255 - (wheel_pos * 3)).into()
+    } else {
+        // No blue in this sector - red and green only
+        wheel_pos -= 170;
+        (wheel_pos * 3, 255 - (wheel_pos * 3), 0).into()
+    }
+}

--- a/boards/solderparty-rp2040-stamp/src/lib.rs
+++ b/boards/solderparty-rp2040-stamp/src/lib.rs
@@ -1,0 +1,53 @@
+#![no_std]
+
+pub use rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_GD25Q64CS;
+
+pub use hal::pac;
+
+hal::bsp_pins!(
+    Gpio0 { name: gpio0 },
+    Gpio1 { name: gpio1 },
+    Gpio2 { name: gpio2 },
+    Gpio3 { name: gpio3 },
+    Gpio4 { name: gpio4 },
+    Gpio5 { name: gpio5 },
+    Gpio6 { name: gpio6 },
+    Gpio7 { name: gpio7 },
+    Gpio8 { name: gpio8 },
+    Gpio9 { name: gpio9 },
+    Gpio10 { name: gpio10 },
+    Gpio11 { name: gpio11 },
+    Gpio12 { name: gpio12 },
+    Gpio13 { name: gpio13 },
+    Gpio14 { name: gpio14 },
+    Gpio15 { name: gpio15 },
+    Gpio16 { name: gpio16 },
+    Gpio17 { name: gpio17 },
+    Gpio18 { name: gpio18 },
+    Gpio19 { name: gpio19 },
+    Gpio20 { name: gpio20 },
+    Gpio21 { name: neopixel },
+    Gpio22 { name: gpio22 },
+    Gpio23 { name: gpio23 },
+    Gpio24 { name: gpio24 },
+    Gpio25 { name: gpio25 },
+    Gpio26 { name: gpio26 },
+    Gpio27 { name: gpio27 },
+    Gpio28 { name: gpio28 },
+    Gpio29 { name: gpio29 },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
Add support for the [RP2040 Stamp board](https://www.solder.party/docs/rp2040-stamp/) by Solder Party.

This board has a single "device" - a neopixel. The example I included for this is copied and updated from the feather board example.