### PR TITLE
Use generic boot loader for rp2040-hal examples

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -35,7 +35,7 @@ defmt = { version = ">=0.2.0, <0.4", optional = true }
 [dev-dependencies]
 cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
-rp2040-boot2 = "0.2.0"
+rp2040-boot2 = "0.2.1"
 hd44780-driver = "0.4.0"
 pio-proc = "0.2.0"
 dht-sensor = "0.2.1"

--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -34,7 +34,7 @@ use hal::pac;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/blinky.rs
+++ b/rp2040-hal/examples/blinky.rs
@@ -32,7 +32,7 @@ use rp2040_hal::clocks::Clock;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/dht11.rs
+++ b/rp2040-hal/examples/dht11.rs
@@ -37,7 +37,7 @@ use hal::Clock;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/gpio_in_out.rs
+++ b/rp2040-hal/examples/gpio_in_out.rs
@@ -31,7 +31,7 @@ use embedded_hal::digital::v2::OutputPin;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/gpio_irq_example.rs
+++ b/rp2040-hal/examples/gpio_irq_example.rs
@@ -54,7 +54,7 @@ use rp2040_hal::gpio::Interrupt::EdgeLow;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -31,7 +31,7 @@ use hal::pac;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/lcd_display.rs
+++ b/rp2040-hal/examples/lcd_display.rs
@@ -37,7 +37,7 @@ use hal::pac;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/multicore_fifo_blink.rs
+++ b/rp2040-hal/examples/multicore_fifo_blink.rs
@@ -37,7 +37,7 @@ use embedded_hal::digital::v2::ToggleableOutputPin;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/multicore_polyblink.rs
+++ b/rp2040-hal/examples/multicore_polyblink.rs
@@ -35,7 +35,7 @@ use embedded_hal::digital::v2::ToggleableOutputPin;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/pio_blink.rs
+++ b/rp2040-hal/examples/pio_blink.rs
@@ -14,7 +14,7 @@ use rp2040_hal as hal;
 
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 #[entry]
 fn main() -> ! {

--- a/rp2040-hal/examples/pio_proc_blink.rs
+++ b/rp2040-hal/examples/pio_proc_blink.rs
@@ -14,7 +14,7 @@ use rp2040_hal as hal;
 
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 #[entry]
 fn main() -> ! {

--- a/rp2040-hal/examples/pio_side_set.rs
+++ b/rp2040-hal/examples/pio_side_set.rs
@@ -16,7 +16,7 @@ use rp2040_hal as hal;
 
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 #[entry]
 fn main() -> ! {

--- a/rp2040-hal/examples/pio_synchronized.rs
+++ b/rp2040-hal/examples/pio_synchronized.rs
@@ -16,7 +16,7 @@ use rp2040_hal as hal;
 
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 #[entry]
 fn main() -> ! {

--- a/rp2040-hal/examples/pwm_blink.rs
+++ b/rp2040-hal/examples/pwm_blink.rs
@@ -33,7 +33,7 @@ use hal::pac;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// The minimum PWM value (i.e. LED brightness) we want
 const LOW: u16 = 0;

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -31,7 +31,7 @@ use hal::Clock;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -35,7 +35,7 @@ use hal::pac;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/uart.rs
+++ b/rp2040-hal/examples/uart.rs
@@ -34,7 +34,7 @@ use rp2040_hal::clocks::Clock;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency

--- a/rp2040-hal/examples/watchdog.rs
+++ b/rp2040-hal/examples/watchdog.rs
@@ -34,7 +34,7 @@ use rp2040_hal::clocks::Clock;
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency


### PR DESCRIPTION
Those examples should be independent of a specific board.
The generic boot loader increases their compatibility.