### PR TITLE
Update examples to defmt 0.3

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -31,7 +31,6 @@ rustflags = [
     "-C", "link-arg=-Tlink.x",
     "-C", "inline-threshold=5",
     "-C", "no-vectorize-loops",
-    "-C", "link-arg=-Tdefmt.x",
 ]
 
 # This runner will make a UF2 file and then copy it to a mounted RP2040 in USB

--- a/.cargo/config
+++ b/.cargo/config
@@ -31,6 +31,7 @@ rustflags = [
     "-C", "link-arg=-Tlink.x",
     "-C", "inline-threshold=5",
     "-C", "no-vectorize-loops",
+    "-C", "link-arg=-Tdefmt.x",
 ]
 
 # This runner will make a UF2 file and then copy it to a mounted RP2040 in USB

--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -16,7 +16,7 @@ rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
-panic-probe = { version = "0.2.0", features = ["print-defmt"] }
+panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 embedded-time = "0.12.0"
 
 [dev-dependencies]

--- a/boards/pimoroni-badger2040/Cargo.toml
+++ b/boards/pimoroni-badger2040/Cargo.toml
@@ -23,8 +23,8 @@ panic-halt= "0.2.0"
 nb = "1.0"
 embedded-graphics = "0.7.1"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -23,8 +23,8 @@ embedded-hal ="0.2.5"
 smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/pimoroni-plasma-2040/build.rs
+++ b/boards/pimoroni-plasma-2040/build.rs
@@ -1,0 +1,6 @@
+//! This build script makes sure the linker flag -Tdefmt.x is added
+//! for the examples.
+
+fn main() {
+    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
+}

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -21,8 +21,8 @@ embedded-time = "0.12.0"
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/pimoroni-tiny2040/build.rs
+++ b/boards/pimoroni-tiny2040/build.rs
@@ -1,0 +1,6 @@
+//! This build script makes sure the linker flag -Tdefmt.x is added
+//! for the examples.
+
+fn main() {
+    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
+}

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -37,8 +37,8 @@ hd44780-driver = "0.4.0"
 pio = "0.2.0"
 pio-proc = "0.2.1"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/rp-pico/build.rs
+++ b/boards/rp-pico/build.rs
@@ -1,0 +1,6 @@
+//! This build script makes sure the linker flag -Tdefmt.x is added
+//! for the examples.
+
+fn main() {
+    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
+}

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -37,8 +37,8 @@ hd44780-driver = "0.4.0"
 pio = "0.2.0"
 pio-proc = "0.2.1"
 
-defmt = "0.2.0"
-defmt-rtt = "0.2.0"
+defmt = "0.3.0"
+defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -37,9 +37,6 @@ hd44780-driver = "0.4.0"
 pio = "0.2.0"
 pio-proc = "0.2.1"
 
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
-
 [features]
 default = ["boot2", "rt"]
 boot2 = ["rp2040-boot2"]


### PR DESCRIPTION
Current version of probe-run is 0.3.3, which uses defmt 0.3.2.

With a firmware using defmt 0.2, this causes the following error
message:

```
Error: defmt wire format version mismatch: firmware is using 0.2, `probe-run` supports 3
suggestion: `cargo install` a different version of `probe-run` that supports defmt 0.2
```

Therefore, upgrade defmt dependency, ~~and also fix the linker script
in .cargo/config~~.

**EDIT:** instead of .cargo/config, use build.rs in individual board crates to set linker options as necessary.