### PR TITLE
implement embedded-hal aplha SPI traits

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -230,7 +230,91 @@ macro_rules! impl_write {
             type Error = Infallible;
         }
 
-/* disabled for now - nb was migrated to separate crate
+        #[cfg(feature = "eh1_0_alpha")]
+        impl<D: SpiDevice> eh1::SpiBusFlush for Spi<Enabled, D, $nr> {
+            fn flush(&mut self) -> Result<(), Self::Error> {
+                while self.is_busy() {}
+                Ok(())
+            }
+        }
+
+        #[cfg(feature = "eh1_0_alpha")]
+        impl<D: SpiDevice> eh1::SpiBusRead<$type> for Spi<Enabled, D, $nr> {
+            fn read(&mut self, words: &mut [$type]) -> Result<(), Self::Error> {
+                for word in words.iter_mut() {
+                    // write empty word
+                    while !self.is_writable() {}
+                    self.device
+                        .sspdr
+                        .write(|w| unsafe { w.data().bits(0) });
+
+                    // read one word
+                    while !self.is_readable() {}
+                    *word = self.device.sspdr.read().data().bits() as $type;
+                }
+                Ok(())
+            }
+        }
+
+        #[cfg(feature = "eh1_0_alpha")]
+        impl<D: SpiDevice> eh1::SpiBusWrite<$type> for Spi<Enabled, D, $nr> {
+            fn write(&mut self, words: &[$type]) -> Result<(), Self::Error> {
+                for word in words.iter() {
+                    // write one word
+                    while !self.is_writable() {}
+                    self.device
+                        .sspdr
+                        .write(|w| unsafe { w.data().bits(*word as u16) });
+
+                    // drop read wordd
+                    while !self.is_readable() {}
+                    let _ = self.device.sspdr.read().data().bits();
+                }
+                Ok(())
+            }
+        }
+
+        #[cfg(feature = "eh1_0_alpha")]
+        impl<D: SpiDevice> eh1::SpiBus<$type> for Spi<Enabled, D, $nr> {
+            fn transfer(&mut self, read: &mut [$type], write: &[$type]) -> Result<(), Self::Error>{
+                let len = read.len().max(write.len());
+                for i in 0..len {
+                    // write one word. Send empty word if buffer is empty.
+                    let wb = write.get(i).copied().unwrap_or(0);
+                    while !self.is_writable() {}
+                    self.device
+                        .sspdr
+                        .write(|w| unsafe { w.data().bits(wb as u16) });
+
+                    // read one word. Drop extra words if buffer is full.
+                    while !self.is_readable() {}
+                    let rb = self.device.sspdr.read().data().bits() as $type;
+                    if let Some(r) = read.get_mut(i) {
+                        *r = rb;
+                    }
+                }
+
+                Ok(())
+            }
+
+            fn transfer_in_place(&mut self, words: &mut [$type]) -> Result<(), Self::Error>{
+                for word in words.iter_mut() {
+                    // write one word
+                    while !self.is_writable() {}
+                    self.device
+                        .sspdr
+                        .write(|w| unsafe { w.data().bits(*word as u16) });
+
+                    // read one word
+                    while !self.is_readable() {}
+                    *word = self.device.sspdr.read().data().bits() as $type;
+                }
+
+                Ok(())
+            }
+        }
+
+        /* disabled for now - nb was migrated to separate crate
         #[cfg(feature = "eh1_0_alpha")]
         impl<D: SpiDevice> eh1::nb::FullDuplex<$type> for Spi<Enabled, D, $nr> {
             fn read(&mut self) -> Result<$type, nb::Error<Infallible>> {


### PR DESCRIPTION
This PR implements the latest embedded-hal v1.0.0-alpha.9 SPI traits (just the blocking traits). 

# Summary 

Took advice straight from the repo to do it.

https://github.com/rust-embedded/embedded-hal/blob/9eb6dabe4694d7bf6400de7c10665d6439b0f370/embedded-hal/src/spi.rs#L132-L142

```markdown
# For HAL authors

HALs **must** implement [`SpiBus`], [`SpiBusRead`] and [`SpiBusWrite`]. Users can combine the bus together with the CS pin (which should
implement [`OutputPin`](crate::digital::blocking::OutputPin)) using HAL-independent [`SpiDevice`] implementations such as the ones in [`embedded-hal-bus`](https://crates.io/crates/embedded-hal-bus).

HALs may additionally implement [`SpiDevice`] to **take advantage of hardware CS management**, which may provide some performance
benefits. (There's no point in a HAL implementing [`SpiDevice`] if the CS management is software-only, this task is better left to
the HAL-independent implementations).

HALs **must not** add infrastructure for sharing at the [`SpiBus`] level. User code owning a [`SpiBus`] must have the guarantee
of exclusive access.
```

Logic for read and write was also inspired by the embassy project:  it took me a really long time to realize that you still have to send empty words to do read-only and drop reads to do write-only, and the embassy implementation demonstrated that.

https://github.com/embassy-rs/embassy/blob/master/embassy-rp/src/spi.rs

# Testing

I tested this by rewriting [mcp2515 crate](https://crates.io/crates/mcp2515) implementation to use `SpiDevice`.

# Other notes:
This will affect the existing PR #469. cc: @pietgeursen