### PR TITLE
Revert "Make Pimoroni Badger 2040's crate name consistent with it's directory"

### DIFF
--- a/boards/pimoroni-badger2040/Cargo.toml
+++ b/boards/pimoroni-badger2040/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pimoroni-badger2040"
+name = "pimoroni_badger2040"
 version = "0.2.0"
 authors = ["9names", "The rp-rs Developers"]
 edition = "2018"


### PR DESCRIPTION
Reverts rp-rs/rp-hal#435

I published it with the _ and this cannot be changed (yet? https://github.com/rust-lang/crates.io/issues/728)