### PR TITLE
Constrain pio::fifo::write value to valid types

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -15,6 +15,7 @@ cortex-m-rt = ">=0.6.15,<0.8"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 eh1_0_alpha = { version = "=1.0.0-alpha.7", package="embedded-hal", optional=true }
 embedded-time = "0.12.0"
+funty = { version = "2.0.0", default-features = false }
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
 rp2040-pac = "0.3.0"

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -4,6 +4,7 @@ use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},
     resets::SubsystemReset,
 };
+use funty::{AtMost32, Integral};
 use pio::{Program, SideSet, Wrap};
 use rp2040_pac::{PIO0, PIO1};
 
@@ -825,7 +826,10 @@ impl<SM: ValidStateMachine> Tx<SM> {
     /// Write an element to TX FIFO.
     ///
     /// Returns `true` if the value was written to FIFO, `false` otherwise.
-    pub fn write<T>(&mut self, value: T) -> bool {
+    pub fn write<T>(&mut self, value: T) -> bool
+    where
+        T: Integral + AtMost32,
+    {
         // Safety: The register is never written by software.
         let is_full = self.is_full();
 
@@ -835,7 +839,7 @@ impl<SM: ValidStateMachine> Tx<SM> {
 
         unsafe {
             let reg_ptr = self.register_block().txf[SM::id()].as_ptr() as *mut T;
-            core::ptr::write_volatile(reg_ptr, value);
+            reg_ptr.write_volatile(value);
         }
 
         true


### PR DESCRIPTION
Use funty to limit the types of values that can be passed as a generic parameter to pio::fifo::write.
Previously it would allow many types that would almost certainly have been unsafe, plus it didn't catch when you accidentally passed in a ref or pointer.

Fixes #316