### PR TITLE
Provide an unsafe function for resetting all spinlocks

### DIFF
--- a/boards/rp-pico/examples/pico_rtic.rs
+++ b/boards/rp-pico/examples/pico_rtic.rs
@@ -27,6 +27,11 @@ mod app {
 
     #[init]
     fn init(c: init::Context) -> (Shared, Local, init::Monotonics) {
+        // Soft-reset does not release the hardware spinlocks
+        // Release them now to avoid a deadlock after debug or watchdog reset
+        unsafe {
+            hal::sio::spinlock_reset();
+        }
         let mut resets = c.device.RESETS;
         let mut watchdog = Watchdog::new(c.device.WATCHDOG);
         let _clocks = init_clocks_and_plls(

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -598,3 +598,22 @@ pub fn spinlock_state() -> [bool; 32] {
     }
     result
 }
+
+/// Free all spinlocks, regardless of their current status
+///
+/// RP2040 does not release all spinlocks on reset.
+/// The C SDK clears these all during entry, and so do we if you call hal::entry!
+/// But if someone is using the default cortex-m entry they risk hitting deadlocks so provide *something* to help out
+///
+/// # Safety
+/// Where possible, you should use the hal::entry macro attribute on main instead of this.
+/// You should call this as soon as possible after reset - preferably as the first entry in fn main(), before *ANY* use of spinlocks, atomics, or critical_section
+pub unsafe fn spinlock_reset() {
+    // Using raw pointers to avoid taking peripherals accidently at startup
+    const SIO_BASE: u32 = 0xd0000000;
+    const SPINLOCK0_PTR: *mut u32 = (SIO_BASE + 0x100) as *mut u32;
+    const SPINLOCK_COUNT: usize = 32;
+    for i in 0..SPINLOCK_COUNT {
+        SPINLOCK0_PTR.wrapping_add(i).write_volatile(1);
+    }
+}


### PR DESCRIPTION
RTIC-based examples can't make use of the hal::entry macro to reset all spinlocks.
Provide an unsafe fn() that can be used to reset all spinlocks in init()