### PR TITLE
Avoid 64bit division

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,3 +48,7 @@ jobs:
         with:
           command: test
           args: --doc --target x86_64-unknown-linux-gnu --features chrono
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --tests --target x86_64-unknown-linux-gnu

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated embedded-hal alpha support to version 1.0.0-alpha.7
+- Update embedded-hal alpha support to version 1.0.0-alpha.7
+- Avoid 64-bit division in clock calculations
 
 ## [0.3.0] - 2021-12-19
 

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -382,3 +382,43 @@ fn fractional_div(numerator: u32, denominator: u32) -> Option<u32> {
 
     Some((div_int << 8) + div_frac)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fractional_div() {
+        // easy values
+        assert_eq!(fractional_div(1, 1), Some(1 << 8));
+
+        // typical values
+        assert_eq!(fractional_div(125_000_000, 48_000_000), Some(666));
+        assert_eq!(fractional_div(48_000_000, 46875), Some(1024 << 8));
+
+        // resulting frequencies
+        assert_eq!(
+            fractional_div(
+                125_000_000,
+                fractional_div(125_000_000, 48_000_000).unwrap()
+            ),
+            Some(48_048_048)
+        );
+        assert_eq!(
+            fractional_div(48_000_000, fractional_div(48_000_000, 46875).unwrap()),
+            Some(46875)
+        );
+
+        // not allowed in src/clocks/mod.rs, but should still deliver correct results
+        assert_eq!(fractional_div(1, 2), Some(128));
+        assert_eq!(fractional_div(1, 256), Some(1));
+        assert_eq!(fractional_div(1, 257), Some(0));
+
+        // borderline cases
+        assert_eq!(fractional_div((1 << 24) - 1, 1), Some(((1 << 24) - 1) << 8));
+        assert_eq!(fractional_div(1 << 24, 1), None);
+        assert_eq!(fractional_div(1 << 24, 2), Some(1 << (23 + 8)));
+        assert_eq!(fractional_div(1 << 24, (1 << 24) + 1), Some(1 << 8));
+        assert_eq!(fractional_div(u32::MAX, u32::MAX), Some(1 << 8));
+    }
+}

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -99,6 +99,8 @@ impl ShareableClocks {
 }
 
 /// Something when wrong setting up the clock
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ClockError {
     /// The frequency desired is higher than the source frequency
     CantIncreaseFreq,


### PR DESCRIPTION
While looking at the code generated by https://github.com/rp-rs/rp-hal/pull/288, I wondered why there were references to 64bit division code (`compiler_builtins::int::specialized_div_rem::u64_div_rem`) for a basically empty firmware.

Turned out that `init_clocks_and_plls()` contained 64bit integer divisions.

As the code to do those divisions takes about 1kB even in fully optimized builds, I changed the clock calculation code to use 32bit divisions, instead.

To keep the code small, I accepted some minimal additional rounding error: In case the remainder of the division is bigger than 2^24, the lower 8 bits will be thrown away, causing a relative rounding error of at most 2^-16.
(To be exact, instead of the expected rounding-down of normal integer division, the value might get rounded up, instead. The resulting difference from the true value might be even smaller than before.)
