### PR TITLE
Match Seeeduino XIAO pin name to function

### DIFF
--- a/boards/seeeduino-xiao-rp2040/src/lib.rs
+++ b/boards/seeeduino-xiao-rp2040/src/lib.rs
@@ -27,7 +27,7 @@ hal::bsp_pins!(
         aliases: { FunctionUart: UartRx, FunctionSpi: Csn }
     },
     Gpio2 {
-        name: d8,
+        name: sck,
         aliases: { FunctionSpi: Sck }
     },
     Gpio3 {


### PR DESCRIPTION
This updates the name for GPIO pin 2 to match its function, so the naming scheme is consistent across pins within the Seeeduino XIAO RP2040 BSP (#369).