### PR TITLE
Add missing open paren in bsp_pins doc macro

### DIFF
--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -1235,7 +1235,7 @@ macro_rules! bsp_pins {
                     <$crate::gpio::bank0::$Id as $crate::gpio::PinId>::DYN;
 
                     $( #[$attr] )*
-                    #[doc = "[DynPinMode]rp2040_hal::gpio::DynPinMode) "]
+                    #[doc = "[DynPinMode](rp2040_hal::gpio::DynPinMode) "]
                     #[doc = "for the `" $Alias "` alias."]
                     pub const [<$Alias:snake:upper _MODE>]: $crate::gpio::DynPinMode =
                     <$crate::gpio::$Mode as $crate::gpio::PinMode>::DYN;


### PR DESCRIPTION
The link for DynPinMode was a broken. The generated docs looked like this:
![image](https://user-images.githubusercontent.com/60134748/176173902-6da46a68-05bb-4a2a-b446-3ac9d22ed1f1.png)
after this patch they look like this
![image2](https://user-images.githubusercontent.com/60134748/176174115-1b9228b6-30c6-45b8-bce7-692dd05f5374.png)

