### PR TITLE
Remove some unused fields from UartPeripheral and Reader

### DIFF
--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -22,7 +22,6 @@ pub struct UartPeripheral<S: State, D: UartDevice, P: ValidUartPinout<D>> {
     device: D,
     _state: S,
     pins: P,
-    config: UartConfig,
 }
 
 impl<S: State, D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<S, D, P> {
@@ -30,7 +29,6 @@ impl<S: State, D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<S, D, P> {
         UartPeripheral {
             device: self.device,
             pins: self.pins,
-            config: self.config,
             _state: state,
         }
     }
@@ -51,7 +49,6 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Disabled, D, P> {
             device,
             _state: Disabled,
             pins,
-            config: common_configs::_9600_8_N_1, // placeholder
         }
     }
 
@@ -90,7 +87,6 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Disabled, D, P> {
 
         Ok(UartPeripheral {
             device,
-            config,
             pins,
             _state: Enabled,
         })
@@ -188,7 +184,6 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Enabled, D, P> {
             device: reader.device,
             _state: Enabled,
             pins: reader.pins,
-            config: reader.config,
         }
     }
 }
@@ -199,7 +194,6 @@ impl<P: ValidUartPinout<UART0>> UartPeripheral<Enabled, UART0, P> {
         let reader = Reader {
             device: self.device,
             pins: self.pins,
-            config: self.config,
         };
         // Safety: reader and writer will never write to the same address
         let device_copy = unsafe { &*UART0::ptr() };
@@ -218,7 +212,6 @@ impl<P: ValidUartPinout<UART1>> UartPeripheral<Enabled, UART1, P> {
         let reader = Reader {
             device: self.device,
             pins: self.pins,
-            config: self.config,
         };
         // Safety: reader and writer will never write to the same address
         let device_copy = unsafe { &*UART1::ptr() };

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -23,7 +23,6 @@ pub struct UartPeripheral<S: State, D: UartDevice, P: ValidUartPinout<D>> {
     _state: S,
     pins: P,
     config: UartConfig,
-    effective_baudrate: Baud,
 }
 
 impl<S: State, D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<S, D, P> {
@@ -32,7 +31,6 @@ impl<S: State, D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<S, D, P> {
             device: self.device,
             pins: self.pins,
             config: self.config,
-            effective_baudrate: self.effective_baudrate,
             _state: state,
         }
     }
@@ -54,7 +52,6 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Disabled, D, P> {
             _state: Disabled,
             pins,
             config: common_configs::_9600_8_N_1, // placeholder
-            effective_baudrate: Baud(0),
         }
     }
 
@@ -65,7 +62,7 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Disabled, D, P> {
         frequency: Hertz,
     ) -> Result<UartPeripheral<Enabled, D, P>, Error> {
         let (mut device, pins) = self.free();
-        let effective_baudrate = configure_baudrate(&mut device, &config.baudrate, &frequency)?;
+        configure_baudrate(&mut device, &config.baudrate, &frequency)?;
 
         device.uartlcr_h.write(|w| {
             // FIFOs are enabled
@@ -95,7 +92,6 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Disabled, D, P> {
             device,
             config,
             pins,
-            effective_baudrate,
             _state: Enabled,
         })
     }
@@ -193,7 +189,6 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Enabled, D, P> {
             _state: Enabled,
             pins: reader.pins,
             config: reader.config,
-            effective_baudrate: reader.effective_baudrate,
         }
     }
 }
@@ -205,7 +200,6 @@ impl<P: ValidUartPinout<UART0>> UartPeripheral<Enabled, UART0, P> {
             device: self.device,
             pins: self.pins,
             config: self.config,
-            effective_baudrate: self.effective_baudrate,
         };
         // Safety: reader and writer will never write to the same address
         let device_copy = unsafe { &*UART0::ptr() };
@@ -225,7 +219,6 @@ impl<P: ValidUartPinout<UART1>> UartPeripheral<Enabled, UART1, P> {
             device: self.device,
             pins: self.pins,
             config: self.config,
-            effective_baudrate: self.effective_baudrate,
         };
         // Safety: reader and writer will never write to the same address
         let device_copy = unsafe { &*UART1::ptr() };

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -6,7 +6,6 @@ use super::{UartConfig, UartDevice, ValidUartPinout};
 use rp2040_pac::uart0::RegisterBlock;
 
 use embedded_hal::serial::Read;
-use embedded_time::rate::Baud;
 use nb::Error::*;
 
 #[cfg(feature = "eh1_0_alpha")]
@@ -168,7 +167,6 @@ pub struct Reader<D: UartDevice, P: ValidUartPinout<D>> {
     pub(super) device: D,
     pub(super) pins: P,
     pub(super) config: UartConfig,
-    pub(super) effective_baudrate: Baud,
 }
 
 impl<D: UartDevice, P: ValidUartPinout<D>> Reader<D, P> {

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is for receiving data with a UART.
 
-use super::{UartConfig, UartDevice, ValidUartPinout};
+use super::{UartDevice, ValidUartPinout};
 use rp2040_pac::uart0::RegisterBlock;
 
 use embedded_hal::serial::Read;
@@ -166,7 +166,6 @@ pub(crate) fn read_full_blocking<D: UartDevice>(
 pub struct Reader<D: UartDevice, P: ValidUartPinout<D>> {
     pub(super) device: D,
     pub(super) pins: P,
-    pub(super) config: UartConfig,
 }
 
 impl<D: UartDevice, P: ValidUartPinout<D>> Reader<D, P> {


### PR DESCRIPTION
As @Liamolucko noticed in #310, the UART code stores some config values in its structs which are never used.

While it's possible that future extensions actually need those fields, I don't think it's reasonable to keep them just in case, without a near-term plan to actually use them.

Closes #310 