### PR TITLE
Upgraded dependency on critical-section 0.2 to 0.2.8

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2022-11-09
+
+### Changed
+
+- Upgraded dependency on critical-section 0.2 to 0.2.8 - @jannic
+  (There is also a dependency on version 1.0.0)
+- Remove critical-section impl for version 0.2 - @jannic
+  Both 0.2.8 and 1.x use the same symbols internally to implement the
+  critical sections, so one impl is sufficient, and having both causes
+  compilation errors
+
 ## [0.6.0] - 2022-08-26
 
 ### Added

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-hal"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"
@@ -27,7 +27,7 @@ void = { version = "1.0.2", default-features = false }
 rand_core = "0.6.3"
 # Always set the custom-impl feature of legacy critical-section, even if we don't provide our own,
 # as the default implementation should no longer be used.
-critical-section_0_2 = { package = "critical-section", version = "0.2.4", features = ["custom-impl"] }
+critical-section_0_2 = { package = "critical-section", version = "0.2.8" }
 critical-section = { version = "1.0.0" }
 
 futures = { version = "0.3", default-features = false, optional = true }

--- a/rp2040-hal/src/critical_section_impl.rs
+++ b/rp2040-hal/src/critical_section_impl.rs
@@ -2,8 +2,6 @@ use core::sync::atomic::{AtomicU8, Ordering};
 
 struct RpSpinlockCs;
 #[cfg(feature = "critical-section-impl")]
-critical_section_0_2::custom_impl!(RpSpinlockCs);
-#[cfg(feature = "critical-section-impl")]
 critical_section::set_impl!(RpSpinlockCs);
 
 /// Marker value to indicate no-one has the lock.
@@ -23,17 +21,6 @@ static mut LOCK_OWNER: AtomicU8 = AtomicU8::new(LOCK_UNOWNED);
 /// If we're the outermost call to `critical_section` we use the values 0 and 1 to indicate we should release the spinlock and set the interrupts back to disabled and enabled, respectively.
 /// The value 2 indicates that we aren't the outermost call, and should not release the spinlock or re-enable interrupts in `release`
 const LOCK_ALREADY_OWNED: u8 = 2;
-
-#[cfg(feature = "critical-section-impl")]
-unsafe impl critical_section_0_2::Impl for RpSpinlockCs {
-    unsafe fn acquire() -> u8 {
-        RpSpinlockCs::acquire()
-    }
-
-    unsafe fn release(token: u8) {
-        RpSpinlockCs::release(token);
-    }
-}
 
 #[cfg(feature = "critical-section-impl")]
 unsafe impl critical_section::Impl for RpSpinlockCs {


### PR DESCRIPTION
This is meant to be released as v0.6.1 immediately, to fix failing builds caused by the release of critical-section 0.2.8.
(visit the rust-embedded [chat](https://matrix.to/#/#rust-embedded:matrix.org) for [details](https://libera.irclog.whitequark.org/rust-embedded/2022-11-29#33428525))