### PR TITLE
Set device_class of twitchy_mouse example to 0

### DIFF
--- a/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
+++ b/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
@@ -113,7 +113,7 @@ fn main() -> ! {
         .manufacturer("Fake company")
         .product("Twitchy Mousey")
         .serial_number("TEST")
-        .device_class(0xEF) // misc
+        .device_class(0)
         .build();
     unsafe {
         // Note (safety): This is safe as interrupts haven't been started yet


### PR DESCRIPTION
This fixes the mouse on Mac.

Closes #327