### PR TITLE
Gate usb Suspend/Resume feature with a feature: usb-suspend

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -45,6 +45,7 @@ rt = ["rp2040-pac/rt"]
 rom-func-cache = []
 disable-intrinsics = []
 rom-v2-intrinsics = []
+usb-suspend = []
 
 [[example]]
 # irq example uses cortex-m-rt::interrupt, need rt feature for that

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -564,7 +564,10 @@ impl UsbBusTrait for UsbBus {
             let sie_status = inner.ctrl_reg.sie_status.read();
             if sie_status.bus_reset().bit_is_set() {
                 return PollResult::Reset;
-            } else if sie_status.suspended().bit_is_set() {
+            }
+
+            #[cfg(feature = "usb-suspend")]
+            if sie_status.suspended().bit_is_set() {
                 return PollResult::Suspend;
             } else if sie_status.resume().bit_is_set() {
                 return PollResult::Resume;

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -447,13 +447,15 @@ impl UsbBusTrait for UsbBus {
             // and when a setup packet is received
             // this should be sufficient for device mode, will need more for host.
             inner.ctrl_reg.inte.modify(|_, w| {
+                #[cfg(feature = "usb-suspend")]
                 w.buff_status()
-                    .set_bit()
-                    .bus_reset()
-                    .set_bit()
                     .dev_resume_from_host()
                     .set_bit()
                     .dev_suspend()
+                    .set_bit();
+                w.buff_status()
+                    .set_bit()
+                    .bus_reset()
                     .set_bit()
                     .setup_req()
                     .set_bit()


### PR DESCRIPTION
Because this is broken in the current version of usb-device, we need to gate this until the upstream fix is published in a version.

**Note:**

I didn't get to test it yet. It'd be greatly appreciated if reviewer could build one of the example and confirm that it is broken without the gate (you'll need to make the usb host suspend the link, typically by putting a laptop host into sleep/suspend).
