### PR TITLE
Specify required feature critical-section-impl for some examples

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -67,9 +67,9 @@ critical-section-impl = ["critical-section/restore-state-u8"]
 [[example]]
 # irq example uses cortex-m-rt::interrupt, need rt feature for that
 name = "gpio_irq_example"
-required-features = ["rt"]
+required-features = ["rt", "critical-section-impl"]
 
 [[example]]
 # vector_table example uses cortex-m-rt::interrupt, need rt feature for that
 name = "vector_table"
-required-features = ["rt"]
+required-features = ["rt", "critical-section-impl"]


### PR DESCRIPTION
Not perfect, but at least leads to a meaningful error message when the feature is missing:
```
error: target `vector_table` in package `rp2040-hal` requires the features: `rt`, `critical-section-impl`
Consider enabling them by passing, e.g., `--features="rt critical-section-impl"`
```
