### PR TITLE
Fix UART read error discard data

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (Non-blocking traits were moved to embedded-hal-nb, which is not yet supported)
 - Implement UartConfig::new constructor method - @jannic
 - Deprecate uart::common_configs - @jannic
+- Fix spelling error in UART error discarded field - @Sizurka
 
 ## [0.6.0] - 2022-08-26
 

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -16,8 +16,8 @@ pub struct ReadError<'err> {
     /// The type of error
     pub err_type: ReadErrorType,
 
-    /// Reference to the data that was read but eventually discared because of the error.
-    pub discared: &'err [u8],
+    /// Reference to the data that was read but eventually discarded because of the error.
+    pub discarded: &'err [u8],
 }
 
 /// Possible types of read errors. See Chapter 4, Section 2 §8 - Table 436: "UARTDR Register"
@@ -149,7 +149,7 @@ pub(crate) fn read_raw<'b, D: UartDevice>(
             if let Some(err_type) = error {
                 return Err(Other(ReadError {
                     err_type,
-                    discared: buffer,
+                    discarded: &buffer[..bytes_read],
                 }));
             }
 


### PR DESCRIPTION
The current handling of a UART error does not accurately report the data before the error.  It currently just returns the whole buffer passed, which will potentially have been partly written by any data read before the error.  Fix this by returning the slice of data that has been read so far.

Also fix a spelling error in the field name.