### PR TITLE
Remove support for deprecated version 0.2 of critical-section

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a method to allow setting the PIO's clock divisor without floats - @ithinuel
 - Use TimerInstant in Timer::GetCounter & add Alarm::schedule_at - @ithinuel
 
+### Removed
+
+- Removed support for critical-section 0.2 (was already deprecated) - @jannic
+
 ## [0.6.0] - 2022-08-26
 
 ### Added

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -29,9 +29,6 @@ usb-device = "0.2.9"
 vcell = "0.1"
 void = { version = "1.0.2", default-features = false }
 rand_core = "0.6.3"
-# Always set the custom-impl feature of legacy critical-section, even if we don't provide our own,
-# as the default implementation should no longer be used.
-critical-section_0_2 = { package = "critical-section", version = "0.2.4", features = ["custom-impl"] }
 critical-section = { version = "1.0.0" }
 
 chrono = { version = "0.4", default-features = false, optional = true }

--- a/rp2040-hal/README.md
+++ b/rp2040-hal/README.md
@@ -105,11 +105,6 @@ at the same time.
 The new blocking [SPI traits](https://docs.rs/embedded-hal/1.0.0-alpha.8/embedded_hal/spi/blocking/index.html)
 are not yet implemented.
 
-### Support for critical-section 0.2
-
-While `rp2040-hal` uses critical-section 1.0, it still provides support for version 0.2.
-That version is deprecated, and support will be removed in a future release. Please upgrade.
-
 <!-- CONTRIBUTING -->
 ## Contributing
 

--- a/rp2040-hal/src/critical_section_impl.rs
+++ b/rp2040-hal/src/critical_section_impl.rs
@@ -1,7 +1,6 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
 struct RpSpinlockCs;
-critical_section_0_2::custom_impl!(RpSpinlockCs);
 critical_section::set_impl!(RpSpinlockCs);
 
 /// Marker value to indicate no-one has the lock.
@@ -21,16 +20,6 @@ static LOCK_OWNER: AtomicU8 = AtomicU8::new(LOCK_UNOWNED);
 /// If we're the outermost call to `critical_section` we use the values 0 and 1 to indicate we should release the spinlock and set the interrupts back to disabled and enabled, respectively.
 /// The value 2 indicates that we aren't the outermost call, and should not release the spinlock or re-enable interrupts in `release`
 const LOCK_ALREADY_OWNED: u8 = 2;
-
-unsafe impl critical_section_0_2::Impl for RpSpinlockCs {
-    unsafe fn acquire() -> u8 {
-        RpSpinlockCs::acquire()
-    }
-
-    unsafe fn release(token: u8) {
-        RpSpinlockCs::release(token);
-    }
-}
 
 unsafe impl critical_section::Impl for RpSpinlockCs {
     unsafe fn acquire() -> u8 {


### PR DESCRIPTION
Critical-section 0.2 may be yanked soon, so we should remove the dependency and release a version 0.7.0.