### PR TITLE
Experiment: Remove defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ rp2040-hal = { path ="./rp2040-hal" }
 
 [patch.crates-io]
 rp2040-hal = { path ="./rp2040-hal" }
+rtt-target = { git = "https://github.com/Dirbaio/rtt-target/", rev = "98854f67efc160609c0c7ff63d5770c0e6694d1c" }

--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -16,7 +16,6 @@ rp2040-boot2 = { version = "0.2.0", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7.0", optional = true }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
-panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 embedded-time = "0.12.0"
 
 [dev-dependencies]

--- a/boards/pimoroni-badger2040/Cargo.toml
+++ b/boards/pimoroni-badger2040/Cargo.toml
@@ -23,9 +23,6 @@ panic-halt= "0.2.0"
 nb = "1.0"
 embedded-graphics = "0.7.1"
 
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
-
 [features]
 default = ["boot2", "rt"]
 boot2 = ["rp2040-boot2"]

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 
 [dev-dependencies]
-rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1" }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 smart-leds = "0.3.0"

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -18,14 +18,11 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 
 [dev-dependencies]
-rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0", features = [ "defmt" ] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
-
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/pimoroni-plasma-2040/build.rs
+++ b/boards/pimoroni-plasma-2040/build.rs
@@ -1,6 +1,0 @@
-//! This build script makes sure the linker flag -Tdefmt.x is added
-//! for the examples.
-
-fn main() {
-    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
-}

--- a/boards/pimoroni-plasma-2040/examples/pimoroni_plasma_2040_blinky.rs
+++ b/boards/pimoroni-plasma-2040/examples/pimoroni_plasma_2040_blinky.rs
@@ -2,11 +2,10 @@
 #![no_std]
 #![no_main]
 
-use defmt::*;
-use defmt_rtt as _;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_time::fixed_point::FixedPoint;
 use panic_halt as _;
+use rtt_target::{rprintln, rtt_init_print};
 
 use pimoroni_plasma_2040 as bsp;
 
@@ -23,7 +22,8 @@ use bsp::hal::{
 /// as soon as all global variables and the spinlock are initialised.
 #[rp2040_hal::entry]
 fn main() -> ! {
-    info!("Program start");
+    rtt_init_print!();
+    rprintln!("Program start");
     let mut pac = pac::Peripherals::take().unwrap();
     let core = pac::CorePeripherals::take().unwrap();
     let mut watchdog = Watchdog::new(pac.WATCHDOG);

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 
 [dev-dependencies]
-rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1" }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -18,12 +18,9 @@ cortex-m-rt = { version = "0.7", optional = true }
 embedded-time = "0.12.0"
 
 [dev-dependencies]
-rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0", features = [ "defmt" ] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
-
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/pimoroni-tiny2040/build.rs
+++ b/boards/pimoroni-tiny2040/build.rs
@@ -1,6 +1,0 @@
-//! This build script makes sure the linker flag -Tdefmt.x is added
-//! for the examples.
-
-fn main() {
-    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
-}

--- a/boards/pimoroni-tiny2040/examples/tiny2040_blinky.rs
+++ b/boards/pimoroni-tiny2040/examples/tiny2040_blinky.rs
@@ -3,11 +3,10 @@
 #![no_main]
 
 use bsp::entry;
-use defmt::*;
-use defmt_rtt as _;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_time::fixed_point::FixedPoint;
 use panic_halt as _;
+use rtt_target::{rprintln, rtt_init_print};
 
 use pimoroni_tiny2040 as bsp;
 
@@ -20,7 +19,8 @@ use bsp::hal::{
 
 #[entry]
 fn main() -> ! {
-    info!("Program start");
+    rtt_init_print!();
+    rprintln!("Program start");
     let mut pac = pac::Peripherals::take().unwrap();
     let core = pac::CorePeripherals::take().unwrap();
     let mut watchdog = Watchdog::new(pac.WATCHDOG);

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -22,7 +22,6 @@ usbd-hid = "0.5.1"
 futures = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
-rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0", features = [ "defmt" ] }
 panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 cortex-m-rtic = "1.1.2"
@@ -39,8 +38,7 @@ pio = "0.2.0"
 pio-proc = "0.2.1"
 critical-section = "1.0.0"
 
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -38,7 +38,7 @@ pio = "0.2.0"
 pio-proc = "0.2.1"
 critical-section = "1.0.0"
 
-rtt-target = { version = "0.3.1", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1" }
 
 [features]
 default = ["boot2", "rt"]

--- a/boards/rp-pico/build.rs
+++ b/boards/rp-pico/build.rs
@@ -1,6 +1,0 @@
-//! This build script makes sure the linker flag -Tdefmt.x is added
-//! for the examples.
-
-fn main() {
-    println!("cargo:rustc-link-arg-examples=-Tdefmt.x");
-}

--- a/boards/rp-pico/examples/pico_pio_pwm.rs
+++ b/boards/rp-pico/examples/pico_pio_pwm.rs
@@ -12,8 +12,8 @@
 #![no_std]
 #![no_main]
 
-use defmt::info;
-use defmt_rtt as _;
+use rtt_target::{rprintln, rtt_init_print};
+
 // The macro for our start-up function
 use rp_pico::entry;
 
@@ -90,6 +90,8 @@ fn pio_pwm_set_level<T: ValidStateMachine>(tx: &mut Tx<T>, level: u32) {
 /// infinite loop.
 #[entry]
 fn main() -> ! {
+    rtt_init_print!();
+
     // Grab our singleton objects
     let mut pac = pac::Peripherals::take().unwrap();
     let core = pac::CorePeripherals::take().unwrap();
@@ -156,7 +158,7 @@ fn main() -> ! {
     // Loop forever and adjust duty cycle to make te led brighter
     let mut level = 0;
     loop {
-        info!("Level = {}", level);
+        rprintln!("Level = {}", level);
         pio_pwm_set_level(&mut tx, level * level);
         level = (level + 1) % 256;
         delay.delay_ms(10);


### PR DESCRIPTION
This is not (yet?) meant for merging but just an experiment to see how using rtt-target instead of defmt would look like.
Removal of the defmt specific link flags simplifies the examples quite a bit. I think we should at least consider such a change.

Additionally, not requiring defmt would make the log messages usable for developers with an existing setup which supports rtt, but not defmt. (ie. many setups from the C world, without rust specific tooling). This was what initially triggered the discussion on defmt vs. rtt-target on the matrix channel.