### PR TITLE
Prep for 0.4.0 release

### DIFF
--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -22,8 +22,7 @@ panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 nb = "1.0.0"
 smart-leds = "0.3.0"
-pio = "0.1.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -22,8 +22,7 @@ panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 smart-leds = "0.3"
 nb = "1.0.0"
-pio = "0.1.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 
 [features]
 default = ["rt", "boot2"]

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -28,5 +28,4 @@ rp2040-boot2 = "0.2"
 smart-leds = "0.3.0"
 embedded-time = "0.12.0"
 nb = "1.0.0"
-pio = "0.1.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -22,8 +22,7 @@ panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 smart-leds = "0.3"
 nb = "1.0.0"
-pio = "0.1.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/adafruit-trinkey-qt2040/Cargo.toml
+++ b/boards/adafruit-trinkey-qt2040/Cargo.toml
@@ -21,7 +21,7 @@ embedded-hal ="0.2.5"
 embedded-time = "0.12.0"
 smart-leds = "0.3"
 nb = "1.0.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -26,7 +26,7 @@ panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 cortex-m-rtic = "0.6.0-rc.4"
 nb = "1.0"
-i2c-pio = { git = "https://github.com/ithinuel/i2c-pio-rs", rev = "df06e4ac94a5b2c985d6a9426dc4cc9be0d535c0" }
+i2c-pio = { git = "https://github.com/ithinuel/i2c-pio-rs", rev = "fa155bbae4e8553b448a66cc47236db38b7524dd" }
 heapless = "0.7.9"
 embedded-sdmmc = { git = "https://github.com/rust-embedded-community/embedded-sdmmc-rs.git" }
 smart-leds = "0.3.0"

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -30,7 +30,7 @@ i2c-pio = { git = "https://github.com/ithinuel/i2c-pio-rs", rev = "df06e4ac94a5b
 heapless = "0.7.9"
 embedded-sdmmc = { git = "https://github.com/rust-embedded-community/embedded-sdmmc-rs.git" }
 smart-leds = "0.3.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 ssd1306 = "0.7.0"
 embedded-graphics = "0.7.1"
 

--- a/boards/solderparty-rp2040-stamp/Cargo.toml
+++ b/boards/solderparty-rp2040-stamp/Cargo.toml
@@ -27,5 +27,5 @@ embedded-hal ="0.2.5"
 nb = "1.0.0"
 smart-leds = "0.3.0"
 pio = "0.1.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 embedded-time = "0.12.0"

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -23,7 +23,7 @@ smart-leds = "0.3.0"
 embedded-time = "0.12.0"
 nb = "1.0.0"
 pio = "0.1.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "4f0d81e594ea9934f9c4c38ed9824ad0cce4ebb5" }
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 
 [features]
 default = ["boot2", "rt"]

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-03-09
+
 ### Added
 
 - ROM function caching
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART IRQ examples
 - PIO side-set example
 - Stopped PIO state machines can change their clock divider
+- Added HAL IRQ example
 
 ### Changed
 
@@ -32,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update critical_section to use new spinlock implementation
 - Update embedded-hal alpha support to version 1.0.0-alpha.7
 - Avoid 64-bit division in clock calculations
+- Update pio and pio-proc to 0.2.0
 
 ## [0.3.0] - 2021-12-19
 
@@ -90,7 +94,8 @@ The Minimum-Supported Rust Version (MSRV) for this release is 1.54.
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/rp-rs/rp-hal/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/rp-rs/rp-hal/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rp-rs/rp-hal/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/v0.1.0

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -18,7 +18,7 @@ itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
 rp2040-pac = "0.3.0"
 paste = "1.0"
-pio = "0.1.0"
+pio = "0.2.0"
 usb-device = "0.2.8"
 vcell = "0.1"
 void = { version = "1.0.2", default-features = false }
@@ -44,7 +44,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 rp2040-boot2 = "0.2.0"
 hd44780-driver = "0.4.0"
-pio-proc = "0.1.0"
+pio-proc = "0.2.0"
 dht-sensor = "0.2.1"
 
 [features]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -56,3 +56,8 @@ alloc = []
 rom-func-cache = []
 disable-intrinsics = []
 rom-v2-intrinsics = []
+
+[[example]]
+# irq example uses cortex-m-rt::interrupt, need rt feature for that
+name = "gpio_irq_example"
+required-features = ["rt"]

--- a/rp2040-hal/examples/pio_proc_blink.rs
+++ b/rp2040-hal/examples/pio_proc_blink.rs
@@ -34,14 +34,11 @@ fn main() -> ! {
     let led_pin_id = 25;
 
     // Define some simple PIO program.
-    let program = pio_proc::pio!(
-        32,
-        "
-.wrap_target
-    set pins, 1 [31]
-    set pins, 0 [31]
-.wrap
-        "
+    let program = pio_proc::pio_asm!(
+        ".wrap_target",
+        "set pins, 1 [31]",
+        "set pins, 0 [31]",
+        ".wrap"
     );
 
     // Initialize and start PIO

--- a/rp2040-hal/examples/pio_side_set.rs
+++ b/rp2040-hal/examples/pio_side_set.rs
@@ -36,15 +36,12 @@ fn main() -> ! {
     let led_pin_id = 25;
 
     // Define some simple PIO program.
-    let program = pio_proc::pio!(
-        32,
-        "
-        .side_set 1 ; each instruction may set 1 bit
-        .wrap_target
-            nop side 1
-            nop side 0
-        .wrap
-        "
+    let program = pio_proc::pio_asm!(
+        ".side_set 1", // each instruction may set 1 bit
+        ".wrap_target",
+        "    nop side 1",
+        "    nop side 0",
+        ".wrap",
     );
 
     // Initialize and start PIO

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -245,11 +245,10 @@ impl<P: PIOExt> PIO<P> {
 /// let (mut pio, sm0, _, _, _) = peripherals.PIO0.split(&mut peripherals.RESETS);
 /// // Install a program in instruction memory.
 /// let program = pio_proc::pio_asm!(
-///     ".wrap_target
-///     set pins, 1 [31]
-///     set pins, 0 [31]
-/// .wrap
-///     "
+///     ".wrap_target",
+///     "set pins, 1 [31]",
+///     "set pins, 0 [31]",
+///     ".wrap"
 /// ).program;
 /// let installed = pio.install(&program).unwrap();
 /// // Configure a state machine to use the program.


### PR DESCRIPTION
Some last-minute tidy ups for the 0.4.0 release.

- Updated to pio 0.2.0 and pio-proc 0.2.0, and migrated the HAL examples to match
- IRQ example wasn't building since it required HAL to be build with features = ["rt"] but that wasn't specified
- Updated the changelog