### PR TITLE
add Adafruit Macropad macros

### DIFF
--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -18,9 +18,9 @@ cortex-m-rt = { version = "0.7", optional = true }
 ws2812-pio = "0.3.0"
 sh1106 = "0.4.0"
 embedded-graphics = "0.7.1"
-embedded-hal = "*"
-embedded-time = "*"
-rotary-encoder-hal = "*"
+embedded-hal = "0.2.7"
+embedded-time = "0.12.1"
+rotary-encoder-hal = "0.5.0"
 
 [dev-dependencies]
 embedded-time = "0.12.0"

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -15,6 +15,13 @@ cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
+#smart-leds = "0.3.0"
+ws2812-pio = "0.3.0"
+sh1106 = "0.4.0"
+embedded-graphics = "0.7.1"
+embedded-hal = "*"
+embedded-time = "*"
+
 [dev-dependencies]
 embedded-time = "0.12.0"
 panic-halt= "0.2.0"
@@ -24,4 +31,3 @@ embedded-hal ="0.2.5"
 default = ["rt", "boot2"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
-

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -15,12 +15,12 @@ cortex-m = "0.7.2"
 rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
-#smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
 sh1106 = "0.4.0"
 embedded-graphics = "0.7.1"
 embedded-hal = "*"
 embedded-time = "*"
+rotary-encoder-hal = "*"
 
 [dev-dependencies]
 embedded-time = "0.12.0"

--- a/boards/adafruit-macropad/src/lib.rs
+++ b/boards/adafruit-macropad/src/lib.rs
@@ -18,6 +18,9 @@ pub use hal::entry;
 pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 
 pub use hal::pac;
+pub use macros::*;
+
+mod macros;
 
 hal::bsp_pins!(
     Gpio0 { name: button },

--- a/boards/adafruit-macropad/src/macros.rs
+++ b/boards/adafruit-macropad/src/macros.rs
@@ -8,7 +8,8 @@
 //! let mut watchdog = Watchdog::new(pac.WATCHDOG);
 //! let clocks = macropad_clocks!(pac, watchdog);
 //! let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
-//! let pins = macropad_pins!(pac);
+//! let mut sio = Sio::new(pac.SIO);
+//! let pins = macropad_pins!(pac, sio);
 //! let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
 //! //
 //! let mut disp = macropad_oled!(pins, clocks, delay, pac);
@@ -33,6 +34,7 @@ pub use core::convert::Infallible;
 pub use embedded_hal::digital::v2::InputPin;
 pub use embedded_hal::spi::MODE_0;
 pub use embedded_time::rate::Extensions;
+pub use rotary_encoder_hal::Rotary;
 pub use sh1106::prelude::GraphicsMode;
 
 // XXX missing: speaker, I2C side port
@@ -87,15 +89,14 @@ macro_rules! macropad_oled {
 
 #[macro_export]
 macro_rules! macropad_pins {
-    ($pac:expr) => {{
-        let sio = $crate::Sio::new($pac.SIO);
+    ($pac:expr, $sio:expr) => {
         $crate::Pins::new(
             $pac.IO_BANK0,
             $pac.PADS_BANK0,
-            sio.gpio_bank0,
+            $sio.gpio_bank0,
             &mut $pac.RESETS,
         )
-    }};
+    };
 }
 
 #[macro_export]
@@ -118,7 +119,7 @@ macro_rules! macropad_clocks {
 #[macro_export]
 macro_rules! macropad_rotary_encoder {
     ($pins:expr) => {
-        Rotary::new(
+        $crate::Rotary::new(
             $pins.encoder_rota.into_pull_up_input(),
             $pins.encoder_rotb.into_pull_up_input(),
         )
@@ -128,7 +129,7 @@ macro_rules! macropad_rotary_encoder {
 #[macro_export]
 macro_rules! macropad_keypad {
     ($pins:expr) => {
-        KeysTwelve {
+        $crate::KeysTwelve {
             key1: $pins.key1.into_pull_up_input(),
             key2: $pins.key2.into_pull_up_input(),
             key3: $pins.key3.into_pull_up_input(),

--- a/boards/adafruit-macropad/src/macros.rs
+++ b/boards/adafruit-macropad/src/macros.rs
@@ -6,8 +6,8 @@
 //! # use adafruit_macropad as bsp;
 //! # use bsp::*;
 //! # use embedded_time::fixed_point::FixedPoint;
-//! # use rp2040_hal::Timer;
-//! # use rp2040_hal::Watchdog;
+//! # use bsp::hal::Timer;
+//! # use bsp::hal::Watchdog;
 //!
 //! let mut pac = pac::Peripherals::take().unwrap();
 //! let core = pac::CorePeripherals::take().unwrap();
@@ -72,7 +72,6 @@ macro_rules! macropad_oled {
             &mut $pac.RESETS,
             $crate::Clock::freq(&$clocks.peripheral_clock),
             $crate::Extensions::Hz(16_000_000u32),
-            // (16_000_000u32 as embedded_time::rate::Extensions).Hz(),
             &$crate::MODE_0,
         );
 
@@ -136,18 +135,18 @@ macro_rules! macropad_rotary_encoder {
 macro_rules! macropad_keypad {
     ($pins:expr) => {
         $crate::KeysTwelve {
-            key1: $pins.key1.into_pull_up_input(),
-            key2: $pins.key2.into_pull_up_input(),
-            key3: $pins.key3.into_pull_up_input(),
-            key4: $pins.key4.into_pull_up_input(),
-            key5: $pins.key5.into_pull_up_input(),
-            key6: $pins.key6.into_pull_up_input(),
-            key7: $pins.key7.into_pull_up_input(),
-            key8: $pins.key8.into_pull_up_input(),
-            key9: $pins.key9.into_pull_up_input(),
-            key10: $pins.key10.into_pull_up_input(),
-            key11: $pins.key11.into_pull_up_input(),
-            key12: $pins.key12.into_pull_up_input(),
+            key1: $pins.key1.into_mode(),
+            key2: $pins.key2.into_mode(),
+            key3: $pins.key3.into_mode(),
+            key4: $pins.key4.into_mode(),
+            key5: $pins.key5.into_mode(),
+            key6: $pins.key6.into_mode(),
+            key7: $pins.key7.into_mode(),
+            key8: $pins.key8.into_mode(),
+            key9: $pins.key9.into_mode(),
+            key10: $pins.key10.into_mode(),
+            key11: $pins.key11.into_mode(),
+            key12: $pins.key12.into_mode(),
         }
     };
 }

--- a/boards/adafruit-macropad/src/macros.rs
+++ b/boards/adafruit-macropad/src/macros.rs
@@ -2,7 +2,12 @@
 //! You probably want a `main()` routine that starts out like this:
 //!
 //! ```
-//! use rp_pico as bsp;
+//! # use adafruit_macropad as bsp;
+//! # use bsp::*;
+//! # use embedded_time::fixed_point::FixedPoint;
+//! # use rp2040_hal::Timer;
+//! # use rp2040_hal::Watchdog;
+//!
 //! let mut pac = pac::Peripherals::take().unwrap();
 //! let core = pac::CorePeripherals::take().unwrap();
 //! let mut watchdog = Watchdog::new(pac.WATCHDOG);
@@ -51,7 +56,7 @@ macro_rules! macropad_neopixels {
         )
     }};
     ($pins: expr, $clocks:expr, $timer:expr, $pac:expr) => {{
-        let (mut pio, sm0, _, _, _) = $pac.PIO0.split(&mut $pac.RESETS);
+        let (mut pio, sm0, _, _, _) = rp2040_hal::pio::PIOExt::split($pac.PIO0, &mut $pac.RESETS);
         macropad_neopixels!($pins, pio, sm0, $clocks, $timer)
     }};
 }

--- a/boards/adafruit-macropad/src/macros.rs
+++ b/boards/adafruit-macropad/src/macros.rs
@@ -1,0 +1,202 @@
+//!
+//! You probably want a `main()` routine that starts out like this:
+//!
+//! ```
+//! use rp_pico as bsp;
+//! let mut pac = pac::Peripherals::take().unwrap();
+//! let core = pac::CorePeripherals::take().unwrap();
+//! let mut watchdog = Watchdog::new(pac.WATCHDOG);
+//! let clocks = macropad_clocks!(pac, watchdog);
+//! let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+//! let pins = macropad_pins!(pac);
+//! let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
+//! //
+//! let mut disp = macropad_oled!(pins, clocks, delay, pac);
+//! let mut led_pin = pins.led.into_push_pull_output();
+//! let mut neopixels = macropad_neopixels!(pins, clocks, timer, pac);
+//! //
+//! let mut rotary = macropad_rotary_encoder!(pins);
+//! let keys = macropad_keypad!(pins);
+//! ```
+//!
+//! If there is a peripheral you don't need, you can probably omit it.
+//!
+pub use crate::hal::clocks::init_clocks_and_plls;
+pub use crate::hal::clocks::Clock;
+pub use crate::hal::gpio::bank0::{
+    Gpio1, Gpio10, Gpio11, Gpio12, Gpio2, Gpio3, Gpio4, Gpio5, Gpio6, Gpio7, Gpio8, Gpio9,
+};
+pub use crate::hal::gpio::{FunctionSpi, Pin, PullUpInput, PushPullOutput};
+pub use crate::hal::sio::Sio;
+pub use crate::hal::Spi;
+pub use core::convert::Infallible;
+pub use embedded_hal::digital::v2::InputPin;
+pub use embedded_hal::spi::MODE_0;
+pub use embedded_time::rate::Extensions;
+pub use sh1106::prelude::GraphicsMode;
+
+// XXX missing: speaker, I2C side port
+
+#[macro_export]
+macro_rules! macropad_neopixels {
+    ($pins:expr, $pio:expr, $sm0: expr, $clocks:expr, $timer:expr) => {{
+        ws2812_pio::Ws2812::new(
+            $pins.neopixel.into_mode(),
+            &mut $pio,
+            $sm0,
+            $crate::Clock::freq(&$clocks.peripheral_clock),
+            $timer.count_down(),
+        )
+    }};
+    ($pins: expr, $clocks:expr, $timer:expr, $pac:expr) => {{
+        let (mut pio, sm0, _, _, _) = $pac.PIO0.split(&mut $pac.RESETS);
+        macropad_neopixels!($pins, pio, sm0, $clocks, $timer)
+    }};
+}
+
+#[macro_export]
+macro_rules! macropad_oled {
+    ($pins:expr, $clocks:expr, $delay: expr, $pac:expr) => {{
+        let _spi_sclk = $pins.sclk.into_mode::<$crate::FunctionSpi>();
+        let _spi_sclk = $pins.mosi.into_mode::<$crate::FunctionSpi>();
+
+        let spi1 = $crate::Spi::<_, _, 8>::new($pac.SPI1).init(
+            &mut $pac.RESETS,
+            $crate::Clock::freq(&$clocks.peripheral_clock),
+            $crate::Extensions::Hz(16_000_000u32),
+            // (16_000_000u32 as embedded_time::rate::Extensions).Hz(),
+            &$crate::MODE_0,
+        );
+
+        let mut oled_reset = $pins.oled_reset.into_push_pull_output();
+
+        let mut disp: $crate::GraphicsMode<_> = sh1106::Builder::new()
+            .connect_spi(
+                spi1,
+                $pins.oled_dc.into_push_pull_output(),
+                $pins.oled_cs.into_push_pull_output(),
+            )
+            .into();
+
+        disp.reset(&mut oled_reset, &mut $delay).unwrap();
+
+        disp.init().unwrap();
+        disp
+    }};
+}
+
+#[macro_export]
+macro_rules! macropad_pins {
+    ($pac:expr) => {{
+        let sio = $crate::Sio::new($pac.SIO);
+        $crate::Pins::new(
+            $pac.IO_BANK0,
+            $pac.PADS_BANK0,
+            sio.gpio_bank0,
+            &mut $pac.RESETS,
+        )
+    }};
+}
+
+#[macro_export]
+macro_rules! macropad_clocks {
+    ($pac:expr, $watchdog:expr) => {
+        $crate::init_clocks_and_plls(
+            $crate::XOSC_CRYSTAL_FREQ,
+            $pac.XOSC,
+            $pac.CLOCKS,
+            $pac.PLL_SYS,
+            $pac.PLL_USB,
+            &mut $pac.RESETS,
+            &mut $watchdog,
+        )
+        .ok()
+        .unwrap()
+    };
+}
+
+#[macro_export]
+macro_rules! macropad_rotary_encoder {
+    ($pins:expr) => {
+        Rotary::new(
+            $pins.encoder_rota.into_pull_up_input(),
+            $pins.encoder_rotb.into_pull_up_input(),
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! macropad_keypad {
+    ($pins:expr) => {
+        KeysTwelve {
+            key1: $pins.key1.into_pull_up_input(),
+            key2: $pins.key2.into_pull_up_input(),
+            key3: $pins.key3.into_pull_up_input(),
+            key4: $pins.key4.into_pull_up_input(),
+            key5: $pins.key5.into_pull_up_input(),
+            key6: $pins.key6.into_pull_up_input(),
+            key7: $pins.key7.into_pull_up_input(),
+            key8: $pins.key8.into_pull_up_input(),
+            key9: $pins.key9.into_pull_up_input(),
+            key10: $pins.key10.into_pull_up_input(),
+            key11: $pins.key11.into_pull_up_input(),
+            key12: $pins.key12.into_pull_up_input(),
+        }
+    };
+}
+
+pub struct KeysTwelve {
+    pub key1: Pin<Gpio1, PullUpInput>,
+    pub key2: Pin<Gpio2, PullUpInput>,
+    pub key3: Pin<Gpio3, PullUpInput>,
+    pub key4: Pin<Gpio4, PullUpInput>,
+    pub key5: Pin<Gpio5, PullUpInput>,
+    pub key6: Pin<Gpio6, PullUpInput>,
+    pub key7: Pin<Gpio7, PullUpInput>,
+    pub key8: Pin<Gpio8, PullUpInput>,
+    pub key9: Pin<Gpio9, PullUpInput>,
+    pub key10: Pin<Gpio10, PullUpInput>,
+    pub key11: Pin<Gpio11, PullUpInput>,
+    pub key12: Pin<Gpio12, PullUpInput>,
+}
+
+impl KeysTwelve {
+    pub fn get_0based(&self, idx: i8) -> Option<&dyn InputPin<Error = Infallible>> {
+        self.get_1based(1 + idx)
+    }
+
+    pub fn get_1based(&self, idx: i8) -> Option<&dyn InputPin<Error = Infallible>> {
+        match idx {
+            1 => Some(&self.key1),
+            2 => Some(&self.key2),
+            3 => Some(&self.key3),
+            4 => Some(&self.key4),
+            5 => Some(&self.key5),
+            6 => Some(&self.key6),
+            7 => Some(&self.key7),
+            8 => Some(&self.key8),
+            9 => Some(&self.key9),
+            10 => Some(&self.key10),
+            11 => Some(&self.key11),
+            12 => Some(&self.key12),
+            _ => None,
+        }
+    }
+
+    pub fn array_0based(&self) -> [&dyn InputPin<Error = Infallible>; 12] {
+        [
+            &self.key1,
+            &self.key2,
+            &self.key3,
+            &self.key4,
+            &self.key5,
+            &self.key6,
+            &self.key7,
+            &self.key8,
+            &self.key9,
+            &self.key10,
+            &self.key11,
+            &self.key12,
+        ]
+    }
+}

--- a/boards/adafruit-macropad/src/macros.rs
+++ b/boards/adafruit-macropad/src/macros.rs
@@ -1,7 +1,8 @@
 //!
 //! You probably want a `main()` routine that starts out like this:
 //!
-//! ```
+//! ```no_run
+//! # // for some reason this code example fails to link during CI ( cargo test --doc --target x86_64-unknown-linux-gnu )
 //! # use adafruit_macropad as bsp;
 //! # use bsp::*;
 //! # use embedded_time::fixed_point::FixedPoint;
@@ -56,7 +57,7 @@ macro_rules! macropad_neopixels {
         )
     }};
     ($pins: expr, $clocks:expr, $timer:expr, $pac:expr) => {{
-        let (mut pio, sm0, _, _, _) = rp2040_hal::pio::PIOExt::split($pac.PIO0, &mut $pac.RESETS);
+        let (mut pio, sm0, _, _, _) = $crate::hal::pio::PIOExt::split($pac.PIO0, &mut $pac.RESETS);
         macropad_neopixels!($pins, pio, sm0, $clocks, $timer)
     }};
 }


### PR DESCRIPTION
Add a bunch of macros in the adafruit-macropad board crate to make it easier to construct working peripheral objects.

With this patch your `main()` can start like this:

```Rust
let mut pac = pac::Peripherals::take().unwrap();
let core = pac::CorePeripherals::take().unwrap();
let mut watchdog = Watchdog::new(pac.WATCHDOG);
let clocks = macropad_clocks!(pac, watchdog);
let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
let pins = macropad_pins!(pac);
let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
//
let mut disp = macropad_oled!(pins, clocks, delay, pac);
let mut led_pin = pins.led.into_push_pull_output();
let mut neopixels = macropad_neopixels!(pins, clocks, timer, pac);
//
let mut rotary = macropad_rotary_encoder!(pins);
let keys = macropad_keypad!(pins);
```
