### PR TITLE
Update BSPs prior to release

### DIFF
--- a/boards/adafruit-feather-rp2040/CHANGELOG.md
+++ b/boards/adafruit-feather-rp2040/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-feather-rp2040-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-feather-rp2040-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-feather-rp2040-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-feather-rp2040-v0.1.0

--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adafruit-feather-rp2040"
 version = "0.2.0"
-authors = ["Andrea Nall <anall@andreanal.com>"]
+authors = ["Andrea Nall <anall@andreanal.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-feather-rp2040"
 description = "Board Support Package for the Adafruit Feather RP2040"

--- a/boards/adafruit-feather-rp2040/README.md
+++ b/boards/adafruit-feather-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Feather.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-feather-rp2040 = "0.1.0"
+adafruit-feather-rp2040 = "0.2.0"
 ```
 
 In your program, you will need to call `adafruit_feather_rp2040::Pins::new` to create

--- a/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-itsy-bitsy-rp2040-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-itsy-bitsy-rp2040-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-itsy-bitsy-rp2040-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-itsy-bitsy-rp2040-v0.1.0

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adafruit-itsy-bitsy-rp2040"
 version = "0.2.0"
-authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>"]
+authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit_itsy_bitsy_rp2040"
 description = "Board Support Package for the Adafruit ItsyBitsy RP2040"

--- a/boards/adafruit-itsy-bitsy-rp2040/README.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the ItsyBitsy RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-itsy-bitsy-rp2040 = "0.1.0"
+adafruit-itsy-bitsy-rp2040 = "0.2.0"
 ```
 
 In your program, you will need to call `adafruit_itsy_bitsy_rp2040::Pins::new` to create

--- a/boards/adafruit-kb2040/CHANGELOG.md
+++ b/boards/adafruit-kb2040/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-kb2040-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-kb2040-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-kb2040-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-kb2040-v0.1.0

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adafruit-kb2040"
 version = "0.2.0"
-authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>"]
+authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-kb2040"
 description = "Board Support Package for the Adafruit adafruit-kb2040"

--- a/boards/adafruit-kb2040/README.md
+++ b/boards/adafruit-kb2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the KB2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-kb2040 = "0.1.0"
+adafruit-kb2040 = "0.2.0"
 ```
 
 In your program, you will need to call `adafruit-kb2040::Pins::new` to create

--- a/boards/adafruit-macropad/CHANGELOG.md
+++ b/boards/adafruit-macropad/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-macropad-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-macropad-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-macropad-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-macropad-v0.1.0

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adafruit-macropad"
 version = "0.2.0"
-authors = ["Andrea Nall <anall@andreanal.com>"]
+authors = ["Andrea Nall <anall@andreanal.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit_macropad"
 description = "Board Support Package for the Adafruit Macropad"

--- a/boards/adafruit-macropad/README.md
+++ b/boards/adafruit-macropad/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Feather.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-macropad = "0.1.0"
+adafruit-macropad = "0.2.0"
 ```
 
 In your program, you will need to call `adafruit_macropad::Pins::new` to create

--- a/boards/adafruit-qt-py-rp2040/CHANGELOG.md
+++ b/boards/adafruit-qt-py-rp2040/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-qt-py-rp2040-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-qt-py-rp2040-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-qt-py-rp2040-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-qt-py-rp2040-v0.1.0

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adafruit-qt-py-rp2040"
 version = "0.2.0"
-authors = ["Stephen Onnen <stephen.onnen@gmail.com>"]
+authors = ["Stephen Onnen <stephen.onnen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-qt-py-rp2040"
 description = "Board Support Package for the Adafruit QT Py RP2040"

--- a/boards/adafruit-qt-py-rp2040/README.md
+++ b/boards/adafruit-qt-py-rp2040/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the QT Py.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-adafruit-qt-py-rp2040 = { git = "https://github.com/rp-rs/rp-hal.git" }
+adafruit-qt-py-rp2040 = "0.2.0"
 ```
 
 In your program, you will need to call `adafruit_qt_py_rp2040::Pins::new` to create

--- a/boards/pimoroni-pico-explorer/CHANGELOG.md
+++ b/boards/pimoroni-pico-explorer/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/pimoroni-pico-explorer-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/pimoroni-pico-explorer-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-explorer-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-explorer-v0.1.0

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pimoroni-pico-explorer"
 version = "0.2.0"
-authors = ["Hmvp <hmvp@users.noreply.github.com>"]
+authors = ["Hmvp <hmvp@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-pico-explorer"
 description = "Board Support Package for the Pico Explorer"

--- a/boards/pimoroni-pico-explorer/README.md
+++ b/boards/pimoroni-pico-explorer/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Pico Explorer.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-pico-explorer = "0.1.0"
+pimoroni-pico-explorer = "0.2.0"
 ```
 
 In your program, you will need to call `pimoroni_pico_explorer::Pins::new` to create

--- a/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
+++ b/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp2040-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/pimoroni-pico-lipo-16mb-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/pimoroni-pico-lipo-16mb-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-lipo-16mb-v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-lipo-16mb-v0.1.0

--- a/boards/pimoroni-pico-lipo-16mb/Cargo.toml
+++ b/boards/pimoroni-pico-lipo-16mb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pimoroni-pico-lipo-16mb"
 version = "0.2.0"
-authors = ["Hmvp <hmvp@users.noreply.github.com>"]
+authors = ["Hmvp <hmvp@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-pico-lipo-16mb"
 description = "Board Support Package for the Pico LiPo 16MB"

--- a/boards/pimoroni-pico-lipo-16mb/README.md
+++ b/boards/pimoroni-pico-lipo-16mb/README.md
@@ -18,7 +18,7 @@ space, and so it may not work if you only have the 4MB variant.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-pimoroni-pico-lipo-16mb = { git = "https://github.com/rp-rs/rp-hal.git" }
+pimoroni-pico-lipo-16mb = "0.2.0"
 ```
 
 In your program, you will need to call `pimoroni_pico_lipo_16mb::Pins::new` to create

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pimoroni-tiny2040"
 version = "0.1.0"
-authors = ["Mike Bell <mdb036@gmail.com>"]
+authors = ["Mike Bell <mdb036@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-tiny2040"
 description = "Board Support Package for the Pimoroni Tiny2040"

--- a/boards/rp-pico/CHANGELOG.md
+++ b/boards/rp-pico/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.3.0] - 2022-03-11
+
+### Changed
+
+- Update to rp-hal 0.4.0
+
 ## [0.2.0] - 2021-12-23
 
 ### Added
@@ -31,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [@jannic]: https://github.com/jannic
 [rp-rs]: https://github.com/rp-rs
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/rp-pico-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/rp-pico-v0.3.0...HEAD
+[0.3.0]: https://github.com/rp-rs/rp-hal/releases/tag/rp-pico-v0.3.0
 [0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/rp-pico-v0.2.0
 [0.1.3]: https://github.com/jannic/rp-microcontroller-rs/tree/rp-pico-0.1.3

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rp-pico"
 version = "0.3.0"
-authors = ["evan <evanmolder@gmail.com>"]
+authors = ["evan <evanmolder@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/rp-pico"
 description = "Board Support Package for the Raspberry Pi Pico"

--- a/boards/rp-pico/README.md
+++ b/boards/rp-pico/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Pico.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-rp-pico = "0.2.0"
+rp-pico = "0.3.0"
 ```
 
 In your program, you will need to call `rp_pico::Pins::new` to create

--- a/boards/solderparty-rp2040-stamp/README.md
+++ b/boards/solderparty-rp2040-stamp/README.md
@@ -16,7 +16,7 @@ RP2040 chip according to how it is connected up on the Stamp
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-solderparty-rp2040-stamp = { git = "https://github.com/rp-rs/rp-hal.git" }
+solderparty-rp2040-stamp = "0.1.0"
 ```
 
 In your program, you will need to call `solderparty_rp2040_stamp::Pins::new` to create

--- a/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
@@ -15,9 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
+## [0.2.0] - 2022-03-11
+
+### Changed
+
+- Update to rp-hal 0.4.0
+
 ## [0.1.0] - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/sparkfun-pro-micro-rp2040-v0.1.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/sparkfun-pro-micro-rp2040-v0.2.0...HEAD
+[0.2.0]: https://github.com/rp-rs/rp-hal/compare/sparkfun-pro-micro-rp2040-v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/sparkfun-pro-micro-rp2040-v0.1.0

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sparkfun-pro-micro-rp2040"
 version = "0.2.0"
-authors = ["Wilfried Chauveau <wilfried.chauveau@ithinuel.me>"]
+authors = ["Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/sparkfun-pro-micro-rp2040"
 description = "Board Support Package for the Sparkfun Pro Micro RP2040"

--- a/boards/sparkfun-pro-micro-rp2040/README.md
+++ b/boards/sparkfun-pro-micro-rp2040/README.md
@@ -17,7 +17,7 @@ RP2040 chip according to how it is connected up on the Pro Micro RP2040.
 To use this crate, your `Cargo.toml` file should contain:
 
 ```toml
-sparkfun-pro-micro-rp2040 = "0.1.0"
+sparkfun-pro-micro-rp2040 = "0.2.0"
 ```
 
 In your program, you will need to call `sparkfun_pro_micro_rp2040::Pins::new` to create

--- a/rp2040-hal/README.md
+++ b/rp2040-hal/README.md
@@ -68,7 +68,7 @@ https://github.com/rp-rs/rp-hal/ for more details.
 To include this crate in your project, amend your `Cargo.toml` file to include
 
 ```toml
-rp2040-hal = "0.3.0"
+rp2040-hal = "0.4.0"
 ```
 
 To obtain a copy of the source code (e.g. if you want to propose a bug-fix or


### PR DESCRIPTION
Now that HAL 0.4.0 is out we can think about publishing updates for all the BSPs.
I thought it would be a good idea to try to get them a little bit more consistent first.

There's also an update for the HAL readme that I missed before pressing the publish button.
I won't push a new version of the HAL until we accumulate a bunch of bug-fixes 