### PR TITLE
Minimal fix for embedded-sdmmc build failure

### DIFF
--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -29,7 +29,7 @@ cortex-m-rtic = "1.1.2"
 nb = "1.0"
 i2c-pio = "0.3.0"
 heapless = "0.7.9"
-embedded-sdmmc = { git = "https://github.com/rust-embedded-community/embedded-sdmmc-rs.git" }
+embedded-sdmmc = { git = "https://github.com/rust-embedded-community/embedded-sdmmc-rs.git", rev = "db58253bb326d20e177c733ebc0b051ef0dcee0f" }
 smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
 ssd1306 = "0.7.0"

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -28,7 +28,6 @@ cortex-m-rtic = "1.1.2"
 nb = "1.0"
 i2c-pio = "0.3.0"
 heapless = "0.7.9"
-embedded-sdmmc = { git = "https://github.com/rust-embedded-community/embedded-sdmmc-rs.git" }
 smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
 ssd1306 = "0.7.0"


### PR DESCRIPTION
Just pin the git dependency on the most recent working version

As the failing CI builds are annoying, and https://github.com/rp-rs/rp-hal/pull/426 sparked some discussions, just fix the build by reverting to a working version of embedded-sdmmc.