### PR TITLE
Allow setting clock divisors on running state machines

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -636,6 +636,20 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
             }
         }
     }
+
+    /// Change the clock divider of a state machine.
+    pub fn set_clock_divisor(&mut self, divisor: f32) {
+        // sm frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+        let int = divisor as u16;
+        let frac = ((divisor - int as f32) * 256.0) as u8;
+
+        self.sm.set_clock_divisor(int, frac);
+    }
+
+    /// Change the clock divider of a state machine using a 16.8 fixed point value.
+    pub fn clock_divisor_fixed_point(&mut self, int: u16, frac: u8) {
+        self.sm.set_clock_divisor(int, frac);
+    }
 }
 
 // Safety: All shared register accesses are atomic.
@@ -654,20 +668,6 @@ impl<SM: ValidStateMachine> StateMachine<SM, Stopped> {
             program: self.program,
             _phantom: core::marker::PhantomData,
         }
-    }
-
-    /// Change the clock divider of a stopped state machine.
-    pub fn set_clock_divisor(&mut self, divisor: f32) {
-        // sm frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
-        let int = divisor as u16;
-        let frac = ((divisor - int as f32) * 256.0) as u8;
-
-        self.sm.set_clock_divisor(int, frac);
-    }
-
-    /// Change the clock divider of a stopped state machine using a 16.8 fixed point value.
-    pub fn clock_divisor_fixed_point(&mut self, int: u16, frac: u8) {
-        self.sm.set_clock_divisor(int, frac);
     }
 
     /// Sets the pin state for the specified pins.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -638,6 +638,10 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
     }
 
     /// Change the clock divider of a state machine.
+    ///
+    /// Changing the clock divider of a running state machine is allowed
+    /// and guaranteed to not cause any glitches, but the exact timing of
+    /// clock pulses during the change is not specified.
     pub fn set_clock_divisor(&mut self, divisor: f32) {
         // sm frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
         let int = divisor as u16;
@@ -647,6 +651,10 @@ impl<SM: ValidStateMachine, State> StateMachine<SM, State> {
     }
 
     /// Change the clock divider of a state machine using a 16.8 fixed point value.
+    ///
+    /// Changing the clock divider of a running state machine is allowed
+    /// and guaranteed to not cause any glitches, but the exact timing of
+    /// clock pulses during the change is not specified.
     pub fn clock_divisor_fixed_point(&mut self, int: u16, frac: u8) {
         self.sm.set_clock_divisor(int, frac);
     }


### PR DESCRIPTION
The documentation of CLKDIV_RESTART contains the following sentence:

"Note also that CLKDIV_RESTART can be written to whilst the state machine is running, and this is useful to resynchronise clock dividers after the divisors (SMx_CLKDIV) have been changed on-the-fly."

This implies that it's allowed to change the value of CLKDIV on a running state machine.