### PR TITLE
Allow to start multiple state machines in sync

### DIFF
--- a/rp2040-hal/examples/pio_synchronized.rs
+++ b/rp2040-hal/examples/pio_synchronized.rs
@@ -39,10 +39,8 @@ fn main() -> ! {
     let pin1 = 1;
 
     // Define some simple PIO program.
-    let program = pio_proc::pio!(
-        32,
+    let program = pio_proc::pio_asm!(
         "
-    irq wait 0
 .wrap_target
     set pins, 1 [31]
     set pins, 0 [31]
@@ -78,10 +76,11 @@ fn main() -> ! {
 
     sm0.synchronize_with(&mut sm1);
 
-    sm0.start();
-    sm1.start();
-
-    pio.clear_irq(1);
+    let mut joining = sm0.join();
+    let sm1 = joining.with(sm1);
+    let mut started = joining.start();
+    let _sm1 = started.take(sm1);
+    let _sm0 = started.free();
 
     // PIO runs in background, independently from CPU
     #[allow(clippy::empty_loop)]

--- a/rp2040-hal/examples/pio_synchronized.rs
+++ b/rp2040-hal/examples/pio_synchronized.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     let program = pio_proc::pio!(
         32,
         "
-    wait 1 irq 0
+    irq wait 0
 .wrap_target
     set pins, 1 [31]
     set pins, 0 [31]
@@ -81,7 +81,7 @@ fn main() -> ! {
     sm0.start();
     sm1.start();
 
-    pio.force_irq(1);
+    pio.clear_irq(1);
 
     // PIO runs in background, independently from CPU
     #[allow(clippy::empty_loop)]

--- a/rp2040-hal/examples/pio_synchronized.rs
+++ b/rp2040-hal/examples/pio_synchronized.rs
@@ -1,0 +1,79 @@
+//! This example toggles the GPIO0 and GPIO1 pins, with each controlled from a
+//! separate PIO state machine.
+//!
+//! Despite running in separate state machines, the clocks are sychronized at
+//! the rise and fall times will be simultaneous.
+#![no_std]
+#![no_main]
+
+use cortex_m_rt::entry;
+use hal::gpio::{FunctionPio0, Pin};
+use hal::pac;
+use hal::pio::PIOExt;
+use hal::Sio;
+use panic_halt as _;
+use rp2040_hal as hal;
+
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+
+    let sio = Sio::new(pac.SIO);
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // configure pins for Pio0.
+    let _: Pin<_, FunctionPio0> = pins.gpio0.into_mode();
+    let _: Pin<_, FunctionPio0> = pins.gpio1.into_mode();
+
+    // PIN id for use inside of PIO
+    let pin0 = 0;
+    let pin1 = 1;
+
+    // Define some simple PIO program.
+    let program = pio_proc::pio!(
+        32,
+        "
+.wrap_target
+    set pins, 1 [31]
+    set pins, 0 [31]
+.wrap
+        "
+    );
+
+    // Initialize and start PIO
+    let (mut pio, sm0, sm1, _, _) = pac.PIO0.split(&mut pac.RESETS);
+    let div = 0f32; // as slow as possible (0 is interpreted as 65536)
+
+    let installed = pio.install(&program.program).unwrap();
+    let (mut sm0, _, _) = rp2040_hal::pio::PIOBuilder::from_program(installed)
+        .set_pins(pin0, 1)
+        .clock_divisor(div)
+        .build(sm0);
+    // The GPIO pin needs to be configured as an output.
+    sm0.set_pindirs([(pin0, hal::pio::PinDir::Output)]);
+
+    // NOTE: with the current rp-hal, I need to call pio.install() twice. This
+    // should be investigated further as it seems wrong.
+    let installed = pio.install(&program.program).unwrap();
+    let (mut sm1, _, _) = rp2040_hal::pio::PIOBuilder::from_program(installed)
+        .set_pins(pin1, 1)
+        .clock_divisor(div)
+        .build(sm1);
+    // The GPIO pin needs to be configured as an output.
+    sm1.set_pindirs([(pin1, hal::pio::PinDir::Output)]);
+
+    sm0.synchronize_with(&mut sm1).start();
+
+    // PIO runs in background, independently from CPU
+    #[allow(clippy::empty_loop)]
+    loop {}
+}


### PR DESCRIPTION
This adds a bunch of boiler-plate structs to pio.rs, but is the easiest way I found to solve #286. Any idea for a better implementation is welcome.

The resulting API is fine though, as those types do not become visible:
```
    // Start both SMs at the same time
    let group = sm0.with(sm1).sync().start();

    // Stop both SMs at the same time
    let group = group.stop();

    // Start them again and extract the individual state machines
    let (sm1, sm2) = group.start().free();

    // Stop the two state machines separately
    let _sm1 = sm1.stop();
    let _sm2 = sm2.stop();
```
(Context: https://github.com/jannic/rp-hal/blob/9b625a573e0ad05c699845239ab3fdb2cae75fd1/rp2040-hal/examples/pio_synchronized.rs#L78-L93)

Closes #286