### PR TITLE
Use optimized assembly for hardware division

### DIFF
--- a/rp2040-hal/src/intrinsics.rs
+++ b/rp2040-hal/src/intrinsics.rs
@@ -13,9 +13,10 @@ macro_rules! intrinsics_aliases {
         $($rest:ident)*
     ) => {
         #[cfg(all(target_arch = "arm", not(feature = "disable-intrinsics")))]
-        intrinsics! {
-            extern $abi fn $alias( $($argname: $ty),* ) -> $ret {
-                $name($($argname),*)
+        mod $alias {
+            #[no_mangle]
+            pub extern $abi fn $alias( $($argname: $ty),* ) -> $ret {
+                super::$name($($argname),*)
             }
         }
 
@@ -31,9 +32,10 @@ macro_rules! intrinsics_aliases {
         $($rest:ident)*
     ) => {
         #[cfg(all(target_arch = "arm", not(feature = "disable-intrinsics")))]
-        intrinsics! {
+        mod $alias {
+            #[no_mangle]
             unsafe extern $abi fn $alias( $($argname: $ty),* ) -> $ret {
-                $name($($argname),*)
+                super::$name($($argname),*)
             }
         }
 

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -171,107 +171,159 @@ impl SioFifo {
     }
 }
 
-pub(crate) fn save_divider<F, R>(f: F) -> R
-where
-    F: FnOnce(&pac::sio::RegisterBlock) -> R,
-{
-    let sio = unsafe { &(*pac::SIO::ptr()) };
-    if !sio.div_csr.read().dirty().bit() {
-        // Not dirty, so nothing is waiting for the calculation.  So we can just
-        // issue it directly without a save/restore.
-        f(sio)
-    } else {
-        // Since we can't save the signed-ness of the calculation, we have to make
-        // sure that there's at least an 8 cycle delay before we read the result.
-        // The Pico SDK ensures this by using a 6 cycle push and two 1 cycle reads.
-        // Since we can't be sure the Rust implementation will optimize to the same,
-        // just use an explicit wait.
-        while !sio.div_csr.read().ready().bit() {}
+// This takes advantage of how AAPCS defines a 64-bit return on 32-bit registers
+// by packing it into r0[0:31] and r1[32:63].  So all we need to do is put
+// the remainder in the high order 32 bits of a 64 bit result.   We can also
+// alias the division operators to these for a similar reason r0 is the
+// result either way and r1 a scratch register, so the caller can't assume it
+// retains the argument value.
+#[cfg(target_arch = "arm")]
+core::arch::global_asm!(
+    ".macro hwdivider_head",
+    "ldr    r2, =(0xd0000000)", // SIO_BASE
+    // Check the DIRTY state of the divider by shifting it into the C
+    // status bit.
+    "ldr    r3, [r2, #0x078]", // DIV_CSR
+    "lsrs   r3, #2",           // DIRTY = 1, so shift 2 down
+    // We only need to save the state when DIRTY, otherwise we can just do the
+    // division directly.
+    "bcs    2f",
+    "1:",
+    // Do the actual division now, we're either not DIRTY, or we've saved the
+    // state and branched back here so it's safe now.
+    ".endm",
+    ".macro hwdivider_tail",
+    // 8 cycle delay to wait for the result.  Each branch takes two cycles
+    // and fits into a 2-byte Thumb instruction, so this is smaller than
+    // 8 NOPs.
+    "b      3f",
+    "3: b   3f",
+    "3: b   3f",
+    "3: b   3f",
+    "3:",
+    // Read the quotient last, since that's what clears the dirty flag.
+    "ldr    r1, [r2, #0x074]", // DIV_REMAINDER
+    "ldr    r0, [r2, #0x070]", // DIV_QUOTIENT
+    // Either return to the caller or back to the state restore.
+    "bx     lr",
+    "2:",
+    // Since we can't save the signed-ness of the calculation, we have to make
+    // sure that there's at least an 8 cycle delay before we read the result.
+    // The push takes 5 cycles, and we've already spent at least 7 checking
+    // the DIRTY state to get here.
+    "push   {{r4-r6, lr}}",
+    // Read the quotient last, since that's what clears the dirty flag.
+    "ldr    r3, [r2, #0x060]", // DIV_UDIVIDEND
+    "ldr    r4, [r2, #0x064]", // DIV_UDIVISOR
+    "ldr    r5, [r2, #0x074]", // DIV_REMAINDER
+    "ldr    r6, [r2, #0x070]", // DIV_QUOTIENT
+    // If we get interrupted here (before a write sets the DIRTY flag) it's
+    // fine, since we have the full state, so the interruptor doesn't have to
+    // restore it.  Once the write happens and the DIRTY flag is set, the
+    // interruptor becomes responsible for restoring our state.
+    "bl     1b",
+    // If we are interrupted here, then the interruptor will start an incorrect
+    // calculation using a wrong divisor, but we'll restore the divisor and
+    // result ourselves correctly. This sets DIRTY, so any interruptor will
+    // save the state.
+    "str    r3, [r2, #0x060]", // DIV_UDIVIDEND
+    // If we are interrupted here, the the interruptor may start the
+    // calculation using incorrectly signed inputs, but we'll restore the
+    // result ourselves. This sets DIRTY, so any interruptor will save the
+    // state.
+    "str    r4, [r2, #0x064]", // DIV_UDIVISOR
+    // If we are interrupted here, the interruptor will have restored
+    // everything but the quotient may be wrongly signed.  If the calculation
+    // started by the above writes is still ongoing it is stopped, so it won't
+    // replace the result we're restoring.  DIRTY and READY set, but only
+    // DIRTY matters to make the interruptor save the state.
+    "str    r5, [r2, #0x074]", // DIV_REMAINDER
+    // State fully restored after the quotient write.  This sets both DIRTY
+    // and READY, so whatever we may have interrupted can read the result.
+    "str    r6, [r2, #0x070]", // DIV_QUOTIENT
+    "pop    {{r4-r6, pc}}",
+    ".endm",
+);
 
-        // Read the quotient last, since that's what clears the dirty flag
-        let dividend = sio.div_udividend.read().bits();
-        let divisor = sio.div_udivisor.read().bits();
-        let remainder = sio.div_remainder.read().bits();
-        let quotient = sio.div_quotient.read().bits();
+macro_rules! division_function {
+    (
+        $name:ident $($intrinsic:ident)* ( $argty:ty ) {
+            $($begin:literal),+
+        }
+    ) => {
+        #[cfg(all(target_arch = "arm", not(feature = "disable-intrinsics")))]
+        core::arch::global_asm!(
+            // Mangle the name slightly, since this is a global symbol.
+            concat!(".global _rphal_", stringify!($name)),
+            concat!(".type _rphal_", stringify!($name), ", %function"),
+            ".align 2",
+            concat!("_rphal_", stringify!($name), ":"),
+            $(
+                concat!(".global ", stringify!($intrinsic)),
+                concat!(".type ", stringify!($intrinsic), ", %function"),
+                concat!(stringify!($intrinsic), ":"),
+            )*
 
-        // If we get interrupted here (before a write sets the DIRTY flag) its fine, since
-        // we have the full state, so the interruptor doesn't have to restore it.  Once the
-        // write happens and the DIRTY flag is set, the interruptor becomes responsible for
-        // restoring our state.
-        let result = f(sio);
+            "hwdivider_head",
+            $($begin),+ ,
+            "hwdivider_tail",
+        );
 
-        // If we are interrupted here, then the interruptor will start an incorrect calculation
-        // using a wrong divisor, but we'll restore the divisor and result ourselves correctly.
-        // This sets DIRTY, so any interruptor will save the state.
-        sio.div_udividend.write(|w| unsafe { w.bits(dividend) });
-        // If we are interrupted here, the the interruptor may start the calculation using
-        // incorrectly signed inputs, but we'll restore the result ourselves.
-        // This sets DIRTY, so any interruptor will save the state.
-        sio.div_udivisor.write(|w| unsafe { w.bits(divisor) });
-        // If we are interrupted here, the interruptor will have restored everything but the
-        // quotient may be wrongly signed.  If the calculation started by the above writes is
-        // still ongoing it is stopped, so it won't replace the result we're restoring.
-        // DIRTY and READY set, but only DIRTY matters to make the interruptor save the state.
-        sio.div_remainder.write(|w| unsafe { w.bits(remainder) });
-        // State fully restored after the quotient write.  This sets both DIRTY and READY, so
-        // whatever we may have interrupted can read the result.
-        sio.div_quotient.write(|w| unsafe { w.bits(quotient) });
+        #[cfg(all(target_arch = "arm", feature = "disable-intrinsics"))]
+        core::arch::global_asm!(
+            // Mangle the name slightly, since this is a global symbol.
+            concat!(".global _rphal_", stringify!($name)),
+            concat!(".type _rphal_", stringify!($name), ", %function"),
+            ".align 2",
+            concat!("_rphal_", stringify!($name), ":"),
 
-        result
+            "hwdivider_head",
+            $($begin),+ ,
+            "hwdivider_tail",
+        );
+
+        #[cfg(target_arch = "arm")]
+        extern "aapcs" {
+            // Connect a local name to global symbol above through FFI.
+            #[link_name = concat!("_rphal_", stringify!($name)) ]
+            fn $name(n: $argty, d: $argty) -> u64;
+        }
+
+        #[cfg(not(target_arch = "arm"))]
+        #[allow(unused_variables)]
+        unsafe fn $name(n: $argty, d: $argty) -> u64 { 0 }
+    };
+}
+
+division_function! {
+    unsigned_divmod __aeabi_uidivmod __aeabi_uidiv ( u32 ) {
+        "str    r0, [r2, #0x060]", // DIV_UDIVIDEND
+        "str    r1, [r2, #0x064]"  // DIV_UDIVISOR
     }
 }
 
-// Don't use cortex_m::asm::delay(8) because that ends up delaying 15 cycles
-// on Cortex-M0.  Each iteration of the inner loop is 3 cycles and it adds
-// one extra iteration.
-#[inline(always)]
-fn divider_delay() {
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
-    cortex_m::asm::nop();
+division_function! {
+    signed_divmod __aeabi_idivmod __aeabi_idiv ( i32 ) {
+        "str    r0, [r2, #0x068]", // DIV_SDIVIDEND
+        "str    r1, [r2, #0x06c]"  // DIV_SDIVISOR
+    }
 }
 
-fn divider_unsigned(dividend: u32, divisor: u32) -> DivResult<u32> {
-    save_divider(|sio| {
-        sio.div_udividend.write(|w| unsafe { w.bits(dividend) });
-        sio.div_udivisor.write(|w| unsafe { w.bits(divisor) });
-
-        divider_delay();
-
-        // Note: quotient must be read last
-        let remainder = sio.div_remainder.read().bits();
-        let quotient = sio.div_quotient.read().bits();
-
-        DivResult {
-            remainder,
-            quotient,
-        }
-    })
+fn divider_unsigned(n: u32, d: u32) -> DivResult<u32> {
+    let packed = unsafe { unsigned_divmod(n, d) };
+    DivResult {
+        quotient: packed as u32,
+        remainder: (packed >> 32) as u32,
+    }
 }
 
-fn divider_signed(dividend: i32, divisor: i32) -> DivResult<i32> {
-    save_divider(|sio| {
-        sio.div_sdividend
-            .write(|w| unsafe { w.bits(dividend as u32) });
-        sio.div_sdivisor
-            .write(|w| unsafe { w.bits(divisor as u32) });
-
-        divider_delay();
-
-        // Note: quotient must be read last
-        let remainder = sio.div_remainder.read().bits() as i32;
-        let quotient = sio.div_quotient.read().bits() as i32;
-
-        DivResult {
-            remainder,
-            quotient,
-        }
-    })
+fn divider_signed(n: i32, d: i32) -> DivResult<i32> {
+    let packed = unsafe { signed_divmod(n, d) };
+    // Double casts to avoid sign extension
+    DivResult {
+        quotient: packed as u32 as i32,
+        remainder: (packed >> 32) as u32 as i32,
+    }
 }
 
 impl HwDivider {
@@ -287,7 +339,6 @@ impl HwDivider {
 }
 
 intrinsics! {
-    #[aeabi = __aeabi_uidiv]
     extern "C" fn __udivsi3(n: u32, d: u32) -> u32 {
         divider_unsigned(n, d).quotient
     }
@@ -304,7 +355,6 @@ intrinsics! {
         quo_rem.quotient
     }
 
-    #[aeabi = __aeabi_idiv]
     extern "C" fn __divsi3(n: i32, d: i32) -> i32 {
         divider_signed(n, d).quotient
     }

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -43,10 +43,10 @@ pub struct HwDivider {
 
 /// Result of divide/modulo operation
 pub struct DivResult<T> {
-    /// The remainder of divide/modulo operation
-    pub remainder: T,
     /// The quotient of divide/modulo operation
     pub quotient: T,
+    /// The remainder of divide/modulo operation
+    pub remainder: T,
 }
 
 /// Struct containing ownership markers for managing ownership of the SIO registers.


### PR DESCRIPTION
This implements the hardware divider usage directly in assembler.  The result is a significant speedup in the common (no state save required) case as well as a small one when a state save is required.

In truth, I'm not sure this specific variant is the best option (see below), because blocks of assembler are always hard to maintain.  The reason I ultimately decided on this variant was simply because division is common enough that having it be as fast as possible seemed worth the tradeoff of some gnarly code.  If I could have found a way to convince the compiler to eliminate the shims/prologues from the pure Rust implementation, then that would likely be superior: it would only sacrifice some performance in the less common save/restore case. 

### Requirements

This PR currently requires a nightly compiler.  This is because is makes use of global asm and because it depends on a change to compiler-builtins (rust-lang/rust#93696) to allow for the `__aeabi_[u]idivmod` intrinsics to be defined.  I believe both of these are expected in 1.60, so it probably can't be merged until then.

### `__aeabi_[u]idivmod` definitions

The `__aeabi_[u]idivmod` functions are defined with [a modified AAPCS ABI](https://developer.arm.com/documentation/ihi0043/latest#integer-32-32-32-division-functions): they return results in both `r0` and `r1`.  However, this can be emulated with plain AAPCS because of how it [defines returning a 64-bit result](https://developer.arm.com/documentation/ihi0042/j/?lang=en#result-return).  Basically: just return a 64-bit result with the remainder in the high order 32 bits and AAPCS guarantees the correct register assignment.

### Alternatives

I also experimented with several alternatives to improve performance.

  1. [Restructuring the Rust code](https://github.com/Sizurka/rp-hal/blob/11d966cd503f80051175663a86a675afef47c023/rp2040-hal/src/sio.rs#L174) to make it interact with the optimizer better.  The compiler generates nearly the same code as the optimized assembly for the actual division operation.  The main problem it exhibits is how it shuffles around the prologue/epilogue and wastes a bunch of time saving registers it doesn't need to in the common case.  So this approach tries to mitigate that.
  2. [Inline assembly](https://github.com/Sizurka/rp-hal/blob/5c44a122930a56c861ab992a57505575f0d0558a/rp2040-hal/src/sio.rs#L184) this is basically a prototype of the global asm version with the only advantage being that it doesn't require a global symbol for the intrinsics disabled case.  It also interacts slightly better with the optimizer at times.

Some benchmarks, taken from a simple test program.

| Size Change (bytes, negative is smaller) | `opt-level = 's'` | `opt-level = 'z'` | `opt-level = '2'` |
| -- | -- | -- | -- |
| Baseline | 0 | 0 | 0 |
| Restructured Rust | +16 | +24 | -64 |
| Inline asm | -28 | -24 | -200 |
| Global asm | -8 | -4 | -168 |

| Single division (cycles, includes all overhead) | `opt-level = 's'` | `opt-level = 'z'` | `opt-level = '2'` |
| -- | -- | -- | -- |
| Baseline | 51 | 63 | 51 |
| Restructured Rust | 45 | 57 | 35 |
| Inline asm | 38 | 38 | 38 |
| Global asm | 26 | 26 | 26 |


### Fighting the optimizer

I was not able to figure out a way to make the `s` and `z` optimization levels eliminate the shims generated for the intrinsics without also duplicating the bodies when any modulus operators are used (which defeats the point of optimizing for size).  At `opt-level` ≥ 2, with a minor change to the intrinsics alias generation, the shims are correctly eliminated and reduced to a direct call to the divider function.  The global asm version avoids this by declaring the intrinsics in the assembler block. 

This is the main source of the problem for the pure Rust variant when optimizing for size.  The other half for the pure Rust one is the equivalent prologue on the actual division function, but that's unavoidable as long as there's no way to disable Rust generating LLVM frame pointers for ARM Thumb. 

The generated shims:

```
10002688 <__aeabi_uidivmod>:
10002688:       b580            push    {r7, lr}
1000268a:       af00            add     r7, sp, #0
1000268c:       f7ff ffa8       bl      100025e0 <rp2040_hal::sio::divider_unsigned>
10002690:       bd80            pop     {r7, pc}

10002692 <__aeabi_uidiv>:
10002692:       b580            push    {r7, lr}
10002694:       af00            add     r7, sp, #0
10002696:       f7ff ffa3       bl      100025e0 <rp2040_hal::sio::divider_unsigned>
1000269a:       bd80            pop     {r7, pc}
```

Add 11 cycles and 10 bytes each, compared to 24 cycles (no state save) for the actual interior division, so this is unfortunately not a trivial overhead.

Also note that the `s` and `z` levels seem to be kind of erratic in producing these shims: sometimes I was getting call sequences that look like: `__aeabi_uidiv` -> `__aeabi_uidivmod` -> `rp2040_hal::sio::divider_unsigned` on `z` but not on `s` (with the prologue/epilogue generated for each one).

