### PR TITLE
Board support for Adafruit Trinkey QT2040

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "boards/adafruit-kb2040",
     "boards/adafruit-macropad",
     "boards/adafruit-qt-py-rp2040",
+    "boards/adafruit-trinkey-qt2040",
     "boards/pimoroni-pico-explorer",
     "boards/pimoroni-pico-lipo-16mb",
     "boards/rp-pico",

--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ RP2040 chip according to how it is connected up on the Feather RP2040.
 [Adafruit QT Py RP2040]: https://www.adafruit.com/product/4900
 [adafruit-qt-py-rp2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-qt-py-rp2040
 
+### [adafruit-trinkey-qt2040] - Board Support for the [Adafruit Trinkey QT2040]
+
+You should include this crate if you are writing code that you want to run on
+an [Adafruit Trinkey QT2040] - a 3x4 keyboard and OLED combo board from Adafruit.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Trinkey.
+
+[Adafruit-Trinkey-QT2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-trinkey-qt2040
+[adafruit trinkey qt2040]: https://www.adafruit.com/product/5056
+
 ### [pimoroni-pico-explorer] - Board Support for the [Pimoroni Pico Explorer]
 
 You should include this crate if you are writing code that you want to run on

--- a/boards/adafruit-trinkey-qt2040/Cargo.toml
+++ b/boards/adafruit-trinkey-qt2040/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "adafruit-trinkey-qt2040"
+version = "0.1.0"
+authors = ["The rp-rs Developers"]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-trinkey-qt2040"
+description = "Board Support Package for the Adafruit Trinkey QT2040"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rp-rs/rp-hal.git"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0" }
+cortex-m-rt = { version = "0.7.0", optional = true }
+rp2040-boot2 = { version = "0.2.0", optional = true }
+
+[dev-dependencies]
+panic-halt= "0.2.0"
+embedded-hal ="0.2.5"
+embedded-time = "0.12.0"
+smart-leds = "0.3"
+nb = "1.0.0"
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+
+[features]
+default = ["boot2", "rt"]
+boot2 = ["rp2040-boot2"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/adafruit-trinkey-qt2040/README.md
+++ b/boards/adafruit-trinkey-qt2040/README.md
@@ -1,0 +1,93 @@
+# [adafruit-trinkey-qt2040] - Board Support for the [Adafruit Trinkey QT2040]
+
+You should include this crate if you are writing code that you want to run on
+an [Adafruit Trinkey QT2040] - a 3x4 keyboard and OLED combo board from Adafruit.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Trinkey.
+
+[adafruit-trinkey-qt2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-trinkey-qt2040
+[adafruit trinkey qt2040]: https://www.adafruit.com/product/5056
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+adafruit-trinkey-qt2040 = "0.1.0"
+```
+
+In your program, you will need to call `adafruit-trinkey-qt2040::Pins::new` to create
+a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal_ repository and run:
+
+```console
+rp-hal/boards/adafruit-trinkey-qt2040 $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal/boards/adafruit-trinkey-qt2040 $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs, then repeating the `cargo run` command above.
+```
+
+### [Rainbow](./examples/adafruit_trinkey_qt2040_rainbow.rs)
+
+This example will display a colour-wheel rainbow effect on the on-board LED.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][coc], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[coc]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can chose either the MIT licence or the
+Apache-2.0 licence when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific licence.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/adafruit-trinkey-qt2040/examples/adafruit_trinkey_qt2040_rainbow.rs
+++ b/boards/adafruit-trinkey-qt2040/examples/adafruit_trinkey_qt2040_rainbow.rs
@@ -1,0 +1,109 @@
+//! # Rainbow Example for the Adafruit Trinkey QT2040
+//!
+//! Runs a rainbow-effect colour wheel on the on-board LED.
+//!
+//! Uses the `ws2812_pio` driver to control the LED, which in turns uses the
+//! RP2040's PIO block.
+
+#![no_std]
+#![no_main]
+
+use core::iter::once;
+use cortex_m_rt::entry;
+use embedded_hal::timer::CountDown;
+use embedded_time::duration::Extensions;
+use panic_halt as _;
+
+use adafruit_trinkey_qt2040::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        pio::PIOExt,
+        timer::Timer,
+        watchdog::Watchdog,
+        Sio,
+    },
+    XOSC_CRYSTAL_FREQ,
+};
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+use ws2812_pio::Ws2812;
+
+/// Entry point to our bare-metal application.
+///
+/// The `#[entry]` macro ensures the Cortex-M start-up code calls this
+/// function as soon as all global variables are initialised.
+///
+/// The function configures the RP2040 peripherals, then the LED, then runs
+/// the colour wheel in an infinite loop.
+#[entry]
+fn main() -> ! {
+    // Configure the RP2040 peripherals
+
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = Sio::new(pac.SIO);
+
+    let pins = adafruit_trinkey_qt2040::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
+    let mut delay = timer.count_down();
+
+    // Configure the addressable LED
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+
+    let mut ws = Ws2812::new(
+        pins.neopixel.into_mode(),
+        &mut pio,
+        sm0,
+        clocks.peripheral_clock.freq(),
+        timer.count_down(),
+    );
+
+    // Infinite colour wheel loop
+
+    let mut n: u8 = 128;
+    loop {
+        ws.write(brightness(once(wheel(n)), 32)).unwrap();
+        n = n.wrapping_add(1);
+
+        delay.start(25.milliseconds());
+        let _ = nb::block!(delay.wait());
+    }
+}
+
+/// Convert a number from `0..=255` to an RGB color triplet.
+///
+/// The colours are a transition from red, to green, to blue and back to red.
+fn wheel(mut wheel_pos: u8) -> RGB8 {
+    wheel_pos = 255 - wheel_pos;
+    if wheel_pos < 85 {
+        // No green in this sector - red and blue only
+        (255 - (wheel_pos * 3), 0, wheel_pos * 3).into()
+    } else if wheel_pos < 170 {
+        // No red in this sector - green and blue only
+        wheel_pos -= 85;
+        (0, wheel_pos * 3, 255 - (wheel_pos * 3)).into()
+    } else {
+        // No blue in this sector - red and green only
+        wheel_pos -= 170;
+        (wheel_pos * 3, 255 - (wheel_pos * 3), 0).into()
+    }
+}

--- a/boards/adafruit-trinkey-qt2040/src/lib.rs
+++ b/boards/adafruit-trinkey-qt2040/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+
+pub extern crate rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+pub use hal::pac;
+
+hal::bsp_pins!(
+    Gpio12 { name: button },
+    Gpio16 {
+        name: sda,
+        aliases: { FunctionI2C: Sda }
+    },
+    Gpio17 {
+        name: scl,
+        aliases: { FunctionI2C: Scl }
+    },
+    Gpio27 { name: neopixel },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
Includes rainbow example. Tested on a board plugged into a Pi 4 Model B.