### PR TITLE
Enable critical-section-impl by default only from board crates, not from hal

### DIFF
--- a/boards/adafruit-feather-rp2040/Cargo.toml
+++ b/boards/adafruit-feather-rp2040/Cargo.toml
@@ -25,6 +25,7 @@ smart-leds = "0.3.0"
 ws2812-pio = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
+++ b/boards/adafruit-itsy-bitsy-rp2040/Cargo.toml
@@ -25,6 +25,7 @@ nb = "1.0.0"
 ws2812-pio = "0.3.0"
 
 [features]
-default = ["rt", "boot2"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/adafruit-kb2040/Cargo.toml
+++ b/boards/adafruit-kb2040/Cargo.toml
@@ -18,7 +18,8 @@ embedded-hal = { version = "0.2.4", features = ["unproven"] }
 rp2040-boot2 = { version = "0.2.0", optional = true }
 
 [features]
-default = ["rt", "boot2"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
 

--- a/boards/adafruit-macropad/Cargo.toml
+++ b/boards/adafruit-macropad/Cargo.toml
@@ -21,7 +21,8 @@ panic-halt= "0.2.0"
 embedded-hal ="0.2.5"
 
 [features]
-default = ["rt", "boot2"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
 

--- a/boards/adafruit-qt-py-rp2040/Cargo.toml
+++ b/boards/adafruit-qt-py-rp2040/Cargo.toml
@@ -25,6 +25,7 @@ nb = "1.0.0"
 ws2812-pio = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/adafruit-trinkey-qt2040/Cargo.toml
+++ b/boards/adafruit-trinkey-qt2040/Cargo.toml
@@ -24,6 +24,7 @@ nb = "1.0.0"
 ws2812-pio = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/arduino_nano_connect/Cargo.toml
+++ b/boards/arduino_nano_connect/Cargo.toml
@@ -25,6 +25,7 @@ embedded-hal ="0.2.5"
 nb = "1.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pimoroni-badger2040/Cargo.toml
+++ b/boards/pimoroni-badger2040/Cargo.toml
@@ -27,6 +27,7 @@ defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pimoroni-pico-explorer/Cargo.toml
+++ b/boards/pimoroni-pico-explorer/Cargo.toml
@@ -28,6 +28,7 @@ arrayvec = { version="0.7.1", default-features=false }
 nb = "1.0.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pimoroni-pico-lipo-16mb/Cargo.toml
+++ b/boards/pimoroni-pico-lipo-16mb/Cargo.toml
@@ -23,6 +23,7 @@ embedded-hal ="0.2.5"
 nb = "1.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -28,6 +28,7 @@ defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -26,6 +26,7 @@ defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -43,7 +43,8 @@ defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
 rp2040-e5 = ["rp2040-hal/rp2040-e5"]

--- a/boards/seeeduino-xiao-rp2040/Cargo.toml
+++ b/boards/seeeduino-xiao-rp2040/Cargo.toml
@@ -23,6 +23,7 @@ embedded-hal ="0.2.5"
 nb = "1.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/solderparty-rp2040-stamp/Cargo.toml
+++ b/boards/solderparty-rp2040-stamp/Cargo.toml
@@ -17,7 +17,8 @@ rp2040-hal = { path = "../../rp2040-hal", version = "0.5.0" }
 cortex-m-rt = { version = "0.7", optional = true }
 
 [features]
-default = ["rt", "boot2"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]
 

--- a/boards/sparkfun-pro-micro-rp2040/Cargo.toml
+++ b/boards/sparkfun-pro-micro-rp2040/Cargo.toml
@@ -26,6 +26,7 @@ pio = "0.1.0"
 ws2812-pio = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/sparkfun-thing-plus-rp2040/Cargo.toml
+++ b/boards/sparkfun-thing-plus-rp2040/Cargo.toml
@@ -26,6 +26,7 @@ pio = "0.1.0"
 ws2812-pio = "0.3.0"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/boards/vcc-gnd-yd-rp2040/Cargo.toml
+++ b/boards/vcc-gnd-yd-rp2040/Cargo.toml
@@ -37,6 +37,7 @@ pio = "0.2.0"
 pio-proc = "0.2.1"
 
 [features]
-default = ["boot2", "rt"]
+default = ["boot2", "rt", "critical-section-impl"]
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
 boot2 = ["rp2040-boot2"]
 rt = ["cortex-m-rt","rp2040-hal/rt"]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -44,7 +44,6 @@ pio-proc = "0.2.0"
 dht-sensor = "0.2.1"
 
 [features]
-default = ["critical-section-impl"]
 rt = ["rp2040-pac/rt"]
 rom-func-cache = []
 disable-intrinsics = []


### PR DESCRIPTION
There are a lot of non-binary crates depending on rp2040-hal. That way, the default-features of rp2040-hal may be activated unintentionally through an indirect dependency. Therefore, a binary crate which wants to disable the `critical-section-impl` feature to provide its own one could have a hard time to do so.

In contrast, the board support crates are usually only used by top-level binary crates. So disabling the default features on those should usually just work.

Binary crates depending on rp2040-hal directly, which don't use any board support crate, might need to activate the feature manually. This is reasonable because those binary crates need to replicate some boilerplate from the board crates anyhow.