### PR TITLE
Add missing copi pin for sparkfun-pro-micro-2040

### DIFF
--- a/boards/sparkfun-pro-micro-rp2040/src/lib.rs
+++ b/boards/sparkfun-pro-micro-rp2040/src/lib.rs
@@ -32,6 +32,7 @@ hal::bsp_pins!(
     Gpio20 { name: cipo },
     Gpio21 { name: ncs },
     Gpio22 { name: sck },
+    Gpio23 { name: copi },
     Gpio25 { name: led },
     Gpio26 { name: adc0 },
     Gpio27 { name: adc1 },


### PR DESCRIPTION
The sparkfun-pro-micro-2040 pins definition was missing the copi pin on gpio 23, see https://cdn.sparkfun.com/assets/e/2/7/6/b/ProMicroRP2040_Graphical_Datasheet.pdf for reference from sparkfun.