### PR TITLE
UsbBus::poll clears suspended interrupt when ints.dev_suspend is set

### DIFF
--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -615,6 +615,7 @@ impl UsbBusTrait for UsbBus {
 
             // check for bus reset and/or suspended states.
             let sie_status = inner.ctrl_reg.sie_status.read();
+            let ints = inner.ctrl_reg.ints.read();
             let mut buff_status = inner.ctrl_reg.buff_status.read().bits();
 
             if sie_status.bus_reset().bit_is_set() {
@@ -629,7 +630,7 @@ impl UsbBusTrait for UsbBus {
                 #[cfg(not(feature = "rp2040-e5"))]
                 return PollResult::Reset;
             } else if buff_status == 0 && sie_status.setup_rec().bit_is_clear() {
-                if sie_status.suspended().bit_is_set() {
+                if sie_status.suspended().bit_is_set() || ints.dev_suspend().bit_is_set() {
                     inner.ctrl_reg.sie_status.write(|w| w.suspended().set_bit());
                     return PollResult::Suspend;
                 } else if sie_status.resume().bit_is_set() {


### PR DESCRIPTION
My device often sees USBCTRL_IRQ interrupt storms after reset.  This appears to
be because INTS DEV_SUSPEND is set, but SIE.SUSPEND is not cleared by
UsbBus::poll().
