### PR TITLE
Avoid dead_code warning if critical-section-impl is not enabled

### DIFF
--- a/rp2040-hal/src/critical_section_impl.rs
+++ b/rp2040-hal/src/critical_section_impl.rs
@@ -1,9 +1,7 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
 struct RpSpinlockCs;
-#[cfg(feature = "critical-section-impl")]
 critical_section_0_2::custom_impl!(RpSpinlockCs);
-#[cfg(feature = "critical-section-impl")]
 critical_section::set_impl!(RpSpinlockCs);
 
 /// Marker value to indicate no-one has the lock.
@@ -24,7 +22,6 @@ static LOCK_OWNER: AtomicU8 = AtomicU8::new(LOCK_UNOWNED);
 /// The value 2 indicates that we aren't the outermost call, and should not release the spinlock or re-enable interrupts in `release`
 const LOCK_ALREADY_OWNED: u8 = 2;
 
-#[cfg(feature = "critical-section-impl")]
 unsafe impl critical_section_0_2::Impl for RpSpinlockCs {
     unsafe fn acquire() -> u8 {
         RpSpinlockCs::acquire()
@@ -35,7 +32,6 @@ unsafe impl critical_section_0_2::Impl for RpSpinlockCs {
     }
 }
 
-#[cfg(feature = "critical-section-impl")]
 unsafe impl critical_section::Impl for RpSpinlockCs {
     unsafe fn acquire() -> u8 {
         RpSpinlockCs::acquire()

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -19,6 +19,7 @@ mod intrinsics;
 pub mod adc;
 pub(crate) mod atomic_register_access;
 pub mod clocks;
+#[cfg(feature = "critical-section-impl")]
 mod critical_section_impl;
 pub mod dma;
 mod float;

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -638,7 +638,12 @@ pub type Spinlock30 = Spinlock<30>;
 impl SpinlockValid for Spinlock<30> {}
 
 /// Spinlock number 31 - used by critical section implementation
+#[cfg(feature = "critical-section-impl")]
 pub(crate) type Spinlock31 = Spinlock<31>;
+
+/// Spinlock number 31 - only public if critical-section-impl is not enabled
+#[cfg(not(feature = "critical-section-impl"))]
+pub type Spinlock31 = Spinlock<31>;
 
 impl SpinlockValid for Spinlock<31> {}
 


### PR DESCRIPTION
Also make Spinlock31 public if it's not used by the critical section impl