### PR TITLE
Provide rp2040_hal::gpio::pin::Pin::into_push_pull_output_in_state

### DIFF
--- a/boards/adafruit-itsy-bitsy-rp2040/examples/adafruit_itsy_bitsy_rainbow.rs
+++ b/boards/adafruit-itsy-bitsy-rp2040/examples/adafruit_itsy_bitsy_rainbow.rs
@@ -4,7 +4,6 @@
 
 use adafruit_itsy_bitsy_rp2040::entry;
 use core::iter::once;
-use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
 use fugit::ExtU32;
 use panic_halt as _;
@@ -14,6 +13,7 @@ use ws2812_pio::Ws2812;
 use adafruit_itsy_bitsy_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
+        gpio::PinState,
         pac,
         pio::PIOExt,
         watchdog::Watchdog,
@@ -51,9 +51,7 @@ fn main() -> ! {
     let led = pins.neopixel_data.into_mode();
 
     pins.neopixel_power
-        .into_push_pull_output()
-        .set_high()
-        .unwrap();
+        .into_push_pull_output_in_state(PinState::High);
 
     let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
     let mut delay = timer.count_down();

--- a/boards/adafruit-qt-py-rp2040/examples/adafruit_qt_py_rp2040_rainbow.rs
+++ b/boards/adafruit-qt-py-rp2040/examples/adafruit_qt_py_rp2040_rainbow.rs
@@ -4,7 +4,6 @@
 
 use adafruit_qt_py_rp2040::entry;
 use core::iter::once;
-use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::timer::CountDown;
 use fugit::ExtU32;
 use panic_halt as _;
@@ -14,6 +13,7 @@ use ws2812_pio::Ws2812;
 use adafruit_qt_py_rp2040::{
     hal::{
         clocks::{init_clocks_and_plls, Clock},
+        gpio::PinState,
         pac,
         pio::PIOExt,
         watchdog::Watchdog,
@@ -51,9 +51,7 @@ fn main() -> ! {
     let led = pins.neopixel_data.into_mode();
 
     pins.neopixel_power
-        .into_push_pull_output()
-        .set_high()
-        .unwrap();
+        .into_push_pull_output_in_state(PinState::High);
 
     let timer = Timer::new(pac.TIMER, &mut pac.RESETS);
     let mut delay = timer.count_down();

--- a/boards/pimoroni-plasma-2040/examples/pimoroni_plasma_2040_blinky.rs
+++ b/boards/pimoroni-plasma-2040/examples/pimoroni_plasma_2040_blinky.rs
@@ -11,6 +11,7 @@ use pimoroni_plasma_2040 as bsp;
 
 use bsp::hal::{
     clocks::{init_clocks_and_plls, Clock},
+    gpio::PinState,
     pac,
     sio::Sio,
     watchdog::Watchdog,
@@ -49,12 +50,11 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    let mut led_green = pins.led_green.into_push_pull_output();
-    let mut led_red = pins.led_red.into_push_pull_output();
-    let mut led_blue = pins.led_blue.into_push_pull_output();
-    led_green.set_high().unwrap();
-    led_red.set_high().unwrap();
-    led_blue.set_high().unwrap();
+    let mut led_green = pins
+        .led_green
+        .into_push_pull_output_in_state(PinState::High);
+    let mut led_red = pins.led_red.into_push_pull_output_in_state(PinState::High);
+    let mut led_blue = pins.led_blue.into_push_pull_output_in_state(PinState::High);
 
     loop {
         led_green.set_low().unwrap();

--- a/boards/seeeduino-xiao-rp2040/examples/seeeduino_xiao_rp2040_blinky.rs
+++ b/boards/seeeduino-xiao-rp2040/examples/seeeduino_xiao_rp2040_blinky.rs
@@ -32,6 +32,8 @@ use seeeduino_xiao_rp2040::hal::pac;
 // higher-level drivers.
 use seeeduino_xiao_rp2040::hal;
 
+use hal::gpio::PinState;
+
 // The minimum PWM value (i.e. LED brightness) we want
 const LOW: u16 = 0;
 
@@ -98,12 +100,12 @@ fn main() -> ! {
     channel.set_duty(u16::MAX);
 
     // Set the blue LED to be an output, initially off
-    let mut led_blue_pin = pins.led_blue.into_push_pull_output();
-    led_blue_pin.set_high().unwrap();
+    let mut led_blue_pin = pins.led_blue.into_push_pull_output_in_state(PinState::High);
 
     // Turn off the green LED
-    let mut led_green_pin = pins.led_green.into_push_pull_output();
-    led_green_pin.set_high().unwrap();
+    let mut _led_green_pin = pins
+        .led_green
+        .into_push_pull_output_in_state(PinState::High);
 
     loop {
         // Blink blue LED at 1 Hz

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -105,6 +105,7 @@ use core::marker::PhantomData;
 use crate::gpio::dynpin::DynFunction;
 #[cfg(feature = "eh1_0_alpha")]
 use eh1_0_alpha::digital as eh1;
+pub use embedded_hal::digital::v2::PinState;
 use hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 use core::mem::transmute;
@@ -527,15 +528,41 @@ where
         self.into_mode()
     }
 
-    /// Configure the pin to operate as a push-pull output
+    /// Configure the pin to operate as a push-pull output.
+    ///
+    /// If you want to specify the initial pin state, use [`Pin::into_push_pull_output_in_state`].
     #[inline]
     pub fn into_push_pull_output(self) -> Pin<I, PushPullOutput> {
         self.into_mode()
     }
 
-    /// Configure the pin to operate as a readable push pull output
+    /// Configure the pin to operate as a push-pull output, specifying an initial
+    /// state which is applied immediately.
+    #[inline]
+    pub fn into_push_pull_output_in_state(mut self, state: PinState) -> Pin<I, PushPullOutput> {
+        match state {
+            PinState::High => self._set_high(),
+            PinState::Low => self._set_low(),
+        }
+        self.into_mode()
+    }
+
+    /// Configure the pin to operate as a readable push pull output.
+    ///
+    /// If you want to specify the initial pin state, use [`Pin::into_readable_output_in_state`].
     #[inline]
     pub fn into_readable_output(self) -> Pin<I, ReadableOutput> {
+        self.into_mode()
+    }
+
+    /// Configure the pin to operate as a readable push pull output, specifying an initial
+    /// state which is applied immediately.
+    #[inline]
+    pub fn into_readable_output_in_state(mut self, state: PinState) -> Pin<I, ReadableOutput> {
+        match state {
+            PinState::High => self._set_high(),
+            PinState::Low => self._set_low(),
+        }
         self.into_mode()
     }
 


### PR DESCRIPTION
With just `into_push_pull_output`, the pin may be driven to the wrong level for a short moment between setting the pin to output and setting the right level.
Using `into_push_pull_output_in_state` avoids that.