### PR TITLE
Implement embedded-hal 1.0.0-alpha.8 traits

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update embedded-hal alpha support to version 1.0.0-alpha.8
+
 ## [0.5.0] - 2022-06-13
 
 ### MSRV

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 cortex-m = "0.7.2"
 cortex-m-rt = ">=0.6.15,<0.8"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
-eh1_0_alpha = { version = "=1.0.0-alpha.7", package="embedded-hal", optional=true }
+eh1_0_alpha = { version = "=1.0.0-alpha.8", package="embedded-hal", optional=true }
 embedded-time = "0.12.0"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"

--- a/rp2040-hal/README.md
+++ b/rp2040-hal/README.md
@@ -102,6 +102,8 @@ will be breaking changes even in minor versions of rp2040-hal.
 Support for embedded-hal 1.0(-alpha) exists in parallel to support for
 embedded-hal 0.2: Traits of both versions are implemented and can be used
 at the same time.
+The new blocking [SPI traits](https://docs.rs/embedded-hal/1.0.0-alpha.8/embedded_hal/spi/blocking/index.html)
+are not yet implemented.
 
 <!-- CONTRIBUTING -->
 ## Contributing


### PR DESCRIPTION
For now, this is only updating the dependency, and removing ADC traits which where also removed from embedded-hal.
The new blocking [SPI traits](https://docs.rs/embedded-hal/1.0.0-alpha.8/embedded_hal/spi/blocking/index.html) are not yet implemented.