### PR TITLE
Add boot2 feature to kb2040 BSP

### DIFF
--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -17,8 +17,9 @@ cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 
 [features]
-default = ["rt"]
-rt = ["cortex-m-rt", "rp2040-hal/rt"]
+default = ["rt", "boot2"]
+boot2 = ["rp2040-boot2"]
+rt = ["cortex-m-rt","rp2040-hal/rt"]
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -15,6 +15,7 @@ cortex-m = "0.7.2"
 rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0" }
 cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
+rp2040-boot2 = { version = "0.2.0", optional = true }
 
 [features]
 default = ["rt", "boot2"]

--- a/boards/adafruit-kb2040/src/lib.rs
+++ b/boards/adafruit-kb2040/src/lib.rs
@@ -6,6 +6,14 @@ extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
 
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
 pub use hal::pac;
 
 hal::bsp_pins!(


### PR DESCRIPTION
I missed this one when updating the others to boot2, maybe this PR was still in progress?