### PR TITLE
Enable rp2040-hal/defmt feature in dev-dependencies

### DIFF
--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -18,6 +18,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 
 [dev-dependencies]
+rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0", features = [ "defmt" ] }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 smart-leds = "0.3.0"

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -18,6 +18,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 
 [dev-dependencies]
+rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0", features = [ "defmt" ] }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -22,6 +22,7 @@ usbd-hid = "0.5.1"
 futures = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
+rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0", features = [ "defmt" ] }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 cortex-m-rtic = "1.1.2"


### PR DESCRIPTION
This is a little bit hacky, as it relies on rp2040-hal actually
using (and therefore linking) some defmt code when the defmt feature is
enabled.

However this solution has the advantage that it only affects
dev-dependencies and therefore has no impact on the board crates
themselves.

Closes #420