### PR TITLE
Use `ignore` instead of `text`

### DIFF
--- a/rp2040-hal/src/intrinsics.rs
+++ b/rp2040-hal/src/intrinsics.rs
@@ -58,7 +58,7 @@ macro_rules! intrinsics_aliases {
 /// Like the compiler-builtins macro, it accepts a series of functions that
 /// looks like normal Rust code:
 ///
-/// ```text
+/// ```ignore
 /// intrinsics! {
 ///     extern "C" fn foo(a: i32) -> u32 {
 ///         // ...


### PR DESCRIPTION
While the code block fails to compile, it's still code and not random text. Marking it with `ignore` allows for proper syntax highlighting, for example.

According to https://github.com/rust-lang/rust/issues/97030#issuecomment-1134499264 this is the proper fix, so this closes #374