### PR TITLE
Use wfi in otherwise empty infinite loops in examples

### DIFF
--- a/boards/rp-pico/examples/pico_i2c_pio.rs
+++ b/boards/rp-pico/examples/pico_i2c_pio.rs
@@ -149,7 +149,7 @@ fn main() -> ! {
     print_temperature(&mut uart, temp);
 
     loop {
-        cortex_m::asm::nop();
+        cortex_m::asm::wfi();
     }
 }
 

--- a/rp2040-hal/examples/dht11.rs
+++ b/rp2040-hal/examples/dht11.rs
@@ -139,9 +139,8 @@ fn main() -> ! {
     // In this case, we just ignore the result. A real application
     // would do something with the measurement.
 
-    #[allow(clippy::empty_loop)]
     loop {
-        // Empty loop
+        cortex_m::asm::wfi();
     }
 }
 

--- a/rp2040-hal/examples/gpio_irq_example.rs
+++ b/rp2040-hal/examples/gpio_irq_example.rs
@@ -147,11 +147,7 @@ fn main() -> ! {
 
     loop {
         // interrupts handle everything else in this example.
-        // if we wanted low power we could go to sleep. to
-        // keep this example simple we'll just execute a `nop`.
-        // the `nop` (No Operation) instruction does nothing,
-        // but if we have no code here clippy would complain.
-        cortex_m::asm::nop();
+        cortex_m::asm::wfi();
     }
 }
 

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -97,9 +97,8 @@ fn main() -> ! {
 
     // Demo finish - just loop until reset
 
-    #[allow(clippy::empty_loop)]
     loop {
-        // Empty loop
+        cortex_m::asm::wfi();
     }
 }
 

--- a/rp2040-hal/examples/lcd_display.rs
+++ b/rp2040-hal/examples/lcd_display.rs
@@ -113,9 +113,8 @@ fn main() -> ! {
     lcd.write_str("HD44780!", &mut delay).unwrap();
 
     // Do nothing - we're finished
-    #[allow(clippy::empty_loop)]
     loop {
-        // Empty loop
+        cortex_m::asm::wfi();
     }
 }
 

--- a/rp2040-hal/examples/pio_blink.rs
+++ b/rp2040-hal/examples/pio_blink.rs
@@ -64,6 +64,7 @@ fn main() -> ! {
     sm.start();
 
     // PIO runs in background, independently from CPU
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }

--- a/rp2040-hal/examples/pio_proc_blink.rs
+++ b/rp2040-hal/examples/pio_proc_blink.rs
@@ -54,6 +54,7 @@ fn main() -> ! {
     sm.start();
 
     // PIO runs in background, independently from CPU
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }

--- a/rp2040-hal/examples/pio_side_set.rs
+++ b/rp2040-hal/examples/pio_side_set.rs
@@ -57,6 +57,7 @@ fn main() -> ! {
     sm.start();
 
     // PIO runs in background, independently from CPU
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }

--- a/rp2040-hal/examples/pio_synchronized.rs
+++ b/rp2040-hal/examples/pio_synchronized.rs
@@ -91,6 +91,7 @@ fn main() -> ! {
     cortex_m::asm::delay(10_000_000);
     let _sm2 = sm2.stop();
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -166,7 +166,7 @@ fn main() -> ! {
 
     // In case the reboot fails
     loop {
-        cortex_m::asm::nop();
+        cortex_m::asm::wfi();
     }
 }
 

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -121,9 +121,8 @@ fn main() -> ! {
         Err(_) => {} // handle errors
     };
 
-    #[allow(clippy::empty_loop)]
     loop {
-        // Empty loop
+        cortex_m::asm::wfi();
     }
 }
 


### PR DESCRIPTION
- Clippy warns about empty loops, https://github.com/rust-lang/rust-clippy/issues/6161
- wfi allows to CPU to save some power

WFI was avoided in examples for fear of ill interactions with debuggers.
However the rp2040 debug port does continue to work, as long as the
relevant clocks are not disabled in SLEEP_EN0/SLEEP_EN1. (By default,
all clocks stay enabled in sleep mode.)

This patch replaces several different workarounds with just calling wfi.