### PR TITLE
WIP: Multicore bootload

### DIFF
--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -108,18 +108,20 @@ fn core1_setup(stack_bottom: *mut usize) {
 /// Perform some basic validation of the program payload
 ///
 /// Validation performed:
-/// - Check `vector_table_addr` is correctly aligned
+/// - Check `vector_table_addr` is correctly aligned. See
+/// [CM0+ user guide](https://developer.arm.com/documentation/dui0662/b/The-Cortex-M0--Processor/Exception-model/Vector-table)
+/// for reference
 /// - Check that `vector_table_addr` is in a valid memory type (SRAM, XIP_SRAM, Flash)
 /// - Check `entry_addr` is after `vector_table_addr`
 /// - Check that `entry_addr` is not beyond the end of the memory type
-/// (SRAM, XIP_SRAM, Flash) that the `vector_table_addr` is in
+/// (SRAM, XIP_SRAM, Flash) that the `vector_table_addr` is in.
 fn validate_bootstrap_payload(
     vector_table_addr: usize,
     stack_addr: usize,
     entry_addr: usize,
 ) -> Result<(), Error> {
-    if vector_table_addr & 0x80 != 0 {
-        // Vector table was not 32 word (128 byte) aligned
+    if vector_table_addr & 0x100 != 0 {
+        // Vector table was not 64 word (256 byte) aligned
         return Err(Error::InvalidVectorTableAlignment);
     }
     if stack_addr & 0x4 != 0 {

--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -120,11 +120,11 @@ fn validate_bootstrap_payload(
     stack_addr: usize,
     entry_addr: usize,
 ) -> Result<(), Error> {
-    if vector_table_addr & 0x100 != 0 {
+    if vector_table_addr & (0x100 - 1) != 0 {
         // Vector table was not 64 word (256 byte) aligned
         return Err(Error::InvalidVectorTableAlignment);
     }
-    if stack_addr & 0x4 != 0 {
+    if stack_addr & (0x4 - 1) != 0 {
         // Stack pointer must be 4 byte aligned - invalid vector table?
         return Err(Error::InvalidStackPointerAlignment);
     }

--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -135,7 +135,7 @@ fn validate_bootstrap_payload(
     // We can still check that we're within the memory segment the program is loaded into
     if vector_table_addr & 0x2000_0000 == 0x2000_0000 {
         // Program is in RAM
-        if entry_addr >= 0x2003_F000 {
+        if entry_addr >= 0x2004_2000 {
             // Reset vector pointed off the end of RAM
             return Err(Error::InvalidEntryAddressAboveRAM);
         }
@@ -156,7 +156,7 @@ fn validate_bootstrap_payload(
     }
 
     // Verify stack pointer is in RAM
-    if !(0x2000_0000..=0x2003_F000).contains(&stack_addr) {
+    if !(0x2000_0000..=0x2004_2000).contains(&stack_addr) {
         return Err(Error::InvalidStackPointerAddress);
     }
     // If we haven't hit any of the previous guard clauses,


### PR DESCRIPTION
Existing Multicore code set up a trampoline function, then vectored into user code in the same executable from there.

This PR extracts the core functionality for launching code on another core from `inner_spawn` into `inner_bootstrap` (named after `cortex_m::asm::bootstrap` that does approximately the same work).
`inner_spawn` now sets up the stack and calculates the entry point for the trampoline before calling `inner_bootstrap`.

A new function `bootload` is used for starting a second program by using information from it's vector table - this one is named after [cortex_m::asm::bootload](https://github.com/rust-embedded/cortex-m/blob/e6c7249982841a8a39ada0bc80e6d0e492a560c3/src/asm.rs#L290)

There is currently no checking for alignment / other errors, will add those later.
I have briefly tested this code - it is mostly the same as some quick POCs i did to run code from [Flash](https://github.com/9names/rp2040_experiments-multicore_multiprogram/blob/main/core0-flash_core1-flash/src/main.rs) and [RAM](https://github.com/9names/rp2040_experiments-multicore_multiprogram/blob/main/core0-flash_core1-ram/src/main.rs) - I plan on updating this test code to validate this PR further