### PR TITLE
Update dependencies on defmt-rtt to 0.4.0

### DIFF
--- a/boards/pimoroni-plasma-2040/Cargo.toml
+++ b/boards/pimoroni-plasma-2040/Cargo.toml
@@ -25,7 +25,7 @@ ws2812-pio = "0.4.0"
 fugit = "0.3.5"
 
 defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt-rtt = "0.4.0"
 
 [features]
 # This is the set of features we enable by default

--- a/boards/pimoroni-servo2040/Cargo.toml
+++ b/boards/pimoroni-servo2040/Cargo.toml
@@ -20,7 +20,7 @@ cortex-m-rt = { version = "0.7", optional = true }
 rp2040-hal = { path = "../../rp2040-hal", version = "0.6.0", features = [ "defmt" ] }
 panic-halt= "0.2.0"
 defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt-rtt = "0.4.0"
 embedded-hal ="0.2.5"
 fugit = "0.3.5"
 nb = "1.0.0"

--- a/boards/pimoroni-tiny2040/Cargo.toml
+++ b/boards/pimoroni-tiny2040/Cargo.toml
@@ -23,7 +23,7 @@ embedded-hal ="0.2.5"
 fugit = "0.3.5"
 
 defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt-rtt = "0.4.0"
 
 [features]
 # This is the set of features we enable by default

--- a/boards/rp-pico/Cargo.toml
+++ b/boards/rp-pico/Cargo.toml
@@ -39,7 +39,7 @@ usbd-serial = "0.1.1"
 usbd-hid = "0.5.1"
 
 defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+defmt-rtt = "0.4.0"
 
 [features]
 # This is the set of features we enable by default


### PR DESCRIPTION
Version 0.3.0 depends on deprecated critical-section 0.2