### PR TITLE
Pio FIFO write restrict

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -822,10 +822,10 @@ impl<SM: ValidStateMachine> Tx<SM> {
         }
     }
 
-    /// Write an element to TX FIFO.
+    /// Write a u32 value to TX FIFO.
     ///
     /// Returns `true` if the value was written to FIFO, `false` otherwise.
-    pub fn write<T>(&mut self, value: T) -> bool {
+    pub fn write(&mut self, value: u32) -> bool {
         // Safety: The register is never written by software.
         let is_full = self.is_full();
 
@@ -834,8 +834,8 @@ impl<SM: ValidStateMachine> Tx<SM> {
         }
 
         unsafe {
-            let reg_ptr = self.register_block().txf[SM::id()].as_ptr() as *mut T;
-            core::ptr::write_volatile(reg_ptr, value);
+            let reg_ptr = self.register_block().txf[SM::id()].as_ptr() as *mut u32;
+            reg_ptr.write_volatile(value);
         }
 
         true


### PR DESCRIPTION
Second pass at fixing #316, after #317 was 
This one only allows specific bit width unsigned int writes, which does make it slightly more difficult to write arbitrary objects to the FIFO, but a decent trade-off for being simple + fast + hard to misuse.