### PR TITLE
Add adafruit-macropad_blinky example

### DIFF
--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -15,6 +15,10 @@ cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.4.0"}
 cortex-m-rt = { version = "0.7", optional = true }
+[dev-dependencies]
+embedded-time = "0.12.0"
+panic-halt= "0.2.0"
+embedded-hal ="0.2.5"
 
 [features]
 default = ["rt", "boot2"]

--- a/boards/adafruit-macropad/examples/adafruit-macropad_blinky.rs
+++ b/boards/adafruit-macropad/examples/adafruit-macropad_blinky.rs
@@ -1,0 +1,57 @@
+//! Blinks the LED on a Adafruit MacroPad board
+//!
+//! This will blink on-board LED.
+#![no_std]
+#![no_main]
+
+use adafruit_macropad::{
+    hal::{
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        watchdog::Watchdog,
+        Sio,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+use cortex_m_rt::entry;
+use embedded_hal::digital::v2::OutputPin;
+use embedded_time::rate::*;
+use panic_halt as _;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+    let mut led_pin = pins.led.into_push_pull_output();
+
+    loop {
+        led_pin.set_high().unwrap();
+        delay.delay_ms(1500);
+        led_pin.set_low().unwrap();
+        delay.delay_ms(1500);
+    }
+}

--- a/boards/adafruit-macropad/src/lib.rs
+++ b/boards/adafruit-macropad/src/lib.rs
@@ -72,3 +72,5 @@ hal::bsp_pins!(
         aliases: { FunctionSpi: Miso }
     },
 );
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
Also adds const XOSC_CRYSTAL_FREQ = 12_000_000, which is the right
value according to https://learn.adafruit.com/assets/103270

Fixes #302