### PR TITLE
Fix clippy warnings

### DIFF
--- a/rp2040-hal/src/gpio/dynpin.rs
+++ b/rp2040-hal/src/gpio/dynpin.rs
@@ -210,7 +210,7 @@ dyn_function!(Spi, Xip, Uart, I2C, Pwm, Pio0, Pio1, Clock, UsbAux);
 //==============================================================================
 
 /// Value-level `enum` for pin groups
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DynGroup {
     /// .
     Bank0,
@@ -219,7 +219,7 @@ pub enum DynGroup {
 }
 
 /// Value-level `struct` representing pin IDs
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct DynPinId {
     /// .
     pub group: DynGroup,

--- a/rp2040-hal/src/pwm/dyn_slice.rs
+++ b/rp2040-hal/src/pwm/dyn_slice.rs
@@ -1,14 +1,14 @@
 //! Semi-internal enums mostly used in typelevel magic
 
 /// Value-level `struct` representing slice IDs
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct DynSliceId {
     /// Slice id
     pub num: u8,
 }
 
 /// Slice modes
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DynSliceMode {
     /// Count continuously whenever the slice is enabled
     FreeRunning,
@@ -21,7 +21,7 @@ pub enum DynSliceMode {
 }
 
 /// Channel ids
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DynChannelId {
     /// Channel A
     A,

--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -383,7 +383,7 @@ where
     pub fn enable_interrupt(&mut self) {
         unsafe {
             let pwm = &(*pac::PWM::ptr());
-            let reg = (&pwm.inte).as_ptr();
+            let reg = pwm.inte.as_ptr();
             write_bitmask_set(reg, self.bitmask());
         }
     }
@@ -393,7 +393,7 @@ where
     pub fn disable_interrupt(&mut self) {
         unsafe {
             let pwm = &(*pac::PWM::ptr());
-            let reg = (&pwm.inte).as_ptr();
+            let reg = pwm.inte.as_ptr();
             write_bitmask_clear(reg, self.bitmask());
         };
     }
@@ -417,7 +417,7 @@ where
     pub fn force_interrupt(&mut self) {
         unsafe {
             let pwm = &(*pac::PWM::ptr());
-            let reg = (&pwm.intf).as_ptr();
+            let reg = pwm.intf.as_ptr();
             write_bitmask_set(reg, self.bitmask());
         }
     }
@@ -428,7 +428,7 @@ where
     pub fn clear_force_interrupt(&mut self) {
         unsafe {
             let pwm = &(*pac::PWM::ptr());
-            let reg = (&pwm.intf).as_ptr();
+            let reg = pwm.intf.as_ptr();
             write_bitmask_clear(reg, self.bitmask());
         }
     }


### PR DESCRIPTION
Fixes a few instances of derive-partial-eq-without-eq and needless-borrow
clippy warnings.