### PR TITLE
Add reexport of rp2040::entry to BSPs

### DIFF
--- a/boards/adafruit-feather-rp2040/examples/adafruit_feather_blinky.rs
+++ b/boards/adafruit-feather-rp2040/examples/adafruit_feather_blinky.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![no_main]
 
+use adafruit_feather_rp2040::entry;
 use adafruit_feather_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
@@ -13,7 +14,6 @@ use adafruit_feather_rp2040::{
     },
     Pins, XOSC_CRYSTAL_FREQ,
 };
-use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_time::rate::*;
 use panic_halt as _;

--- a/boards/adafruit-feather-rp2040/examples/adafruit_feather_neopixel_rainbow.rs
+++ b/boards/adafruit-feather-rp2040/examples/adafruit_feather_neopixel_rainbow.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+use adafruit_feather_rp2040::entry;
 use adafruit_feather_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
@@ -18,7 +19,6 @@ use adafruit_feather_rp2040::{
     Pins, XOSC_CRYSTAL_FREQ,
 };
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;
 use panic_halt as _;

--- a/boards/adafruit-feather-rp2040/src/lib.rs
+++ b/boards/adafruit-feather-rp2040/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/adafruit-itsy-bitsy-rp2040/examples/adafruit_itsy_bitsy_blinky.rs
+++ b/boards/adafruit-itsy-bitsy-rp2040/examples/adafruit_itsy_bitsy_blinky.rs
@@ -10,7 +10,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use adafruit_itsy_bitsy_rp2040::entry;
 
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)

--- a/boards/adafruit-itsy-bitsy-rp2040/examples/adafruit_itsy_bitsy_rainbow.rs
+++ b/boards/adafruit-itsy-bitsy-rp2040/examples/adafruit_itsy_bitsy_rainbow.rs
@@ -2,8 +2,8 @@
 #![no_std]
 #![no_main]
 
+use adafruit_itsy_bitsy_rp2040::entry;
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;

--- a/boards/adafruit-itsy-bitsy-rp2040/src/lib.rs
+++ b/boards/adafruit-itsy-bitsy-rp2040/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/adafruit-kb2040/examples/adafruit_kb2040_rainbow.rs
+++ b/boards/adafruit-kb2040/examples/adafruit_kb2040_rainbow.rs
@@ -8,8 +8,8 @@
 #![no_std]
 #![no_main]
 
+use adafruit_kb2040::entry;
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;
 use panic_halt as _;

--- a/boards/adafruit-kb2040/src/lib.rs
+++ b/boards/adafruit-kb2040/src/lib.rs
@@ -4,7 +4,7 @@ pub use rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/adafruit-macropad/src/lib.rs
+++ b/boards/adafruit-macropad/src/lib.rs
@@ -5,7 +5,7 @@ pub use rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 // Adafruit macropad uses W25Q64JVxQ flash chip. Should work with BOOT_LOADER_W25Q080 (untested)
 

--- a/boards/adafruit-qt-py-rp2040/examples/adafruit_qt_py_rp2040_rainbow.rs
+++ b/boards/adafruit-qt-py-rp2040/examples/adafruit_qt_py_rp2040_rainbow.rs
@@ -2,8 +2,8 @@
 #![no_std]
 #![no_main]
 
+use adafruit_qt_py_rp2040::entry;
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;

--- a/boards/adafruit-qt-py-rp2040/src/lib.rs
+++ b/boards/adafruit-qt-py-rp2040/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/adafruit-trinkey-qt2040/examples/adafruit_trinkey_qt2040_rainbow.rs
+++ b/boards/adafruit-trinkey-qt2040/examples/adafruit_trinkey_qt2040_rainbow.rs
@@ -8,8 +8,8 @@
 #![no_std]
 #![no_main]
 
+use adafruit_trinkey_qt2040::entry;
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;
 use panic_halt as _;

--- a/boards/adafruit-trinkey-qt2040/src/lib.rs
+++ b/boards/adafruit-trinkey-qt2040/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/pimoroni-pico-explorer/examples/pimoroni_pico_explorer_showcase.rs
+++ b/boards/pimoroni-pico-explorer/examples/pimoroni_pico_explorer_showcase.rs
@@ -3,7 +3,6 @@
 
 use arrayvec::ArrayString;
 use core::fmt::Write;
-use cortex_m_rt::entry;
 use embedded_graphics::{
     mono_font::{ascii::FONT_10X20, MonoTextStyleBuilder},
     pixelcolor::Rgb565,
@@ -14,6 +13,7 @@ use embedded_hal::digital::v2::OutputPin;
 use embedded_time::rate::*;
 use hal::{adc::Adc, clocks::*, watchdog::Watchdog, Sio};
 use panic_halt as _;
+use pimoroni_pico_explorer::entry;
 use pimoroni_pico_explorer::{hal, pac, Button, PicoExplorer, XOSC_CRYSTAL_FREQ};
 
 // See 4.9.5 from RP2040 datasheet

--- a/boards/pimoroni-pico-explorer/src/lib.rs
+++ b/boards/pimoroni-pico-explorer/src/lib.rs
@@ -6,7 +6,7 @@ pub extern crate rp2040_hal as hal;
 extern crate cortex_m_rt;
 
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/pimoroni-pico-lipo-16mb/examples/pimoroni_pico_lipo_16mb_blinky.rs
+++ b/boards/pimoroni-pico-lipo-16mb/examples/pimoroni_pico_lipo_16mb_blinky.rs
@@ -11,7 +11,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use pimoroni_pico_lipo_16mb::entry;
 
 // GPIO traits
 use embedded_hal::digital::v2::OutputPin;

--- a/boards/pimoroni-pico-lipo-16mb/src/lib.rs
+++ b/boards/pimoroni-pico-lipo-16mb/src/lib.rs
@@ -5,7 +5,7 @@ pub use rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/pimoroni-tiny2040/examples/tiny2040_blinky.rs
+++ b/boards/pimoroni-tiny2040/examples/tiny2040_blinky.rs
@@ -2,7 +2,7 @@
 #![no_std]
 #![no_main]
 
-use cortex_m_rt::entry;
+use bsp::entry;
 use defmt::*;
 use defmt_rtt as _;
 use embedded_hal::digital::v2::OutputPin;

--- a/boards/pimoroni-tiny2040/src/lib.rs
+++ b/boards/pimoroni-tiny2040/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/rp-pico/examples/pico_blinky.rs
+++ b/boards/rp-pico/examples/pico_blinky.rs
@@ -11,7 +11,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // GPIO traits
 use embedded_hal::digital::v2::OutputPin;

--- a/boards/rp-pico/examples/pico_countdown_blinky.rs
+++ b/boards/rp-pico/examples/pico_countdown_blinky.rs
@@ -11,7 +11,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 use cortex_m::prelude::*;
 

--- a/boards/rp-pico/examples/pico_gpio_in_out.rs
+++ b/boards/rp-pico/examples/pico_gpio_in_out.rs
@@ -13,7 +13,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // GPIO traits
 use embedded_hal::digital::v2::{InputPin, OutputPin};

--- a/boards/rp-pico/examples/pico_i2c_oled_display_ssd1306.rs
+++ b/boards/rp-pico/examples/pico_i2c_oled_display_ssd1306.rs
@@ -45,7 +45,7 @@
 use core::fmt::Write;
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // Time handling traits:
 use embedded_time::duration::*;

--- a/boards/rp-pico/examples/pico_i2c_pio.rs
+++ b/boards/rp-pico/examples/pico_i2c_pio.rs
@@ -15,7 +15,7 @@
 use core::fmt::Write as FmtWrite;
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // I2C HAL traits & Types.
 use embedded_hal::blocking::i2c::{Operation, Read, Transactional, Write};

--- a/boards/rp-pico/examples/pico_pwm_blink.rs
+++ b/boards/rp-pico/examples/pico_pwm_blink.rs
@@ -11,7 +11,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // GPIO traits
 use embedded_hal::PwmPin;

--- a/boards/rp-pico/examples/pico_spi_sd_card.rs
+++ b/boards/rp-pico/examples/pico_spi_sd_card.rs
@@ -93,7 +93,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // info!() and error!() macros for printing information to the debug output
 use defmt::*;

--- a/boards/rp-pico/examples/pico_uart_irq_buffer.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_buffer.rs
@@ -31,7 +31,7 @@ use core::fmt::Write;
 use rp2040_hal::Clock;
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)

--- a/boards/rp-pico/examples/pico_uart_irq_echo.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_echo.rs
@@ -29,7 +29,7 @@ use embedded_time::fixed_point::FixedPoint;
 use rp2040_hal::Clock;
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)

--- a/boards/rp-pico/examples/pico_usb_serial.rs
+++ b/boards/rp-pico/examples/pico_usb_serial.rs
@@ -13,7 +13,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)

--- a/boards/rp-pico/examples/pico_usb_serial_interrupt.rs
+++ b/boards/rp-pico/examples/pico_usb_serial_interrupt.rs
@@ -13,7 +13,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // The macro for marking our interrupt functions
 use rp_pico::hal::pac::interrupt;

--- a/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
+++ b/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
@@ -15,7 +15,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // The macro for marking our interrupt functions
 use rp_pico::hal::pac::interrupt;

--- a/boards/rp-pico/examples/pico_ws2812_led.rs
+++ b/boards/rp-pico/examples/pico_ws2812_led.rs
@@ -41,7 +41,7 @@
 #![no_main]
 
 // The macro for our start-up function
-use cortex_m_rt::entry;
+use rp_pico::entry;
 
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)

--- a/boards/rp-pico/src/lib.rs
+++ b/boards/rp-pico/src/lib.rs
@@ -5,7 +5,7 @@ pub extern crate rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/solderparty-rp2040-stamp/examples/solderparty_stamp_neopixel_rainbow.rs
+++ b/boards/solderparty-rp2040-stamp/examples/solderparty_stamp_neopixel_rainbow.rs
@@ -7,11 +7,11 @@
 #![no_main]
 
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;
 use panic_halt as _;
 use smart_leds::{brightness, SmartLedsWrite, RGB8};
+use solderparty_rp2040_stamp::entry;
 use solderparty_rp2040_stamp::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},

--- a/boards/solderparty-rp2040-stamp/src/lib.rs
+++ b/boards/solderparty-rp2040-stamp/src/lib.rs
@@ -5,7 +5,7 @@ pub use rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.

--- a/boards/sparkfun-pro-micro-rp2040/examples/sparkfun_pro_micro_rainbow.rs
+++ b/boards/sparkfun-pro-micro-rp2040/examples/sparkfun_pro_micro_rainbow.rs
@@ -9,10 +9,10 @@
 #![no_main]
 
 use core::iter::once;
-use cortex_m_rt::entry;
 use embedded_hal::timer::CountDown;
 use embedded_time::duration::Extensions;
 use panic_halt as _;
+use sparkfun_pro_micro_rp2040::entry;
 
 use smart_leds::{brightness, SmartLedsWrite, RGB8};
 use sparkfun_pro_micro_rp2040::{

--- a/boards/sparkfun-pro-micro-rp2040/src/lib.rs
+++ b/boards/sparkfun-pro-micro-rp2040/src/lib.rs
@@ -4,7 +4,7 @@ pub use rp2040_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
+pub use hal::entry;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.


### PR DESCRIPTION
#300 added a entry macro for the HAL, so we could do things at startup like clear all spinlocks.
All the BSPs examples previously ignored the HAL's export of entry, importing cortex_m::entry themselves.
I've added a reexport of rp2040-hal::entry (so you can `use bsp::entry`) and updated all the examples to use that.
This should allow us to add board-specific entries in the future without needing to update all the examples.