### PR TITLE
Use .freq() to avoid moving clock

### DIFF
--- a/rp2040-hal/examples/uart.rs
+++ b/rp2040-hal/examples/uart.rs
@@ -91,7 +91,7 @@ fn main() -> ! {
     let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
         .enable(
             hal::uart::common_configs::_9600_8_N_1,
-            clocks.peripheral_clock.into(),
+            clocks.peripheral_clock.freq(),
         )
         .unwrap();
 


### PR DESCRIPTION
The original uart example passed the peripheral clock by calling
```rust
clocks.peripheral_clock.into()
```
which *moves* the peripheral clock, not very helpful for an example.
By getting an integer representation first via
```rust
clocks.peripheral_clock.freq(),
```
we get a copy of the value so other peripherals (like a 2nd UART) can still be initialised