### PR TITLE
Remove unnecessary `mut` from `static mut LOCK_OWNER: AtomicU8` in critical section impl.

### DIFF
--- a/rp2040-hal/src/critical_section_impl.rs
+++ b/rp2040-hal/src/critical_section_impl.rs
@@ -14,7 +14,7 @@ const LOCK_UNOWNED: u8 = 0;
 /// Indicates which core owns the lock so that we can call critical_section recursively.
 ///
 /// 0 = no one has the lock, 1 = core0 has the lock, 2 = core1 has the lock
-static mut LOCK_OWNER: AtomicU8 = AtomicU8::new(LOCK_UNOWNED);
+static LOCK_OWNER: AtomicU8 = AtomicU8::new(LOCK_UNOWNED);
 
 /// Marker value to indicate that we already owned the lock when we started the `critical_section`.
 ///


### PR DESCRIPTION
`LOCK_OWNER` is only accessed using the atomic APIs, which take `&self`, so it does not need to be `static mut`, `static` is fine.