### PR TITLE
Remove unused embassy/embassy-traits deps in arduino-nano-connect

### DIFF
--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -18,23 +18,6 @@ cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 panic-probe = { version = "0.2.0", features = ["print-defmt"] }
 embedded-time = "0.12.0"
-# usb-device= "0.2.8"
-# usbd-serial = "0.1.1"
-# usbd-hid = "0.5.1"
-futures = { version = "0.3", default-features = false, optional = true }
-
-[dependencies.embassy]
-git = "https://github.com/embassy-rs/embassy"
-rev = "6d6e6f55b8a9ecd38b5a6d3bb11f74b2654afdeb"
-optional = true
-
-# namespaced features will let use use "dep:embassy-traits" in the features rather than using this
-# trick of renaming the crate.
-[dependencies.embassy_traits]
-git = "https://github.com/embassy-rs/embassy"
-rev = "6d6e6f55b8a9ecd38b5a6d3bb11f74b2654afdeb"
-package = "embassy-traits"
-optional = true
 
 [dev-dependencies]
 panic-halt= "0.2.0"
@@ -46,4 +29,3 @@ nb = "1.0"
 default = ["boot2", "rt"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
-embassy-traits = ["futures", "embassy", "embassy_traits"]


### PR DESCRIPTION
These deps aren't used and are blocking publishing on crates.io