### PR TITLE
Fix interpolator example post migration to fugit

### DIFF
--- a/boards/rp-pico/examples/pico_interpolator.rs
+++ b/boards/rp-pico/examples/pico_interpolator.rs
@@ -16,9 +16,6 @@
 // The macro for our start-up function
 use rp_pico::entry;
 
-// Time handling traits
-use embedded_time::rate::*;
-
 // GPIO traits
 use embedded_hal::digital::v2::OutputPin;
 
@@ -72,7 +69,7 @@ fn main() -> ! {
 
     // The delay object lets us wait for specified amounts of time (in
     // milliseconds)
-    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().integer());
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
 
     // The single-cycle I/O block controls our GPIO pins
     let mut sio = hal::Sio::new(pac.SIO);


### PR DESCRIPTION
For some reason this didn't get caught by CI.