### PR TITLE
Comment out code in intrinsics docstring to avoid breakage

### DIFF
--- a/rp2040-hal/src/intrinsics.rs
+++ b/rp2040-hal/src/intrinsics.rs
@@ -58,16 +58,16 @@ macro_rules! intrinsics_aliases {
 /// Like the compiler-builtins macro, it accepts a series of functions that
 /// looks like normal Rust code:
 ///
-///     intrinsics! {
-///         extern "C" fn foo(a: i32) -> u32 {
-///             // ...
-///         }
-///
-///         #[nonstandard_attribute]
-///         extern "C" fn bar(a: i32) -> u32 {
-///             // ...
-///         }
-///     }
+/// //    intrinsics! {
+/// //        extern "C" fn foo(a: i32) -> u32 {
+/// //            // ...
+/// //        }
+/// //
+/// //        #[nonstandard_attribute]
+/// //        extern "C" fn bar(a: i32) -> u32 {
+/// //            // ...
+/// //        }
+/// //    }
 ///
 /// Each function can also be decorated with nonstandard attributes to control
 /// additional behaviour:


### PR DESCRIPTION
The new Rust release is interpreting the code in this docstring as a code block (despite not being labelled as such).
Commenting out the code to get CI off our back until we can work out what's wrong.
Tracking issue for getting a proper fix in place: #374