### PR TITLE
Implement intrinsics for the hardware divider

### DIFF
--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -215,6 +215,21 @@ where
     }
 }
 
+// Don't use cortex_m::asm::delay(8) because that ends up delaying 15 cycles
+// on Cortex-M0.  Each iteration of the inner loop is 3 cycles and it adds
+// one extra iteration.
+#[inline(always)]
+fn divider_delay() {
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+    cortex_m::asm::nop();
+}
+
 impl HwDivider {
     /// Perform hardware unsigned divide/modulo operation
     pub fn unsigned(&self, dividend: u32, divisor: u32) -> DivResult<u32> {
@@ -222,7 +237,7 @@ impl HwDivider {
             sio.div_udividend.write(|w| unsafe { w.bits(dividend) });
             sio.div_udivisor.write(|w| unsafe { w.bits(divisor) });
 
-            cortex_m::asm::delay(8);
+            divider_delay();
 
             // Note: quotient must be read last
             let remainder = sio.div_remainder.read().bits();
@@ -243,7 +258,7 @@ impl HwDivider {
             sio.div_sdivisor
                 .write(|w| unsafe { w.bits(divisor as u32) });
 
-            cortex_m::asm::delay(8);
+            divider_delay();
 
             // Note: quotient must be read last
             let remainder = sio.div_remainder.read().bits() as i32;


### PR DESCRIPTION
This implements intrinsics for the hardware divider so normal operators use it instead of the default software implementations.  So with this applied `/` and `%` operations should make use of the hardware divider.  This also makes access to the divider interrupt safe by implementing the save/restore logic used by the Pico SDK. 

Unsurprisingly, there's quite a bit of room for optimization here, when you compare the generated assembly to that hand optimized version in the Pico SDK.  However, in my testing it still results in about a 60% speedup compared to the default software implementations.

To be honest, I'm not completely sure why the override works correctly: the functions defined by [compiler-builtins intrinsics macro](https://github.com/rust-lang/compiler-builtins/blob/ea0cb5b589cc498d629c545e9bae600301ba6aed/src/macros.rs#L61) don't look like they're defined as weak symbols.   However, the generated assembly does the correct thing and the new definitions are used instead.  So this is probably just my failure to understand the whole link chain being used or something about Rust's symbol resolution order, but it does make me a little nervous.

There is also a bit of an oddity in the signed modulus operators: the compiler generates code that uses `__aeabi_idivmod` instead of a more direct `__modsi3` while `__aeabi_idivmod` [isn't defined as a weak symbol](https://github.com/rust-lang/compiler-builtins/blob/ea0cb5b589cc498d629c545e9bae600301ba6aed/src/arm.rs#L81) so we can't override it, and even it if was it'd require a bit of nasty implementation due to the odd way it returns results (remainder in `r1`).  So the modulus operator ends up doing an implied multiply after the division, this isn't a huge deal though since we do have hardware multiplication.  The same applies to `__aeabi_uidivmod` but that at least calls `__udivmodsi4` directly.

### References

[Unsigned intrinsics](https://github.com/rust-lang/compiler-builtins/blob/ea0cb5b589cc498d629c545e9bae600301ba6aed/src/int/udiv.rs)
[Signed intrinsics](https://github.com/rust-lang/compiler-builtins/blob/ea0cb5b589cc498d629c545e9bae600301ba6aed/src/int/sdiv.rs)
[Pico SDK divider](https://github.com/raspberrypi/pico-sdk/blob/2062372d203b372849d573f252cf7c6dc2800c0a/src/rp2_common/pico_divider/divider.S)
[Pico SDK save/restore](https://github.com/raspberrypi/pico-sdk/blob/2062372d203b372849d573f252cf7c6dc2800c0a/src/rp2_common/hardware_divider/include/hardware/divider_helper.S)