### PR TITLE
Add derive(Debug) and derive(defmt::Format) to error types

### DIFF
--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -43,6 +43,7 @@ use crate::Sio;
 
 /// Errors for multicore operations.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Operation is invalid on this core.
     InvalidCore,

--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -73,6 +73,8 @@ impl<S: State, D: PhaseLockedLoopDevice> PhaseLockedLoop<S, D> {
 
 /// Error type for the PLL module.
 /// See Chapter 2, Section 18 §2 for details on constraints triggering these errors.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Proposed VCO frequency is out of range.
     VcoFreqOutOfRange,

--- a/rp2040-hal/src/rtc/datetime_no_deps.rs
+++ b/rp2040-hal/src/rtc/datetime_no_deps.rs
@@ -4,6 +4,7 @@ use rp2040_pac::rtc::{rtc_0, rtc_1, setup_0, setup_1};
 ///
 /// [`DateTimeFilter`]: struct.DateTimeFilter.html
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// The [DateTime] contains an invalid year value. Must be between `0..=4095`.
     InvalidYear,

--- a/rp2040-hal/src/uart/utils.rs
+++ b/rp2040-hal/src/uart/utils.rs
@@ -5,6 +5,7 @@ use fugit::HertzU32;
 
 /// Error type for UART operations.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Bad argument : when things overflow, ...
     BadArgument,

--- a/rp2040-hal/src/xosc.rs
+++ b/rp2040-hal/src/xosc.rs
@@ -32,6 +32,8 @@ impl State for Stable {}
 impl State for Dormant {}
 
 /// Possible errors when initializing the CrystalOscillator
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Frequency is out of the 1-15MHz range (see datasheet)
     FrequencyOutOfRange,


### PR DESCRIPTION
pll and xosc Error types didn't implement Debug, which made them annoying to work with.
And only a few of our Error types implemented derive(defmt::Format).
I added both to all the errors I could find to make things a little more consistent.