### PR TITLE
Bump version of board support crates

### DIFF
--- a/boards/adafruit-feather-rp2040/CHANGELOG.md
+++ b/boards/adafruit-feather-rp2040/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-feather-rp2040-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-feather-rp2040-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-feather-rp2040-v0.1.0

--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-feather-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrea Nall <anall@andreanal.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-feather-rp2040"

--- a/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
+++ b/boards/adafruit-itsy-bitsy-rp2040/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-itsy-bitsy-rp2040-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-itsy-bitsy-rp2040-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-itsy-bitsy-rp2040-v0.1.0

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-itsy-bitsy-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit_itsy_bitsy_rp2040"

--- a/boards/adafruit-kb2040/CHANGELOG.md
+++ b/boards/adafruit-kb2040/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-kb2040-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-kb2040-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-kb2040-v0.1.0

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-kb2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Christiansen <andrewtaylorchristiansen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-kb2040"

--- a/boards/adafruit-macropad/CHANGELOG.md
+++ b/boards/adafruit-macropad/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-macropad-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-macropad-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-macropad-v0.1.0

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-macropad"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrea Nall <anall@andreanal.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit_macropad"

--- a/boards/adafruit-qt-py-rp2040/CHANGELOG.md
+++ b/boards/adafruit-qt-py-rp2040/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/adafruit-qt-py-rp2040-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-qt-py-rp2040-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/adafruit-qt-py-rp2040-v0.1.0

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-qt-py-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Stephen Onnen <stephen.onnen@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-qt-py-rp2040"

--- a/boards/adafruit-trinkey-qt2040/Cargo.toml
+++ b/boards/adafruit-trinkey-qt2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-trinkey-qt2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/adafruit-trinkey-qt2040"

--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_nano_connect"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["splicedbread <dxbunrated@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/arduino_nano_connect"

--- a/boards/pimoroni-pico-explorer/CHANGELOG.md
+++ b/boards/pimoroni-pico-explorer/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/pimoroni-pico-explorer-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-explorer-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-explorer-v0.1.0

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-pico-explorer"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Hmvp <hmvp@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-pico-explorer"

--- a/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
+++ b/boards/pimoroni-pico-lipo-16mb/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp2040-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/pimoroni-pico-lipo-16mb-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-lipo-16mb-v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/pimoroni-pico-lipo-16mb-v0.1.0

--- a/boards/pimoroni-pico-lipo-16mb/Cargo.toml
+++ b/boards/pimoroni-pico-lipo-16mb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-pico-lipo-16mb"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Hmvp <hmvp@users.noreply.github.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-pico-lipo-16mb"

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-plasma-2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jordan Williams <jordan@jwillikers.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-plasma-2040"

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pimoroni-tiny2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mike Bell <mdb036@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/pimoroni-tiny2040"

--- a/boards/rp-pico/CHANGELOG.md
+++ b/boards/rp-pico/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,13 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.3.0] - 2022-03-11
+## 0.4.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.3.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp-hal 0.4.0
 
-## [0.2.0] - 2021-12-23
+## 0.2.0 - 2021-12-23
 
 ### Added
 
@@ -31,13 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Basically re-written.
 
-## [0.1.3] - 2021-02-03
+## 0.1.3 - 2021-02-03
 
 - Last release outside the [rp-rs] organisation by [@jannic].
 
 [@jannic]: https://github.com/jannic
 [rp-rs]: https://github.com/rp-rs
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/rp-pico-v0.3.0...HEAD
-[0.3.0]: https://github.com/rp-rs/rp-hal/releases/tag/rp-pico-v0.3.0
-[0.2.0]: https://github.com/rp-rs/rp-hal/releases/tag/rp-pico-v0.2.0
-[0.1.3]: https://github.com/jannic/rp-microcontroller-rs/tree/rp-pico-0.1.3

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp-pico"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["evan <evanmolder@gmail.com>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/rp-pico"

--- a/boards/solderparty-rp2040-stamp/Cargo.toml
+++ b/boards/solderparty-rp2040-stamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solderparty-rp2040-stamp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/solderparty-rp2040-stamp"

--- a/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-pro-micro-rp2040/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,16 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.2.0] - 2022-03-11
+## 0.3.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.2.0 - 2022-03-11
 
 ### Changed
 
 - Update to rp-hal 0.4.0
 
-## [0.1.0] - 2021-12-20
+## 0.1.0 - 2021-12-20
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/sparkfun-pro-micro-rp2040-v0.2.0...HEAD
-[0.2.0]: https://github.com/rp-rs/rp-hal/compare/sparkfun-pro-micro-rp2040-v0.1.0...v0.2.0
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/sparkfun-pro-micro-rp2040-v0.1.0

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkfun-pro-micro-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/sparkfun-pro-micro-rp2040"

--- a/boards/sparkfun-thing-plus-rp2040/CHANGELOG.md
+++ b/boards/sparkfun-thing-plus-rp2040/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -15,8 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - None
 
-## [0.1.0] - 2022-04-28
+## 0.2.0 - 2022-06-13
+
+### Changed
+
+- Update to rp2040-hal 0.5.0
+
+## 0.1.0 - 2022-04-28
 
 - Initial release
 
-[0.1.0]: https://github.com/rp-rs/rp-hal/releases/tag/sparkfun-thing-plus-rp2040-v0.1.0

--- a/boards/sparkfun-thing-plus-rp2040/Cargo.toml
+++ b/boards/sparkfun-thing-plus-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sparkfun-thing-plus-rp2040"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tyler Pottenger <tyler.pottenger@gmail.com>", "Wilfried Chauveau <wilfried.chauveau@ithinuel.me>", "The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/sparkfun-thing-plus-rp2040"


### PR DESCRIPTION
As the BSPs re-export the hal, their version needs to be bumped after the release of rp2040-hal.

Also updates the changelogs and removes broken links.