### PR TITLE
Added set_fifos/set_rx_watermark/set_tx_watermark

### DIFF
--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -62,7 +62,7 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Disabled, D, P> {
 
         device.uartlcr_h.write(|w| {
             // FIFOs are enabled
-            w.fen().set_bit();
+            w.fen().set_bit(); // Leaved here for backward compatibility
             set_format(w, &config.data_bits, &config.stop_bits, &config.parity);
             w
         });
@@ -106,6 +106,29 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Enabled, D, P> {
         });
 
         self.transition(Disabled)
+    }
+
+    /// Enable/disable the rx/tx FIFO
+    ///
+    /// Unfortunately, it's not possible to enable/disable rx/tx
+    /// independently on this chip
+    /// Default is false
+    pub fn set_fifos(&mut self, enable: bool) {
+        super::reader::set_fifos(&self.device, enable)
+    }
+
+    /// Set rx FIFO watermark
+    ///
+    /// See DS: Table 423
+    pub fn set_rx_watermark(&mut self, watermark: FifoWatermark) {
+        super::reader::set_rx_watermark(&self.device, watermark)
+    }
+
+    /// Set tx FIFO watermark
+    ///
+    /// See DS: Table 423
+    pub fn set_tx_watermark(&mut self, watermark: FifoWatermark) {
+        super::writer::set_tx_watermark(&self.device, watermark)
     }
 
     /// Enables the Receive Interrupt.

--- a/rp2040-hal/src/uart/utils.rs
+++ b/rp2040-hal/src/uart/utils.rs
@@ -44,7 +44,6 @@ pub enum DataBits {
 pub enum StopBits {
     /// 1 bit
     One,
-
     /// 2 bits
     Two,
 }
@@ -54,7 +53,6 @@ pub enum StopBits {
 pub enum Parity {
     /// Odd parity
     Odd,
-
     /// Even parity
     Even,
 }
@@ -84,6 +82,28 @@ pub struct UartConfig {
 
     /// The parity that this uart should have
     pub parity: Option<Parity>,
+}
+
+/// Rx/Tx FIFO Watermark
+///
+/// Determine the FIFO level that trigger DMA/Interrupt
+/// Default is Bytes16, see DS Table 423 and UARTIFLS Register
+/// Example of use:
+///     uart0.set_fifos(true); // Default is false
+///     uart0.set_rx_watermark(hal::uart::FifoWatermark::Bytes8);
+///     uart0.enable_rx_interrupt();
+///
+pub enum FifoWatermark {
+    /// Trigger when 4 bytes are (Rx: filled / Tx: available)
+    Bytes4,
+    /// Trigger when 8 bytes are (Rx: filled / Tx: available)
+    Bytes8,
+    /// Trigger when 16 bytes are (Rx: filled / Tx: available)
+    Bytes16,
+    /// Trigger when 24 bytes are (Rx: filled / Tx: available)
+    Bytes24,
+    /// Trigger when 28 bytes are (Rx: filled / Tx: available)
+    Bytes28,
 }
 
 impl Default for UartConfig {


### PR DESCRIPTION
I added the possibility to enable/disable the UART Rx/tx FIFOs as well as setting the watermark for the Rx/Tx  FIFO independently.
I removed the watermark setting on the enable_rx_interrupt function. Since the default value for the watermark is the same as the one set in the enable_rx_interrupt function, it is backward compatible.