### PR TITLE
GPIO IRQ example: Check the interrupt source in ISR

### DIFF
--- a/rp2040-hal/examples/gpio_irq_example.rs
+++ b/rp2040-hal/examples/gpio_irq_example.rs
@@ -174,14 +174,17 @@ fn IO_IRQ_BANK0() {
         // these will be of type `&mut LedPin` and `&mut ButtonPin`, so we don't have
         // to move them back into the static after we use them
         let (led, button) = gpios;
+        // Check if the interrupt source is from the pushbutton going from high-to-low.
+        // Note: this will always be true in this example, as that is the only enabled GPIO interrupt source
+        if button.interrupt_status(EdgeLow) {
+            // toggle can't fail, but the embedded-hal traits always allow for it
+            // we can discard the return value by assigning it to an unnamed variable
+            let _ = led.toggle();
 
-        // toggle can't fail, but the embedded-hal traits always allow for it
-        // we can discard the return value by assigning it to an unnamed variable
-        let _ = led.toggle();
-
-        // Our interrupt doesn't clear itself.
-        // Do that now so we don't immediately jump back to this interrupt handler.
-        button.clear_interrupt(EdgeLow);
+            // Our interrupt doesn't clear itself.
+            // Do that now so we don't immediately jump back to this interrupt handler.
+            button.clear_interrupt(EdgeLow);
+        }
     }
 }
 


### PR DESCRIPTION
The example previously assumed that if the interrupt service routine was running, that the source of the interrupt had to be the button EdgeLow trigger.
While this is true, it does not reflect a real-world usage where other pins or edges may be configured to generate interrupts.
#400 was asking how to do this, so it makes sense to update the example to help others find this information.