### PR TITLE
Enable feature "rt" when compiling vector_table example

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -50,3 +50,8 @@ rom-v2-intrinsics = []
 # irq example uses cortex-m-rt::interrupt, need rt feature for that
 name = "gpio_irq_example"
 required-features = ["rt"]
+
+[[example]]
+# vector_table example uses cortex-m-rt::interrupt, need rt feature for that
+name = "vector_table"
+required-features = ["rt"]


### PR DESCRIPTION
Without this change, building the vector_table example fails when
building from the rp2040-hal directory:

```
rp2040-hal$ cargo build --release --example vector_table
   Compiling rp2040-hal v0.5.0 (rp2040-hal)
error[E0432]: unresolved import `pac::interrupt`
  --> rp2040-hal/examples/vector_table.rs:30:5
   |
30 | use pac::interrupt;
   |     ^^^^^---------
   |     |    |
   |     |    help: a similar name exists in the module (notice the capitalization): `Interrupt`
   |     no `interrupt` in the root

error: cannot determine resolution for the attribute macro `interrupt`
   --> rp2040-hal/examples/vector_table.rs:148:3
    |
148 | #[interrupt]
    |   ^^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports
```