### PR TITLE
Replace cortex_m::interrupt::Mutex with critical_section::Mutex in examples

### DIFF
--- a/boards/rp-pico/CHANGELOG.md
+++ b/boards/rp-pico/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `rp2040-e5` feature enabling the workaround for errata 5 on the USB device peripheral.
+- Support for critical-section 1.0.0 in the examples.
 
 ### Changed
 

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -36,6 +36,7 @@ embedded-graphics = "0.7.1"
 hd44780-driver = "0.4.0"
 pio = "0.2.0"
 pio-proc = "0.2.1"
+critical-section = "1.0.0"
 
 defmt = "0.3.0"
 defmt-rtt = "0.3.0"

--- a/boards/rp-pico/examples/pico_uart_irq_buffer.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_buffer.rs
@@ -49,7 +49,7 @@ use pac::interrupt;
 
 // Some short-cuts to useful types
 use core::cell::RefCell;
-use cortex_m::interrupt::Mutex;
+use critical_section::Mutex;
 use heapless::spsc::Queue;
 
 /// Import the GPIO pins we use
@@ -148,7 +148,7 @@ fn main() -> ! {
 
     // Now we give away the entire UART peripheral, via the variable
     // `GLOBAL_UART`. We can no longer access the UART from this main thread.
-    cortex_m::interrupt::free(|cs| {
+    critical_section::with(|cs| {
         GLOBAL_UART.borrow(cs).replace(Some(uart));
     });
 
@@ -180,7 +180,7 @@ fn main() -> ! {
 impl UartQueue {
     /// Try and get some data out of the UART Queue. Returns None if queue empty.
     fn read_byte(&self) -> Option<u8> {
-        cortex_m::interrupt::free(|cs| {
+        critical_section::with(|cs| {
             let cell_queue = self.mutex_cell_queue.borrow(cs);
             let mut queue = cell_queue.borrow_mut();
             queue.dequeue()
@@ -189,7 +189,7 @@ impl UartQueue {
 
     /// Peek at the next byte in the queue without removing it.
     fn peek_byte(&self) -> Option<u8> {
-        cortex_m::interrupt::free(|cs| {
+        critical_section::with(|cs| {
             let cell_queue = self.mutex_cell_queue.borrow(cs);
             let queue = cell_queue.borrow_mut();
             queue.peek().cloned()
@@ -208,7 +208,7 @@ impl UartQueue {
                 // Grab the mutex, by turning interrupts off. NOTE: This
                 // doesn't work if you are using Core 1 as we only turn
                 // interrupts off on one core.
-                cortex_m::interrupt::free(|cs| {
+                critical_section::with(|cs| {
                     // Grab the mutex contents.
                     let cell_queue = self.mutex_cell_queue.borrow(cs);
                     // Grab mutable access to the queue. This can't fail
@@ -262,7 +262,7 @@ fn UART0_IRQ() {
     // This is one-time lazy initialisation. We steal the variable given to us
     // via `GLOBAL_UART`.
     if UART.is_none() {
-        cortex_m::interrupt::free(|cs| {
+        critical_section::with(|cs| {
             *UART = GLOBAL_UART.borrow(cs).take();
         });
     }

--- a/boards/rp-pico/examples/pico_uart_irq_echo.rs
+++ b/boards/rp-pico/examples/pico_uart_irq_echo.rs
@@ -47,7 +47,7 @@ use hal::pac::interrupt;
 
 // Some short-cuts to useful types
 use core::cell::RefCell;
-use cortex_m::interrupt::Mutex;
+use critical_section::Mutex;
 
 /// Import the GPIO pins we use
 use hal::gpio::pin::bank0::{Gpio0, Gpio1};
@@ -142,7 +142,7 @@ fn main() -> ! {
 
     // Now we give away the entire UART peripheral, via the variable
     // `GLOBAL_UART`. We can no longer access the UART from this main thread.
-    cortex_m::interrupt::free(|cs| {
+    critical_section::with(|cs| {
         GLOBAL_UART.borrow(cs).replace(Some(uart));
     });
 
@@ -177,7 +177,7 @@ fn UART0_IRQ() {
     // This is one-time lazy initialisation. We steal the variable given to us
     // via `GLOBAL_UART`.
     if UART.is_none() {
-        cortex_m::interrupt::free(|cs| {
+        critical_section::with(|cs| {
             *UART = GLOBAL_UART.borrow(cs).take();
         });
     }

--- a/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
+++ b/boards/rp-pico/examples/pico_usb_twitchy_mouse.rs
@@ -168,7 +168,7 @@ fn main() -> ! {
 ///
 /// We do this with interrupts disabled, to avoid a race hazard with the USB IRQ.
 fn push_mouse_movement(report: MouseReport) -> Result<usize, usb_device::UsbError> {
-    cortex_m::interrupt::free(|_| unsafe {
+    critical_section::with(|_| unsafe {
         // Now interrupts are disabled, grab the global variable and, if
         // available, send it a HID report
         USB_HID.as_mut().map(|hid| hid.push_input(&report))

--- a/rp2040-hal/examples/gpio_irq_example.rs
+++ b/rp2040-hal/examples/gpio_irq_example.rs
@@ -44,7 +44,7 @@ use hal::pac::interrupt;
 
 // Some short-cuts to useful types
 use core::cell::RefCell;
-use cortex_m::interrupt::Mutex;
+use critical_section::Mutex;
 use rp2040_hal::gpio;
 
 // The GPIO interrupt type we're going to generate
@@ -133,7 +133,7 @@ fn main() -> ! {
 
     // Give away our pins by moving them into the `GLOBAL_PINS` variable.
     // We won't need to access them in the main thread again
-    cortex_m::interrupt::free(|cs| {
+    critical_section::with(|cs| {
         GLOBAL_PINS.borrow(cs).replace(Some((led, in_pin)));
     });
 
@@ -159,7 +159,7 @@ fn IO_IRQ_BANK0() {
     // This is one-time lazy initialisation. We steal the variables given to us
     // via `GLOBAL_PINS`.
     if LED_AND_BUTTON.is_none() {
-        cortex_m::interrupt::free(|cs| {
+        critical_section::with(|cs| {
             *LED_AND_BUTTON = GLOBAL_PINS.borrow(cs).take();
         });
     }


### PR DESCRIPTION
For consistency let's use `critical_section` everywhere.

~(There was also a `cortex_m::interrupt::free` left over in `timer.rs`)~ 