### PR TITLE
Fix clocks docs "extended usage" to match `init_clocks_and_plls`

### DIFF
--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -22,12 +22,13 @@
 //! let mut watchdog = Watchdog::new(peripherals.WATCHDOG);
 //! const XOSC_CRYSTAL_FREQ: u32 = 12_000_000; // Typically found in BSP crates
 //!
-//! // Start tick in watchdog
-//! watchdog.enable_tick_generation(XOSC_CRYSTAL_FREQ as u8);
-//!
-//! let mut clocks = ClocksManager::new(peripherals.CLOCKS);
 //! // Enable the xosc
 //! let xosc = setup_xosc_blocking(peripherals.XOSC, XOSC_CRYSTAL_FREQ.Hz()).map_err(InitError::XoscErr)?;
+//!
+//! // Start tick in watchdog
+//! watchdog.enable_tick_generation((XOSC_CRYSTAL_FREQ / 1_000_000) as u8);
+//!
+//! let mut clocks = ClocksManager::new(peripherals.CLOCKS);
 //!
 //! // Configure PLLs
 //! //                   REF     FBDIV VCO            POSTDIV


### PR DESCRIPTION
The current extended usage clocks example is written correctly but the XOSC needs to be setup first in order for it to work properly. This matches the layout in `init_clocks_and_plls`.