### PR TITLE
Use rp2040_boot2::BOOT_LOADER_GENERIC_03H in the vector-table example

### DIFF
--- a/rp2040-hal/examples/vector_table.rs
+++ b/rp2040-hal/examples/vector_table.rs
@@ -48,7 +48,7 @@ const FAST_BLINK_INTERVAL_US: MicrosDurationU32 = MicrosDurationU32::millis(300)
 /// need this to help the ROM bootloader get our code up and running.
 #[link_section = ".boot2"]
 #[used]
-pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
 /// if your board has a different frequency


### PR DESCRIPTION
This PR aligns the `vector_table` example with the other examples from `rp2040-hal`.