### PR TITLE
Add ability to modify installed program wrap bounds

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -292,7 +292,25 @@ pub struct InstalledProgram<P> {
 }
 
 impl<P: PIOExt> InstalledProgram<P> {
-    /// Get the warp target (entry point) of the instaled program.
+    /// Change the source and/or target for automatic program wrapping.
+    ///
+    /// This replaces the current wrap bounds with a new set. This can be useful if you are running
+    /// multiple state machines with the same program but using different wrap bounds.
+    ///
+    /// # Returns
+    ///
+    /// * [`Ok`] containing a new program with the provided wrap bounds
+    /// * [`Err`] containing the old program if the provided wrap was invalid (outside the bounds of
+    ///   the program length)
+    pub fn set_wrap(self, wrap: Wrap) -> Result<Self, Self> {
+        if (self.offset + wrap.source) < self.length && (self.offset + wrap.target) < self.length {
+            Ok(InstalledProgram { wrap, ..self })
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Get the wrap target (entry point) of the installed program.
     pub fn wrap_target(&self) -> u8 {
         self.offset + self.wrap.target
     }

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -303,7 +303,7 @@ impl<P: PIOExt> InstalledProgram<P> {
     /// * [`Err`] containing the old program if the provided wrap was invalid (outside the bounds of
     ///   the program length)
     pub fn set_wrap(self, wrap: Wrap) -> Result<Self, Self> {
-        if (self.offset + wrap.source) < self.length && (self.offset + wrap.target) < self.length {
+        if wrap.source < self.length && wrap.target < self.length {
             Ok(InstalledProgram { wrap, ..self })
         } else {
             Err(self)


### PR DESCRIPTION
The wrap source and target cannot change after installing the program
into the PIO at present, even though this is possible with the C/C++
HAL. This is useful when using the same program across multiple state
machines that have different wrap sources and targets.
