### PR TITLE
Adafruit macropad macros

### DIFF
--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -15,6 +15,11 @@ cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
+smart-leds = "0.3.0"
+ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
+ssd1306 = "0.7.0"
+embedded-graphics = "0.7.1"
+
 [dev-dependencies]
 embedded-time = "0.12.0"
 panic-halt= "0.2.0"

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -17,9 +17,9 @@ rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
 smart-leds = "0.3.0"
 ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
-ssd1306 = "0.7.0"
+sh1106 = "0.4.0"
 embedded-graphics = "0.7.1"
-display-interface-spi = "*"
+
 [dev-dependencies]
 embedded-time = "0.12.0"
 panic-halt= "0.2.0"

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -16,7 +16,7 @@ rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
 smart-leds = "0.3.0"
-ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
+ws2812-pio = "0.3.0"
 sh1106 = "0.4.0"
 embedded-graphics = "0.7.1"
 

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -19,7 +19,7 @@ smart-leds = "0.3.0"
 ws2812-pio = { git = "https://github.com/ithinuel/ws2812-pio-rs", rev = "fd6b6604d65a66242b52ccf7f24a95ca325991dd" }
 ssd1306 = "0.7.0"
 embedded-graphics = "0.7.1"
-
+display-interface-spi = "*"
 [dev-dependencies]
 embedded-time = "0.12.0"
 panic-halt= "0.2.0"

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -19,6 +19,8 @@ smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
 sh1106 = "0.4.0"
 embedded-graphics = "0.7.1"
+embedded-hal = "*"
+embedded-time = "*"
 
 [dev-dependencies]
 embedded-time = "0.12.0"
@@ -29,4 +31,3 @@ embedded-hal ="0.2.5"
 default = ["rt", "boot2"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
-

--- a/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
+++ b/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
@@ -130,13 +130,13 @@ fn main() -> ! {
         &embedded_hal::spi::MODE_0,
     );
 
-    // let interface = display_interface_spi::SPIInterfaceNoCS::new(spi, dc);
-    // let mut display = Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate0)
-    //     .into_buffered_graphics_mode();
-    //     // reset<RST, DELAY, PinE>
-    // display.reset(&mut rst, &mut delay).unwrap();
-    // display.init().unwrap();
-    // display.init().unwrap();
+    let interface = display_interface_spi::SPIInterfaceNoCS::new(spi, dc);
+    let mut display = Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate0)
+        .into_buffered_graphics_mode();
+        // reset<RST, DELAY, PinE>
+    display.reset(&mut rst, &mut delay).unwrap();
+    display.init().unwrap();
+    display.init().unwrap();
 
     // // Create a text style for drawing the font:
     // let text_style = MonoTextStyleBuilder::new()

--- a/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
+++ b/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
@@ -24,12 +24,12 @@ use panic_halt as _;
 use smart_leds::{brightness, SmartLedsWrite, RGB, RGB8};
 
 // Import the actual crate to handle the Ws2812 protocol:
+use embedded_hal::digital::v2::OutputPin;
 use ws2812_pio::Ws2812;
 
 // Currently 3 consecutive LEDs are driven by this example
 // to keep the power draw compatible with USB:
 const STRIP_LEN: usize = 12;
-
 // For in the graphics drawing utilities like the font
 // and the drawing routines:
 use embedded_graphics::{
@@ -140,6 +140,11 @@ fn main() -> ! {
     // it currently prints garbage to the screen
     display.clear();
     display.flush().unwrap();
+    // Set up the buzzer pins
+    let mut speaker = pins.speaker.into_push_pull_output();
+    let mut speaker_shutdown = pins.speaker_shutdown.into_push_pull_output();
+    // Enable buzzer output
+    speaker_shutdown.set_high().unwrap();
     loop {
         Text::with_baseline("Hello Rust!", Point::new(0, 16), text_style, Baseline::Top)
             .draw(&mut display)
@@ -164,6 +169,8 @@ fn main() -> ! {
         while t > 1.0 {
             t -= 1.0;
         }
+        // Generate an annoying 30hz buzz
+        speaker.toggle().unwrap();
     }
 }
 

--- a/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
+++ b/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
@@ -1,0 +1,273 @@
+//!  all the functionality on a Adafruit MacroPad Showcase board
+//!
+//! This will showcase all the functionality on a Adafruit MacroPad board
+#![no_std]
+#![no_main]
+
+use adafruit_macropad::{
+    hal::{
+        self as hal,
+        clocks::{init_clocks_and_plls, Clock},
+        gpio, pac,
+        pio::PIOExt,
+        watchdog::Watchdog,
+        Sio, Spi, Timer, I2C,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+use cortex_m_rt::entry;
+use embedded_hal::digital::v2::OutputPin;
+use embedded_time::rate::*;
+use panic_halt as _;
+
+// Import useful traits to handle the ws2812 LEDs:
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+
+// Import the actual crate to handle the Ws2812 protocol:
+use ws2812_pio::Ws2812;
+
+// Currently 3 consecutive LEDs are driven by this example
+// to keep the power draw compatible with USB:
+const STRIP_LEN: usize = 12;
+
+// For string formatting.
+use core::fmt::Write;
+// For in the graphics drawing utilities like the font
+// and the drawing routines:
+use embedded_graphics::{
+    mono_font::{ascii::FONT_9X18_BOLD, MonoTextStyleBuilder},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    text::{Baseline, Text},
+};
+
+// The display driver:
+use ssd1306::size::DisplaySize128x64;
+use ssd1306::{mode::DisplayConfig, prelude::SPIInterfaceNoCS, Ssd1306};
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    // Setup a delay for the LED blink signals:
+    // let mut frame_delay =
+    // cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    // Create a count down timer for the Ws2812 instance:
+    let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
+    // Import the `sin` function for a smooth hue animation from the
+    // Pico rp2040 ROM:
+    let sin = adafruit_macropad::hal::rom_data::float_funcs::fsin::ptr();
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+    let mut led_pin = pins.led.into_push_pull_output();
+
+    // Split the PIO state machine 0 into individual objects, so that
+    // Ws2812 can use it:
+    let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+
+    // Instanciate a Ws2812 LED strip:
+    let mut ws = Ws2812::new(
+        // Use neopixel pin (19) on the Adafruit macropad (which is GPIO19 of the rp2040 chip)
+        // for the LED data output:
+        pins.neopixel.into_mode(),
+        &mut pio,
+        sm0,
+        clocks.peripheral_clock.freq(),
+        timer.count_down(),
+    );
+
+    let mut leds: [RGB8; STRIP_LEN] = [(0, 0, 0).into(); STRIP_LEN];
+    let mut t = 0.0;
+
+    // Bring down the overall brightness of the LEDS
+    // Original code here was worried about power consumption
+    // my measurements show around 300ma for 12 LEDs at full brightness. we should be good.
+    let strip_brightness = 64u8; // Limit brightness to 64/256
+
+    // Slow down timer by this factor (0.1 will result in 10 seconds):
+    let animation_speed = 0.1;
+
+    // Configure two pins as being I²C for the qwiic port
+    let sda_pin = pins.sda.into_mode::<hal::gpio::FunctionI2C>();
+    let scl_pin = pins.scl.into_mode::<hal::gpio::FunctionI2C>();
+
+    // These are implicitly used by the spi driver if they are in the correct mode
+    let _spi_sclk = pins.sclk.into_mode::<gpio::FunctionSpi>();
+    let _spi_mosi = pins.mosi.into_mode::<gpio::FunctionSpi>();
+    let _spi_miso = pins.miso.into_mode::<gpio::FunctionSpi>();
+    // let spi_cs = pins.gpio5.into_push_pull_output();
+
+    let dc = pins.oled_dc.into_push_pull_output();
+    let oled_reset = pins.oled_reset.into_push_pull_output();
+    // Create an SPI driver instance for the SPI0 device
+    let spi = Spi::<_, _, 8>::new(pac.SPI1);
+    // Exchange the uninitialised SPI driver for an initialised one
+    let spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        16_000_000u32.Hz(),
+        &embedded_hal::spi::MODE_0,
+    );
+
+    // let interface = display_interface_spi::SPIInterfaceNoCS::new(spi, dc);
+    // let mut display = Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate0)
+    //     .into_buffered_graphics_mode();
+    //     // reset<RST, DELAY, PinE>
+    // display.reset(&mut rst, &mut delay).unwrap();
+    // display.init().unwrap();
+    // display.init().unwrap();
+
+    // // Create a text style for drawing the font:
+    // let text_style = MonoTextStyleBuilder::new()
+    //     .font(&FONT_9X18_BOLD)
+    //     .text_color(BinaryColor::On)
+    //     .build();
+
+    let mut count = 0;
+    let mut buf = FmtBuf::new();
+    loop {
+        buf.reset();
+        // Format some text into a static buffer:
+        write!(&mut buf, "counter: {}", count).unwrap();
+        count += 1;
+
+        // // Empty the display:
+        // display.clear();
+
+        // // Draw 3 lines of text:
+        // Text::with_baseline("Hello world!", Point::zero(), text_style, Baseline::Top)
+        //     .draw(&mut display)
+        //     .unwrap();
+
+        // Text::with_baseline("Hello Rust!", Point::new(0, 16), text_style, Baseline::Top)
+        //     .draw(&mut display)
+        //     .unwrap();
+
+        // Text::with_baseline(buf.as_str(), Point::new(0, 32), text_style, Baseline::Top)
+        //     .draw(&mut display)
+        //     .unwrap();
+
+        // display.flush().unwrap();
+        for (i, led) in leds.iter_mut().enumerate() {
+            // An offset to give each LED:
+            let hue_offs = i as f32 / 12.0;
+
+            let sin_11 = sin((t + hue_offs) * 2.0 * core::f32::consts::PI);
+            // Bring -1..1 sine range to 0..1 range:
+            let sin_01 = (sin_11 + 1.0) * 0.5;
+
+            let hue = 360.0 * sin_01;
+            let sat = 1.0;
+            let val = 1.0;
+
+            let rgb = hsv2rgb_u8(hue, sat, val);
+            *led = rgb.into();
+        }
+
+        // Here the magic happens and the `leds` buffer is written to the
+        // ws2812 LEDs:
+        ws.write(brightness(leds.iter().copied(), strip_brightness))
+            .unwrap();
+
+        // Wait a bit until calculating the next frame:
+        delay.delay_ms(16); // ~60 FPS
+
+        // Increase the time counter variable and make sure it
+        // stays inbetween 0.0 to 1.0 range:
+        t += (16.0 / 1000.0) * animation_speed;
+        while t > 1.0 {
+            t -= 1.0;
+        }
+    }
+}
+
+pub fn hsv2rgb(hue: f32, sat: f32, val: f32) -> (f32, f32, f32) {
+    let c = val * sat;
+    let v = (hue / 60.0) % 2.0 - 1.0;
+    let v = if v < 0.0 { -v } else { v };
+    let x = c * (1.0 - v);
+    let m = val - c;
+    let (r, g, b) = if hue < 60.0 {
+        (c, x, 0.0)
+    } else if hue < 120.0 {
+        (x, c, 0.0)
+    } else if hue < 180.0 {
+        (0.0, c, x)
+    } else if hue < 240.0 {
+        (0.0, x, c)
+    } else if hue < 300.0 {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+    (r + m, g + m, b + m)
+}
+
+pub fn hsv2rgb_u8(h: f32, s: f32, v: f32) -> (u8, u8, u8) {
+    let r = hsv2rgb(h, s, v);
+
+    (
+        (r.0 * 255.0) as u8,
+        (r.1 * 255.0) as u8,
+        (r.2 * 255.0) as u8,
+    )
+}
+
+/// This is a very simple buffer to pre format a short line of text
+/// limited arbitrarily to 64 bytes.
+struct FmtBuf {
+    buf: [u8; 64],
+    ptr: usize,
+}
+
+impl FmtBuf {
+    fn new() -> Self {
+        Self {
+            buf: [0; 64],
+            ptr: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.ptr = 0;
+    }
+
+    fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.buf[0..self.ptr]).unwrap()
+    }
+}
+
+impl core::fmt::Write for FmtBuf {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let rest_len = self.buf.len() - self.ptr;
+        let len = if rest_len < s.len() {
+            rest_len
+        } else {
+            s.len()
+        };
+        self.buf[self.ptr..(self.ptr + len)].copy_from_slice(&s.as_bytes()[0..len]);
+        self.ptr += len;
+        Ok(())
+    }
+}

--- a/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
+++ b/boards/adafruit-macropad/examples/adafruit-macropad_showcase.rs
@@ -1,6 +1,17 @@
-//!  all the functionality on a Adafruit MacroPad Showcase board
+//!  Adafruit MacroPad showcase example
 //!
-//! This will showcase all the functionality on a Adafruit MacroPad board
+//! This example exercises shows off all the functionality on an Adafruit MacroPad board
+//! - LCD displays a message
+//! - LEDs cycle a colour pattern
+//! - Buzzer makes some sound
+//! - Blinks the LED
+//! TODO:
+//! - Poll keys
+//! - Poll rotary encoder
+//! - Poll rotary encoder button
+//! - USB
+//! - Interact with external i2c devices connected via qwiic port
+
 #![no_std]
 #![no_main]
 
@@ -27,8 +38,7 @@ use smart_leds::{brightness, SmartLedsWrite, RGB, RGB8};
 use embedded_hal::digital::v2::OutputPin;
 use ws2812_pio::Ws2812;
 
-// Currently 3 consecutive LEDs are driven by this example
-// to keep the power draw compatible with USB:
+// There are 12 RGB leds in the strip, one for each key
 const STRIP_LEN: usize = 12;
 // For in the graphics drawing utilities like the font
 // and the drawing routines:
@@ -91,15 +101,16 @@ fn main() -> ! {
     let mut leds: [RGB8; STRIP_LEN] = [(0, 0, 0).into(); STRIP_LEN];
     let mut t = 0.0;
 
-    // Bring down the overall brightness of the LEDS
-    // Original code here was worried about power consumption
-    // my measurements show around 300ma for 12 LEDs at full brightness. we should be good.
-    let strip_brightness = 64u8; // Limit brightness to 64/256
+    // Bring down the overall brightness of the LEDs.
+    // The onboard LEDs are very bright, they still look pretty good when not as bright.
+    // Reducing power might also be helpful for bad cables/connectors.
+    let strip_brightness = 64u8; // Limit brightness to 64/255
 
     // Slow down timer by this factor (0.1 will result in 10 seconds)
     let animation_speed = 0.1;
 
     // Configure two pins as being I²C for the qwiic port
+    // TODO: use qwiic port in example
     let _sda_pin = pins.sda.into_mode::<hal::gpio::FunctionI2C>();
     let _scl_pin = pins.scl.into_mode::<hal::gpio::FunctionI2C>();
 

--- a/boards/adafruit-macropad/src/lib.rs
+++ b/boards/adafruit-macropad/src/lib.rs
@@ -18,6 +18,9 @@ pub use hal::entry;
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
 pub use hal::pac;
+pub use macros::*;
+
+mod macros;
 
 hal::bsp_pins!(
     Gpio0 { name: button },

--- a/boards/adafruit-macropad/src/macros.rs
+++ b/boards/adafruit-macropad/src/macros.rs
@@ -1,0 +1,202 @@
+//!
+//! You probably want a `main()` routine that starts out like this:
+//!
+//! ```
+//! use rp_pico as bsp;
+//! let mut pac = pac::Peripherals::take().unwrap();
+//! let core = pac::CorePeripherals::take().unwrap();
+//! let mut watchdog = Watchdog::new(pac.WATCHDOG);
+//! let clocks = macropad_clocks!(pac, watchdog);
+//! let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+//! let pins = macropad_pins!(pac);
+//! let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
+//! //
+//! let mut disp = macropad_oled!(pins, clocks, delay, pac);
+//! let mut led_pin = pins.led.into_push_pull_output();
+//! let mut neopixels = macropad_neopixels!(pins, clocks, timer, pac);
+//! //
+//! let mut rotary = macropad_rotary_encoder!(pins);
+//! let keys = macropad_keypad!(pins);
+//! ```
+//!
+//! If there is a peripheral you don't need, you can probably omit it.
+//!
+pub use crate::hal::clocks::init_clocks_and_plls;
+pub use crate::hal::clocks::Clock;
+pub use crate::hal::gpio::bank0::{
+    Gpio1, Gpio10, Gpio11, Gpio12, Gpio2, Gpio3, Gpio4, Gpio5, Gpio6, Gpio7, Gpio8, Gpio9,
+};
+pub use crate::hal::gpio::{FunctionSpi, Pin, PullUpInput, PushPullOutput};
+pub use crate::hal::sio::Sio;
+pub use crate::hal::Spi;
+pub use core::convert::Infallible;
+pub use embedded_hal::digital::v2::InputPin;
+pub use embedded_hal::spi::MODE_0;
+pub use embedded_time::rate::Extensions;
+pub use sh1106::prelude::GraphicsMode;
+
+// XXX missing: speaker, I2C side port
+
+#[macro_export]
+macro_rules! macropad_neopixels {
+    ($pins:expr, $pio:expr, $sm0: expr, $clocks:expr, $timer:expr) => {{
+        ws2812_pio::Ws2812::new(
+            $pins.neopixel.into_mode(),
+            &mut $pio,
+            $sm0,
+            $crate::Clock::freq(&$clocks.peripheral_clock),
+            $timer.count_down(),
+        )
+    }};
+    ($pins: expr, $clocks:expr, $timer:expr, $pac:expr) => {{
+        let (mut pio, sm0, _, _, _) = $pac.PIO0.split(&mut $pac.RESETS);
+        macropad_neopixels!($pins, pio, sm0, $clocks, $timer)
+    }};
+}
+
+#[macro_export]
+macro_rules! macropad_oled {
+    ($pins:expr, $clocks:expr, $delay: expr, $pac:expr) => {{
+        let _spi_sclk = $pins.sclk.into_mode::<$crate::FunctionSpi>();
+        let _spi_sclk = $pins.mosi.into_mode::<$crate::FunctionSpi>();
+
+        let spi1 = $crate::Spi::<_, _, 8>::new($pac.SPI1).init(
+            &mut $pac.RESETS,
+            $crate::Clock::freq(&$clocks.peripheral_clock),
+            $crate::Extensions::Hz(16_000_000u32),
+            // (16_000_000u32 as embedded_time::rate::Extensions).Hz(),
+            &$crate::MODE_0,
+        );
+
+        let mut oled_reset = $pins.oled_reset.into_push_pull_output();
+
+        let mut disp: $crate::GraphicsMode<_> = sh1106::Builder::new()
+            .connect_spi(
+                spi1,
+                $pins.oled_dc.into_push_pull_output(),
+                $pins.oled_cs.into_push_pull_output(),
+            )
+            .into();
+
+        disp.reset(&mut oled_reset, &mut $delay).unwrap();
+
+        disp.init().unwrap();
+        disp
+    }};
+}
+
+#[macro_export]
+macro_rules! macropad_pins {
+    ($pac:expr) => {{
+        let sio = $crate::Sio::new($pac.SIO);
+        $crate::Pins::new(
+            $pac.IO_BANK0,
+            $pac.PADS_BANK0,
+            sio.gpio_bank0,
+            &mut $pac.RESETS,
+        )
+    }};
+}
+
+#[macro_export]
+macro_rules! macropad_clocks {
+    ($pac:expr, $watchdog:expr) => {
+        $crate::init_clocks_and_plls(
+            $crate::XOSC_CRYSTAL_FREQ,
+            $pac.XOSC,
+            $pac.CLOCKS,
+            $pac.PLL_SYS,
+            $pac.PLL_USB,
+            &mut $pac.RESETS,
+            &mut $watchdog,
+        )
+        .ok()
+        .unwrap()
+    };
+}
+
+#[macro_export]
+macro_rules! macropad_rotary_encoder {
+    ($pins:expr) => {
+        Rotary::new(
+            $pins.encoder_rota.into_pull_up_input(),
+            $pins.encoder_rotb.into_pull_up_input(),
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! macropad_keypad {
+    ($pins:expr) => {
+        KeysTwelve {
+            key1: $pins.key1.into_pull_up_input(),
+            key2: $pins.key2.into_pull_up_input(),
+            key3: $pins.key3.into_pull_up_input(),
+            key4: $pins.key4.into_pull_up_input(),
+            key5: $pins.key5.into_pull_up_input(),
+            key6: $pins.key6.into_pull_up_input(),
+            key7: $pins.key7.into_pull_up_input(),
+            key8: $pins.key8.into_pull_up_input(),
+            key9: $pins.key9.into_pull_up_input(),
+            key10: $pins.key10.into_pull_up_input(),
+            key11: $pins.key11.into_pull_up_input(),
+            key12: $pins.key12.into_pull_up_input(),
+        }
+    };
+}
+
+pub struct KeysTwelve {
+    pub key1: Pin<Gpio1, PullUpInput>,
+    pub key2: Pin<Gpio2, PullUpInput>,
+    pub key3: Pin<Gpio3, PullUpInput>,
+    pub key4: Pin<Gpio4, PullUpInput>,
+    pub key5: Pin<Gpio5, PullUpInput>,
+    pub key6: Pin<Gpio6, PullUpInput>,
+    pub key7: Pin<Gpio7, PullUpInput>,
+    pub key8: Pin<Gpio8, PullUpInput>,
+    pub key9: Pin<Gpio9, PullUpInput>,
+    pub key10: Pin<Gpio10, PullUpInput>,
+    pub key11: Pin<Gpio11, PullUpInput>,
+    pub key12: Pin<Gpio12, PullUpInput>,
+}
+
+impl KeysTwelve {
+    pub fn get_0based(&self, idx: i8) -> Option<&dyn InputPin<Error = Infallible>> {
+        self.get_1based(1 + idx)
+    }
+
+    pub fn get_1based(&self, idx: i8) -> Option<&dyn InputPin<Error = Infallible>> {
+        match idx {
+            1 => Some(&self.key1),
+            2 => Some(&self.key2),
+            3 => Some(&self.key3),
+            4 => Some(&self.key4),
+            5 => Some(&self.key5),
+            6 => Some(&self.key6),
+            7 => Some(&self.key7),
+            8 => Some(&self.key8),
+            9 => Some(&self.key9),
+            10 => Some(&self.key10),
+            11 => Some(&self.key11),
+            12 => Some(&self.key12),
+            _ => None,
+        }
+    }
+
+    pub fn array_0based(&self) -> [&dyn InputPin<Error = Infallible>; 12] {
+        [
+            &self.key1,
+            &self.key2,
+            &self.key3,
+            &self.key4,
+            &self.key5,
+            &self.key6,
+            &self.key7,
+            &self.key8,
+            &self.key9,
+            &self.key10,
+            &self.key11,
+            &self.key12,
+        ]
+    }
+}


### PR DESCRIPTION
This patch creates a set of macros in the adafruit-macropad board crate which simplify instantiation of the hardware that is built in to the Adafruit Macropad.
