### PR TITLE
fix concurrent accesses to sm_execctrl and sm_instr when sideset isn't optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ rp2040-hal = { path = "./rp2040-hal" }
 
 [patch.crates-io]
 rp2040-hal = { path = "./rp2040-hal" }
+i2c-pio = { git = "https://github.com/ithinuel/i2c-pio-rs", branch = "fix-pio-exec-instruction" }

--- a/boards/rp-pico/examples/pico_pio_pwm.rs
+++ b/boards/rp-pico/examples/pico_pio_pwm.rs
@@ -34,7 +34,7 @@ use rp_pico::hal;
 
 // Import pio crates
 use hal::pio::{PIOBuilder, Running, StateMachine, Tx, ValidStateMachine, SM0};
-use pio::{InstructionOperands, OutDestination};
+use pio::{Instruction, InstructionOperands, OutDestination};
 use pio_proc::pio_file;
 
 /// Set pio pwm period
@@ -53,20 +53,22 @@ fn pio_pwm_set_period<T: ValidStateMachine>(
 
     let mut sm = sm.stop();
     tx.write(period);
-    sm.exec_instruction(
-        InstructionOperands::PULL {
+    sm.exec_instruction(Instruction {
+        operands: InstructionOperands::PULL {
             if_empty: false,
             block: false,
-        }
-        .encode(),
-    );
-    sm.exec_instruction(
-        InstructionOperands::OUT {
+        },
+        delay: 0,
+        side_set: None,
+    });
+    sm.exec_instruction(Instruction {
+        operands: InstructionOperands::OUT {
             destination: OutDestination::ISR,
             bit_count: 32,
-        }
-        .encode(),
-    );
+        },
+        delay: 0,
+        side_set: None,
+    });
     sm.start()
 }
 


### PR DESCRIPTION
This also includes an alternative implementation of the install function with the hope that using pattern matching will give more opportunity to the compiler to prune the branches we are not interested in.