### PR TITLE
Fix typo in License section of READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/adafruit-feather-rp2040/README.md
+++ b/boards/adafruit-feather-rp2040/README.md
@@ -90,7 +90,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/adafruit-itsy-bitsy-rp2040/README.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/README.md
@@ -90,7 +90,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/adafruit-kb2040/README.md
+++ b/boards/adafruit-kb2040/README.md
@@ -86,7 +86,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/adafruit-macropad/README.md
+++ b/boards/adafruit-macropad/README.md
@@ -82,7 +82,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/adafruit-qt-py-rp2040/README.md
+++ b/boards/adafruit-qt-py-rp2040/README.md
@@ -86,7 +86,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/adafruit-trinkey-qt2040/README.md
+++ b/boards/adafruit-trinkey-qt2040/README.md
@@ -85,7 +85,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/pimoroni-pico-explorer/README.md
+++ b/boards/pimoroni-pico-explorer/README.md
@@ -87,7 +87,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/pimoroni-pico-lipo-16mb/README.md
+++ b/boards/pimoroni-pico-lipo-16mb/README.md
@@ -88,7 +88,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/pimoroni-plasma-2040/README.md
+++ b/boards/pimoroni-plasma-2040/README.md
@@ -92,7 +92,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/pimoroni-tiny2040/README.md
+++ b/boards/pimoroni-tiny2040/README.md
@@ -87,7 +87,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/rp-pico/README.md
+++ b/boards/rp-pico/README.md
@@ -129,7 +129,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/solderparty-rp2040-stamp/README.md
+++ b/boards/solderparty-rp2040-stamp/README.md
@@ -86,7 +86,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/sparkfun-pro-micro-rp2040/README.md
+++ b/boards/sparkfun-pro-micro-rp2040/README.md
@@ -87,7 +87,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT license or the
+2.0_ License. That means you can choose either the MIT license or the
 Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific license.
 

--- a/boards/sparkfun-thing-plus-rp2040/README.md
+++ b/boards/sparkfun-thing-plus-rp2040/README.md
@@ -87,7 +87,7 @@ to intervene to uphold that code of conduct.
 ## License
 
 The contents of this repository are dual-licensed under the _MIT OR Apache
-2.0_ License. That means you can chose either the MIT licence or the
+2.0_ License. That means you can choose either the MIT licence or the
 Apache-2.0 licence when you re-use this code. See `MIT` or `APACHE2.0` for more
 information on each specific licence.
 


### PR DESCRIPTION
Found a minor typo that appears to have been copied and pasted into all of this project's subcrates (including the one I just contributed, whoops!). Nothing a little `sed` command can't fix.