### PR TITLE
examples: clarify usage of boot2 section

### DIFF
--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -28,6 +28,8 @@ use hal::pac;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/blinky.rs
+++ b/rp2040-hal/examples/blinky.rs
@@ -26,6 +26,8 @@ use rp2040_hal::clocks::Clock;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/dht11.rs
+++ b/rp2040-hal/examples/dht11.rs
@@ -31,6 +31,8 @@ use hal::Clock;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/gpio_in_out.rs
+++ b/rp2040-hal/examples/gpio_in_out.rs
@@ -26,6 +26,8 @@ use embedded_hal::digital::v2::OutputPin;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/gpio_irq_example.rs
+++ b/rp2040-hal/examples/gpio_irq_example.rs
@@ -49,6 +49,8 @@ use rp2040_hal::gpio::Interrupt::EdgeLow;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -26,6 +26,8 @@ use hal::pac;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/lcd_display.rs
+++ b/rp2040-hal/examples/lcd_display.rs
@@ -31,6 +31,8 @@ use hal::pac;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/multicore_fifo_blink.rs
+++ b/rp2040-hal/examples/multicore_fifo_blink.rs
@@ -31,6 +31,8 @@ use embedded_hal::digital::v2::ToggleableOutputPin;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/multicore_polyblink.rs
+++ b/rp2040-hal/examples/multicore_polyblink.rs
@@ -30,6 +30,8 @@ use embedded_hal::digital::v2::ToggleableOutputPin;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/pio_blink.rs
+++ b/rp2040-hal/examples/pio_blink.rs
@@ -11,6 +11,10 @@ use hal::Sio;
 use panic_halt as _;
 use rp2040_hal as hal;
 
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/pio_proc_blink.rs
+++ b/rp2040-hal/examples/pio_proc_blink.rs
@@ -11,6 +11,10 @@ use hal::Sio;
 use panic_halt as _;
 use rp2040_hal as hal;
 
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/pio_side_set.rs
+++ b/rp2040-hal/examples/pio_side_set.rs
@@ -13,6 +13,10 @@ use hal::Sio;
 use panic_halt as _;
 use rp2040_hal as hal;
 
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/pio_synchronized.rs
+++ b/rp2040-hal/examples/pio_synchronized.rs
@@ -13,6 +13,10 @@ use hal::Sio;
 use panic_halt as _;
 use rp2040_hal as hal;
 
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/pwm_blink.rs
+++ b/rp2040-hal/examples/pwm_blink.rs
@@ -27,6 +27,8 @@ use hal::pac;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -26,6 +26,8 @@ use hal::Clock;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -30,6 +30,8 @@ use hal::pac;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/uart.rs
+++ b/rp2040-hal/examples/uart.rs
@@ -28,6 +28,8 @@ use rp2040_hal::clocks::Clock;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;

--- a/rp2040-hal/examples/vector_table.rs
+++ b/rp2040-hal/examples/vector_table.rs
@@ -46,6 +46,8 @@ const FAST_BLINK_INTERVAL_US: MicrosDurationU32 = MicrosDurationU32::millis(300)
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;

--- a/rp2040-hal/examples/watchdog.rs
+++ b/rp2040-hal/examples/watchdog.rs
@@ -28,6 +28,8 @@ use rp2040_hal::clocks::Clock;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
 #[link_section = ".boot2"]
 #[used]
 pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;


### PR DESCRIPTION
Clarify in rp-hal examples that BOOT2 bootloader setup is unnecessary when using a rp-hal based BSP crate.