### PR TITLE
Implement conversion from Clock to Hertz using reference

### DIFF
--- a/boards/rp-pico/examples/pico_i2c_oled_display_ssd1306.rs
+++ b/boards/rp-pico/examples/pico_i2c_oled_display_ssd1306.rs
@@ -134,7 +134,7 @@ fn main() -> ! {
         scl_pin,
         400.kHz(),
         &mut pac.RESETS,
-        clocks.peripheral_clock,
+        &clocks.peripheral_clock,
     );
 
     // Create the I²C display interface:

--- a/boards/rp-pico/examples/pico_i2c_pio.rs
+++ b/boards/rp-pico/examples/pico_i2c_pio.rs
@@ -98,7 +98,7 @@ fn main() -> ! {
     let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
         .enable(
             hal::uart::common_configs::_115200_8_N_1,
-            clocks.peripheral_clock.into(),
+            clocks.peripheral_clock.freq(),
         )
         .unwrap();
 

--- a/boards/rp-pico/examples/pico_uart_irq_buffer.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_buffer.rs
@@ -138,7 +138,7 @@ fn main() -> ! {
     let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
         .enable(
             hal::uart::common_configs::_9600_8_N_1,
-            clocks.peripheral_clock.into(),
+            clocks.peripheral_clock.freq(),
         )
         .unwrap();
 

--- a/boards/rp-pico/examples/pico_uart_irq_echo.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_echo.rs
@@ -122,7 +122,7 @@ fn main() -> ! {
     let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
         .enable(
             hal::uart::common_configs::_9600_8_N_1,
-            clocks.peripheral_clock.into(),
+            clocks.peripheral_clock.freq(),
         )
         .unwrap();
 

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update embedded-hal alpha support to version 1.0.0-alpha.8
+- Implement `From<&SomeClock> for Hertz` instead of `From<SomeClock> for Hertz`
+  for the clocks in `rp2040_hal::clocks`.
 
 ## [0.5.0] - 2022-06-13
 

--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -94,7 +94,7 @@ fn main() -> ! {
     let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
         .enable(
             hal::uart::common_configs::_9600_8_N_1,
-            clocks.peripheral_clock.into(),
+            clocks.peripheral_clock.freq(),
         )
         .unwrap();
 

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -89,7 +89,7 @@ fn main() -> ! {
         scl_pin, // Try `not_an_scl_pin` here
         400.kHz(),
         &mut pac.RESETS,
-        clocks.peripheral_clock,
+        &clocks.peripheral_clock,
     );
 
     // Write three bytes to the I²C device with 7-bit address 0x2C

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -89,7 +89,7 @@ fn main() -> ! {
         scl_pin, // Try `not_an_scl_pin` here
         400.kHz(),
         &mut pac.RESETS,
-        &clocks.peripheral_clock,
+        &clocks.system_clock,
     );
 
     // Write three bytes to the I²C device with 7-bit address 0x2C

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -25,6 +25,7 @@ use hal::pac;
 
 // Some traits we need
 use core::fmt::Write;
+use hal::Clock;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -89,7 +90,7 @@ fn main() -> ! {
     let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
         .enable(
             hal::uart::common_configs::_9600_8_N_1,
-            clocks.peripheral_clock.into(),
+            clocks.peripheral_clock.freq(),
         )
         .unwrap();
 

--- a/rp2040-hal/src/clocks/macros.rs
+++ b/rp2040-hal/src/clocks/macros.rs
@@ -417,9 +417,9 @@ macro_rules! base_clock {
 
             impl Sealed for $name {}
 
-            impl From<$name> for Hertz
+            impl From<&$name> for Hertz
              {
-                fn from(value: $name) -> Hertz {
+                fn from(value: &$name) -> Hertz {
                     value.frequency
                 }
             }

--- a/rp2040-hal/src/uart/mod.rs
+++ b/rp2040-hal/src/uart/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! See [examples/uart.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/uart.rs) for a more complete example
 //! ```no_run
-//! use rp2040_hal::{clocks::init_clocks_and_plls, gpio::{Pins, FunctionUart}, pac, sio::Sio, uart::{self, UartPeripheral}, watchdog::Watchdog};
+//! use rp2040_hal::{Clock, clocks::init_clocks_and_plls, gpio::{Pins, FunctionUart}, pac, sio::Sio, uart::{self, UartPeripheral}, watchdog::Watchdog};
 //!
 //! const XOSC_CRYSTAL_FREQ: u32 = 12_000_000; // Typically found in BSP crates
 //!
@@ -25,7 +25,7 @@
 //! let uart = UartPeripheral::new(peripherals.UART0, pins, &mut peripherals.RESETS)
 //!     .enable(
 //!         uart::common_configs::_9600_8_N_1,
-//!         clocks.peripheral_clock.into(),
+//!         clocks.peripheral_clock.freq(),
 //!     ).unwrap();
 //!
 //! uart.write_full_blocking(b"Hello World!\r\n");


### PR DESCRIPTION
Implementing `impl From<SystemClock> for Hertz` is a footgun, as
SystemClock is not Copy, so the automatic conversion consumes the
owned clock.

This is visible in the example i2c.rs:

```
    let mut i2c = hal::I2C::i2c1(
        pac.I2C1,
        sda_pin,
        scl_pin, // Try `not_an_scl_pin` here
        400.kHz(),
        &mut pac.RESETS,
        clocks.peripheral_clock,
    );
```

If the user wants to use both `i2c0` and `i2c1` at the same time,
copying from this example won't work:

```
error[E0382]: use of moved value: `clocks.peripheral_clock`
   --> rp2040-hal/examples/i2c.rs:106:9
    |
97  |         clocks.peripheral_clock,
    |         ----------------------- value moved here
...
106 |         clocks.peripheral_clock,
    |         ^^^^^^^^^^^^^^^^^^^^^^^ value used here after move
    |
    = note: move occurs because `clocks.peripheral_clock` has type
`PeripheralClock`, which does not implement the `Copy` trait
```

As getting the frequency from a clock doesn't really need ownership,
changing it to `impl From<&SystemClock> for Hertz` is both more
logical and provides better usability.

This is, however, a breaking change: Code relying on this trait
implementation needs to be changed by adding a `&`.