### PR TITLE
Add meaningful names to steps and remove quasi-repetition

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,9 +1,13 @@
 on: [push, pull_request]
 name: Build and Test check
 jobs:
-  check:
-    name: cargo-check
+  builds:
+    name: "Build checks"
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        features: ["", "--features eh1_0_alpha", "--features chrono"]
+        mode: ["", "--release"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -12,51 +16,26 @@ jobs:
           target: thumbv6m-none-eabi
           override: true
           profile: minimal
-      - name: "Build workspace (debug)"
+      - name: "Build workspace"
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace
-      - name: "Build workspace and examples (debug)"
+          args: ${{ matrix.mode }} --workspace ${{ matrix.features }}
+      - name: "Build workspace and examples"
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --examples
-      - name: "List built examples and clean"
-        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
-      - name: "Build workspace and examples (debug, features=eh1_0_alpha)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --examples --features eh1_0_alpha
-      - name: "List built examples and clean"
-        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
-      - name: "Build workspace and examples (release)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --workspace --examples
-      - name: "List built examples and clean"
-        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
-      - name: "Build workspace and examples (release, features=eh1_0_alpha)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --workspace --examples --features eh1_0_alpha
+          args: ${{ matrix.mode }} --workspace --examples ${{ matrix.features }}
       - name: "List built examples and clean"
         run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
       - name: "Test"
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --tests --target x86_64-unknown-linux-gnu
+          args: --tests --target x86_64-unknown-linux-gnu ${{ matrix.features }}
       - name: "Test docs"
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --doc --target x86_64-unknown-linux-gnu
-      - name: "Test docs (features=chrono)"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --target x86_64-unknown-linux-gnu --features chrono
+          args: --doc --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,43 +12,51 @@ jobs:
           target: thumbv6m-none-eabi
           override: true
           profile: minimal
-      - uses: actions-rs/cargo@v1
+      - name: "Build workspace (debug)"
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --workspace
-      - uses: actions-rs/cargo@v1
+      - name: "Build workspace and examples (debug)"
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --workspace --examples
-      - run: echo "Debug examples built:" && ls target/thumbv6m-none-eabi/debug/examples/ |grep -v '-' |grep -v '\.d'
-      - run: rm target/thumbv6m-none-eabi/debug/examples/ -rf
-      - uses: actions-rs/cargo@v1
+      - name: "List built examples and clean"
+        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
+      - name: "Build workspace and examples (debug, features=eh1_0_alpha)"
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --workspace --examples --features eh1_0_alpha
-      - run: echo "Debug eh1_0 examples built:" && ls target/thumbv6m-none-eabi/debug/examples/ |grep -v '-' |grep -v '\.d'
-      - run: rm target/thumbv6m-none-eabi/debug/examples/ -rf
-      - uses: actions-rs/cargo@v1
+      - name: "List built examples and clean"
+        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
+      - name: "Build workspace and examples (release)"
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --workspace --examples
-      - run: echo "Release examples built:" && ls target/thumbv6m-none-eabi/release/examples/ |grep -v '-' |grep -v '\.d'
-      - run: rm target/thumbv6m-none-eabi/release/examples/ -rf
-      - uses: actions-rs/cargo@v1
+      - name: "List built examples and clean"
+        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
+      - name: "Build workspace and examples (release, features=eh1_0_alpha)"
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --workspace --examples --features eh1_0_alpha
-      - run: echo "Release eh1_0 examples built:" && ls target/thumbv6m-none-eabi/release/examples/ |grep -v '-' |grep -v '\.d'
-      - run: rm target/thumbv6m-none-eabi/release/examples/ -rf
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --target x86_64-unknown-linux-gnu
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --target x86_64-unknown-linux-gnu --features chrono
-      - uses: actions-rs/cargo@v1
+      - name: "List built examples and clean"
+        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
+      - name: "Test"
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --tests --target x86_64-unknown-linux-gnu
+      - name: "Test docs"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc --target x86_64-unknown-linux-gnu
+      - name: "Test docs (features=chrono)"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc --target x86_64-unknown-linux-gnu --features chrono


### PR DESCRIPTION
The workflow only shows "Runs action-rs/cargo@v1" which does not tell us much about what's actually being done.
The list and clean up done after each build varies by only the debug/release part of the path that is repeated several times (2).

This PR gives each step a more meaningful name and simplify the list & clean up step with a generic one liner that can be copy/pasted without modification.