### PR TITLE
bump usb-device to 0.2.9

### DIFF
--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -16,7 +16,7 @@ rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
-usb-device= "0.2.8"
+usb-device= "0.2.9"
 usbd-serial = "0.1.1"
 usbd-hid = "0.5.1"
 futures = { version = "0.3", default-features = false, optional = true }

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -16,7 +16,7 @@ rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
-usb-device= "0.2.8"
+usb-device= "0.2.9"
 usbd-serial = "0.1.1"
 usbd-hid = "0.5.1"
 futures = { version = "0.3", default-features = false, optional = true }

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -21,7 +21,7 @@ rp2040-pac = "0.3.0"
 paste = "1.0"
 pio = "0.2.0"
 rp2040-hal-macros = { version = "0.1.0", path = "../rp2040-hal-macros" }
-usb-device = "0.2.8"
+usb-device = "0.2.9"
 vcell = "0.1"
 void = { version = "1.0.2", default-features = false }
 rand_core = "0.6.3"


### PR DESCRIPTION
This version contains the fix to usb-device support for suspend.