### PR TITLE
Use atomic operations for altering Timer alarm interrupts

### DIFF
--- a/boards/rp-pico/examples/pico_rtic.rs
+++ b/boards/rp-pico/examples/pico_rtic.rs
@@ -54,7 +54,7 @@ mod app {
         let mut timer = hal::Timer::new(c.device.TIMER, &mut resets);
         let mut alarm = timer.alarm_0().unwrap();
         let _ = alarm.schedule(SCAN_TIME_US.microseconds());
-        alarm.enable_interrupt(&mut timer);
+        alarm.enable_interrupt();
 
         (Shared { timer, alarm, led }, Local {}, init::Monotonics())
     }
@@ -73,10 +73,9 @@ mod app {
         }
         *c.local.tog = !*c.local.tog;
 
-        let timer = c.shared.timer;
-        let alarm = c.shared.alarm;
-        (timer, alarm).lock(|t, a| {
-            a.clear_interrupt(t);
+        let mut alarm = c.shared.alarm;
+        (alarm).lock(|a| {
+            a.clear_interrupt();
             let _ = a.schedule(SCAN_TIME_US.microseconds());
         });
     }


### PR DESCRIPTION
The existing Alarm implementation uses register.modify() calls to access the interrupt manipulation registers.
To make this a little safer, the original implementer made them all take &mut Timer to ensure there wasn't a data race when performing that RMW.
That's great for safety, but bad for ergonomics.

This PR uses the atomic_clear and atomic_set functions to avoid these data races.
Functionality is largely the same as the PWM interrupt interactions, example:
https://github.com/rp-rs/rp-hal/blob/5771f872f2d08af821ea405d09d12e3d404996b5/rp2040-hal/src/pwm/mod.rs#L385-L391