### PR TITLE
Fix build of pico_spi_sd_card

### DIFF
--- a/boards/rp-pico/examples/pico_spi_sd_card.rs
+++ b/boards/rp-pico/examples/pico_spi_sd_card.rs
@@ -273,7 +273,7 @@ fn main() -> ! {
     blink_signals(&mut led_pin, &mut delay, &BLINK_OK_LONG);
 
     info!("Init SD card controller...");
-    let mut cont = Controller::new(block, DummyTimesource::default());
+    let mut cont: Controller<_, _, 4, 4> = Controller::new(block, DummyTimesource::default());
 
     blink_signals(&mut led_pin, &mut delay, &BLINK_OK_LONG);
 


### PR DESCRIPTION
The build failure was triggered by this commit:
https://github.com/rust-embedded-community/embedded-sdmmc-rs/commit/566f2023653dace195a43b05a6429f47e6be8a50

@ostenning, does this fix look reasonable? Was it intended that all callers of `Controller::new` would need to add those type parameters? (I'm not complaining about the breaking change. We are using a git dependency, therefore we have to live with breaking changes.)