### PR TITLE
WIP: port to new PAC spinlock syntax

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -16,7 +16,8 @@ eh1_0_alpha = { version = "=1.0.0-alpha.6", package="embedded-hal", optional=tru
 embedded-time = "0.12.0"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
-rp2040-pac = "0.2.0"
+# TODO: move to rp2040-pac > 0.2.0 before merging!
+rp2040-pac = { git="https://github.com/rp-rs/rp2040-pac" }
 paste = "1.0"
 pio = "0.1.0"
 usb-device = "0.2.8"

--- a/rp2040-hal/src/critical_section_impl.rs
+++ b/rp2040-hal/src/critical_section_impl.rs
@@ -41,7 +41,7 @@ unsafe impl critical_section::Impl for RpSpinlockCs {
                 // Ensure the compiler doesn't re-order accesses and violate safety here
                 core::sync::atomic::compiler_fence(Ordering::SeqCst);
                 // Read the spinlock reserved for `critical_section`
-                if (*pac::SIO::ptr()).spinlock31.read().bits() != 0 {
+                if (*pac::SIO::ptr()).spinlock[31].read().bits() != 0 {
                     // We just acquired the lock.
                     // Store which core we are so we can tell if we're called recursively
                     LOCK_OWNER.store(core, Ordering::Relaxed);
@@ -67,7 +67,7 @@ unsafe impl critical_section::Impl for RpSpinlockCs {
             // Ensure the compiler doesn't re-order accesses and violate safety here
             core::sync::atomic::compiler_fence(Ordering::SeqCst);
             // Release the spinlock to allow others to enter critical_section again
-            (*pac::SIO::ptr()).spinlock31.write_with_zero(|w| w.bits(1));
+            (*pac::SIO::ptr()).spinlock[31].write_with_zero(|w| w.bits(1));
             // Re-enable interrupts if they were enabled when we first called acquire()
             // We only do this on the outermost `critical_section` to ensure interrupts stay disabled
             // for the whole time that we have the lock

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -231,7 +231,7 @@ pub trait Spinlock: typelevel::Sealed + Sized {
 }
 
 macro_rules! impl_spinlock {
-    ($($spinlock_name:ident,$spinlock_num:literal)*) => {
+    ($($spinlock_name:ident => $spinlock_num:literal,)*) => {
         $(
             /// Hardware based spinlock.
             ///
@@ -284,38 +284,40 @@ macro_rules! impl_spinlock {
     }
 }
 
-impl_spinlock!(Spinlock0,0);
-impl_spinlock!(Spinlock1,1);
-impl_spinlock!(Spinlock2,2);
-impl_spinlock!(Spinlock3,3);
-impl_spinlock!(Spinlock4,4);
-impl_spinlock!(Spinlock5,5);
-impl_spinlock!(Spinlock6,6);
-impl_spinlock!(Spinlock7,7);
-impl_spinlock!(Spinlock8,8);
-impl_spinlock!(Spinlock9,9);
-impl_spinlock!(Spinlock10,10);
-impl_spinlock!(Spinlock11,11);
-impl_spinlock!(Spinlock12,12);
-impl_spinlock!(Spinlock13,13);
-impl_spinlock!(Spinlock14,14);
-impl_spinlock!(Spinlock15,15);
-impl_spinlock!(Spinlock16,16);
-impl_spinlock!(Spinlock17,17);
-impl_spinlock!(Spinlock18,18);
-impl_spinlock!(Spinlock19,19);
-impl_spinlock!(Spinlock20,20);
-impl_spinlock!(Spinlock21,21);
-impl_spinlock!(Spinlock22,22);
-impl_spinlock!(Spinlock23,23);
-impl_spinlock!(Spinlock24,24);
-impl_spinlock!(Spinlock25,25);
-impl_spinlock!(Spinlock26,26);
-impl_spinlock!(Spinlock27,27);
-impl_spinlock!(Spinlock28,28);
-impl_spinlock!(Spinlock29,29);
-impl_spinlock!(Spinlock30,30);
-impl_spinlock!(Spinlock31,31);
+impl_spinlock! {
+    Spinlock0 => 0,
+    Spinlock1 => 1,
+    Spinlock2 => 2,
+    Spinlock3 => 3,
+    Spinlock4 => 4,
+    Spinlock5 => 5,
+    Spinlock6 => 6,
+    Spinlock7 => 7,
+    Spinlock8 => 8,
+    Spinlock9 => 9,
+    Spinlock10 => 10,
+    Spinlock11 => 11,
+    Spinlock12 => 12,
+    Spinlock13 => 13,
+    Spinlock14 => 14,
+    Spinlock15 => 15,
+    Spinlock16 => 16,
+    Spinlock17 => 17,
+    Spinlock18 => 18,
+    Spinlock19 => 19,
+    Spinlock20 => 20,
+    Spinlock21 => 21,
+    Spinlock22 => 22,
+    Spinlock23 => 23,
+    Spinlock24 => 24,
+    Spinlock25 => 25,
+    Spinlock26 => 26,
+    Spinlock27 => 27,
+    Spinlock28 => 28,
+    Spinlock29 => 29,
+    Spinlock30 => 30,
+    Spinlock31 => 31,
+}
 
 /// Returns the current state of the spinlocks. Each index corresponds to the associated spinlock, e.g. if index `5` is set to `true`, it means that [`Spinlock5`] is currently locked.
 ///

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -229,8 +229,9 @@ pub trait Spinlock: typelevel::Sealed + Sized {
         Self::try_claim().ok_or(nb::Error::WouldBlock)
     }
 }
+
 macro_rules! impl_spinlock {
-    ($($spinlock_name:ident => $register:ident,)*) => {
+    ($($spinlock_name:ident,$spinlock_num:literal)*) => {
         $(
             /// Hardware based spinlock.
             ///
@@ -258,7 +259,7 @@ macro_rules! impl_spinlock {
                 fn try_claim() -> Option<$spinlock_name> {
                     // Safety: We're only reading from this register
                     let sio = unsafe { &*pac::SIO::ptr() };
-                    let lock = sio.$register.read().bits();
+                    let lock = sio.spinlock[$spinlock_num].read().bits();
                     if lock > 0 {
                         Some(Self(core::marker::PhantomData))
                     } else {
@@ -276,47 +277,45 @@ macro_rules! impl_spinlock {
                     let sio = unsafe { &*pac::SIO::ptr() };
 
                     // Write (any value): release the lock
-                    sio.$register.write(|b| unsafe { b.bits(1) });
+                    sio.spinlock[$spinlock_num].write(|b| unsafe { b.bits(1) });
                 }
             }
         )*
     }
 }
 
-impl_spinlock! {
-    Spinlock0 => spinlock0,
-    Spinlock1 => spinlock1,
-    Spinlock2 => spinlock2,
-    Spinlock3 => spinlock3,
-    Spinlock4 => spinlock4,
-    Spinlock5 => spinlock5,
-    Spinlock6 => spinlock6,
-    Spinlock7 => spinlock7,
-    Spinlock8 => spinlock8,
-    Spinlock9 => spinlock9,
-    Spinlock10 => spinlock10,
-    Spinlock11 => spinlock11,
-    Spinlock12 => spinlock12,
-    Spinlock13 => spinlock13,
-    Spinlock14 => spinlock14,
-    Spinlock15 => spinlock15,
-    Spinlock16 => spinlock16,
-    Spinlock17 => spinlock17,
-    Spinlock18 => spinlock18,
-    Spinlock19 => spinlock19,
-    Spinlock20 => spinlock20,
-    Spinlock21 => spinlock21,
-    Spinlock22 => spinlock22,
-    Spinlock23 => spinlock23,
-    Spinlock24 => spinlock24,
-    Spinlock25 => spinlock25,
-    Spinlock26 => spinlock26,
-    Spinlock27 => spinlock27,
-    Spinlock28 => spinlock28,
-    Spinlock29 => spinlock29,
-    Spinlock30 => spinlock30,
-    Spinlock31 => spinlock31,
-}
+impl_spinlock!(Spinlock0,0);
+impl_spinlock!(Spinlock1,1);
+impl_spinlock!(Spinlock2,2);
+impl_spinlock!(Spinlock3,3);
+impl_spinlock!(Spinlock4,4);
+impl_spinlock!(Spinlock5,5);
+impl_spinlock!(Spinlock6,6);
+impl_spinlock!(Spinlock7,7);
+impl_spinlock!(Spinlock8,8);
+impl_spinlock!(Spinlock9,9);
+impl_spinlock!(Spinlock10,10);
+impl_spinlock!(Spinlock11,11);
+impl_spinlock!(Spinlock12,12);
+impl_spinlock!(Spinlock13,13);
+impl_spinlock!(Spinlock14,14);
+impl_spinlock!(Spinlock15,15);
+impl_spinlock!(Spinlock16,16);
+impl_spinlock!(Spinlock17,17);
+impl_spinlock!(Spinlock18,18);
+impl_spinlock!(Spinlock19,19);
+impl_spinlock!(Spinlock20,20);
+impl_spinlock!(Spinlock21,21);
+impl_spinlock!(Spinlock22,22);
+impl_spinlock!(Spinlock23,23);
+impl_spinlock!(Spinlock24,24);
+impl_spinlock!(Spinlock25,25);
+impl_spinlock!(Spinlock26,26);
+impl_spinlock!(Spinlock27,27);
+impl_spinlock!(Spinlock28,28);
+impl_spinlock!(Spinlock29,29);
+impl_spinlock!(Spinlock30,30);
+impl_spinlock!(Spinlock31,31);
 
 /// Returns the current state of the spinlocks. Each index corresponds to the associated spinlock, e.g. if index `5` is set to `true`, it means that [`Spinlock5`] is currently locked.
 ///


### PR DESCRIPTION
Did the minimal work to get the spinlocks working with the new arrayified registers.
The change in macro style was only because that was the easiest thing for me to get working.

We will want to get a new PAC release out before merging this.