### PR TITLE
Add board waveshare-rp2040-lcd-0.96

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ members = [
     "boards/sparkfun-pro-micro-rp2040",
     "boards/sparkfun-thing-plus-rp2040",
     "boards/vcc-gnd-yd-rp2040",
-    "boards/waveshare-rp2040-zero"
+    "boards/waveshare-rp2040-zero",
+    "boards/waveshare-rp2040-lcd-0-96",
 ]
 
 [patch.'https://github.com/rp-rs/rp-hal.git']

--- a/README.md
+++ b/README.md
@@ -333,7 +333,6 @@ RP2040 chip according to how it is connected up on the YD-RP2040.
 [VCC-GND Studio YD-RP2040]: http://152.32.187.208:8080/yd-data/YD-RP2040/
 [vcc-gnd-yd-rp2040]: https://github.com/rp-rs/rp-hal/tree/main/boards/vcc-gnd-yd-rp2040
 
-
 ### [waveshare-rp2040-zero] - Board Support for the [Waveshare RP2040 Zero]
 
 You should include this crate if you are writing code that you want to run on
@@ -344,6 +343,18 @@ RP2040 chip according to how it is connected up on the Feather.
 
 [Waveshare RP2040 Zero]: https://www.waveshare.com/wiki/RP2040-Zero
 [waveshare-rp2040-zero]: https://github.com/rp-rs/rp-hal/tree/main/boards/waveshare-rp2040-zero
+
+### [waveshare-rp2040-lcd-0_96] - Board Support for the [Waveshare RP2040 LCD 0.96"]
+
+You should include this crate if you are writing code that you want to run on
+an [Waveshare RP2040 LCD 0.96"] - a very small RP2040 breakout board with USB-C, 
+a 65K IPS LCD 160x80, 16MBit Flash and 1A battery charger from Waveshare.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Feather.
+
+[Waveshare RP2040 LCD 0.96"]: https://www.waveshare.com/wiki/RP2040-LCD-0.96
+[waveshare-rp2040-lcd-0_96]: https://github.com/rp-rs/rp-hal/tree/main/boards/waveshare-rp2040-lcd-0_96
 
 <!-- PROGRAMMING -->
 ## Programming

--- a/boards/waveshare-rp2040-lcd-0-96/CHANGELOG.md
+++ b/boards/waveshare-rp2040-lcd-0-96/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 0.4.0 - 2022-11-15
+
+### Changed
+
+- Inital release
+- Copied from waveshare-rp2040-zero
+- Update board name
+

--- a/boards/waveshare-rp2040-lcd-0-96/Cargo.toml
+++ b/boards/waveshare-rp2040-lcd-0-96/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "waveshare-rp2040-lcd-0-96"
+version = "0.4.0"
+authors = ["René van Dorst <opensource@vdorst.com>", "Andrea Nall <anall@andreanal.com>", "TilCreator <contact.github@tc-j.de>", "The rp-rs Developers"]
+edition = "2018"
+homepage = "https://github.com/rp-rs/rp-hal/tree/main/boards/waveshare-rp2040-lcd-0_96"
+description = "Board Support Package for the Waveshare RP2040 LCD 0.96 inch"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rp-rs/rp-hal.git"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.7.2"
+rp2040-boot2 = { version = "0.2.0", optional = true }
+rp2040-hal = { path = "../../rp2040-hal", version = "0.6.0" }
+cortex-m-rt = { version = "0.7", optional = true }
+
+[dev-dependencies]
+panic-halt= "0.2.0"
+embedded-hal ="0.2.5"
+fugit = "0.3.5"
+nb = "1.0.0"
+embedded-graphics = "0.7.1"
+st7735-lcd = { version = "0.8.1", features = ["graphics"] }
+
+[features]
+# This is the set of features we enable by default
+default = ["boot2", "rt", "critical-section-impl", "rom-func-cache"]
+
+# critical section that is safe for multicore use
+critical-section-impl = ["rp2040-hal/critical-section-impl"]
+
+# 2nd stage bootloaders for rp2040
+boot2 = ["rp2040-boot2"]
+
+# Minimal startup / runtime for Cortex-M microcontrollers
+rt = ["cortex-m-rt","rp2040-hal/rt"]
+
+# This enables a fix for USB errata 5: USB device fails to exit RESET state on busy USB bus.
+# Only required for RP2040 B0 and RP2040 B1, but it doesn't hurt to enable it
+rp2040-e5 = ["rp2040-hal/rp2040-e5"]
+
+# Memoize(cache) ROM function pointers on first use to improve performance
+rom-func-cache = ["rp2040-hal/rom-func-cache"]
+
+# Disable automatic mapping of language features (like floating point math) to ROM functions
+disable-intrinsics = ["rp2040-hal/disable-intrinsics"]
+
+# This enables ROM functions for f64 math that were not present in the earliest RP2040s
+rom-v2-intrinsics = ["rp2040-hal/rom-v2-intrinsics"]

--- a/boards/waveshare-rp2040-lcd-0-96/README.md
+++ b/boards/waveshare-rp2040-lcd-0-96/README.md
@@ -1,7 +1,7 @@
-# [waveshare-rp2040-lcd-0-96] - Board Support for the [Waveshare RP2040 LCD 0.96"]
+# [waveshare-rp2040-lcd-0-96] - Board Support for the [Waveshare RP2040 LCD 0.96]
 
 You should include this crate if you are writing code that you want to run on
-an [Waveshare RP2040 LCD 0.96"] - a very small RP2040 breakout board with USB-C, 
+an [Waveshare RP2040 LCD 0.96] - a very small RP2040 breakout board with USB-C, 
 a 65K IPS LCD 160x80, 16MBit Flash and 1A battery charger from Waveshare.
 
 This crate includes the [rp2040-hal], but also configures each pin of the

--- a/boards/waveshare-rp2040-lcd-0-96/README.md
+++ b/boards/waveshare-rp2040-lcd-0-96/README.md
@@ -1,0 +1,97 @@
+# [waveshare-rp2040-lcd-0-96] - Board Support for the [Waveshare RP2040 LCD 0.96"]
+
+You should include this crate if you are writing code that you want to run on
+an [Waveshare RP2040 LCD 0.96"] - a very small RP2040 breakout board with USB-C, 
+a 65K IPS LCD 160x80, 16MBit Flash and 1A battery charger from Waveshare.
+
+This crate includes the [rp2040-hal], but also configures each pin of the
+RP2040 chip according to how it is connected up on the Feather.
+
+[Waveshare RP2040 LCD 0.96]: https://www.waveshare.com/wiki/RP2040-LCD-0.96
+[waveshare-rp2040-lcd-0-96]: https://github.com/rp-rs/rp-hal/tree/main/boards/waveshare-rp2040-lcd-0-96
+[rp2040-hal]: https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal
+[Raspberry Silicon RP2040]: https://www.raspberrypi.org/products/rp2040/
+
+## Using
+
+To use this crate, your `Cargo.toml` file should contain:
+
+```toml
+waveshare_rp2040_lcd_0_96 = "0.4.0"
+```
+
+In your program, you will need to call `waveshare_rp2040_lcd_0_96::Pins::new` to create
+a new `Pins` structure. This will set up all the GPIOs for any on-board
+devices. See the [examples](./examples) folder for more details.
+
+## Examples
+
+### General Instructions
+
+To compile an example, clone the _rp-hal_ repository and run:
+
+```console
+rp-hal/boards/waveshare-rp2040-lcd-0-96 $ cargo build --release --example <name>
+```
+
+You will get an ELF file called
+`./target/thumbv6m-none-eabi/release/examples/<name>`, where the `target`
+folder is located at the top of the _rp-hal_ repository checkout. Normally
+you would also need to specify `--target=thumbv6m-none-eabi` but when
+building examples from this git repository, that is set as the default.
+
+If you want to convert the ELF file to a UF2 and automatically copy it to the
+USB drive exported by the RP2040 bootloader, simply boot your board into
+bootloader mode and run:
+
+```console
+rp-hal/boards/waveshare-rp2040-lcd-0-96 $ cargo run --release --example <name>
+```
+
+If you get an error about not being able to find `elf2uf2-rs`, try:
+
+```console
+$ cargo install elf2uf2-rs, then repeating the `cargo run` command above.
+```
+
+### [waveshare_rp2040_lcd_demo](./examples/waveshare_rp2040_lcd_demo.rs)
+
+Draws a red and green line with a blue regtangle.
+After that is fills the screen line for line, that end it starts over with an
+other colour, RED, GREEN and BLUE.
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to
+be, learn, inspire, and create. Any contributions you make are **greatly
+appreciated**.
+
+The steps are:
+
+1. Fork the Project by clicking the 'Fork' button at the top of the page.
+2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
+3. Make some changes to the code or documentation.
+4. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
+5. Push to the Feature Branch (`git push origin feature/AmazingFeature`)
+6. Create a [New Pull Request](https://github.com/rp-rs/rp-hal/pulls)
+7. An admin will review the Pull Request and discuss any changes that may be required.
+8. Once everyone is happy, the Pull Request can be merged by an admin, and your work is part of our project!
+
+## Code of Conduct
+
+Contribution to this crate is organized under the terms of the [Rust Code of
+Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
+to intervene to uphold that code of conduct.
+
+[CoC]: CODE_OF_CONDUCT.md
+[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+
+## License
+
+The contents of this repository are dual-licensed under the _MIT OR Apache
+2.0_ License. That means you can choose either the MIT license or the
+Apache-2.0 license when you re-use this code. See `MIT` or `APACHE2.0` for more
+information on each specific license.
+
+Any submissions to this project (e.g. as Pull Requests) must be made available
+under these terms.

--- a/boards/waveshare-rp2040-lcd-0-96/examples/waveshare_rp2040_lcd_demo.rs
+++ b/boards/waveshare-rp2040-lcd-0-96/examples/waveshare_rp2040_lcd_demo.rs
@@ -1,0 +1,160 @@
+//! Example of graphics on the LCD of the Waveshare RP2040-LCD-0.96
+//!
+//! Draws a red and green line with a blue rectangle.
+//! After that it fills the screen line for line, at the end it starts over with
+//! another colour, RED, GREEN and BLUE.
+#![no_std]
+#![no_main]
+
+use cortex_m::delay::Delay;
+use embedded_graphics::primitives::Line;
+use fugit::RateExtU32;
+use panic_halt as _;
+
+use waveshare_rp2040_lcd_0_96::entry;
+use waveshare_rp2040_lcd_0_96::{
+    hal::{
+        self,
+        clocks::{init_clocks_and_plls, Clock},
+        pac,
+        pio::PIOExt,
+        watchdog::Watchdog,
+        Sio,
+    },
+    Pins, XOSC_CRYSTAL_FREQ,
+};
+
+use embedded_graphics::{
+    pixelcolor::Rgb565,
+    prelude::*,
+    primitives::{PrimitiveStyle, PrimitiveStyleBuilder, Rectangle},
+};
+use st7735_lcd::{Orientation, ST7735};
+
+const LCD_WIDTH: u32 = 160;
+const LCD_HEIGHT: u32 = 80;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = Sio::new(pac.SIO);
+    let pins = Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // Set up the delay for the first core.
+    let sys_freq = clocks.system_clock.freq().to_Hz();
+    let mut delay = Delay::new(core.SYST, sys_freq);
+
+    let (mut _pio, _sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
+
+    // https://www.waveshare.com/wiki/RP2040-LCD-0.96
+    // ST7735S LCD
+    let lcd_dc = pins.gp8.into_push_pull_output();
+    let mut _lcd_cs = pins.gp9.into_mode::<hal::gpio::FunctionSpi>();
+    let mut _lcd_clk = pins.gp10.into_mode::<hal::gpio::FunctionSpi>();
+    let mut _lcd_mosi = pins.gp11.into_mode::<hal::gpio::FunctionSpi>();
+    let lcd_rst = pins
+        .gp12
+        .into_push_pull_output_in_state(hal::gpio::PinState::High);
+    let mut _lcd_bl = pins
+        .gp25
+        .into_push_pull_output_in_state(hal::gpio::PinState::High);
+
+    let spi = hal::Spi::<_, _, 8>::new(pac.SPI1);
+
+    // Exchange the uninitialised SPI driver for an initialised one
+    let spi = spi.init(
+        &mut pac.RESETS,
+        clocks.peripheral_clock.freq(),
+        10.MHz(),
+        &embedded_hal::spi::MODE_0,
+    );
+
+    // LCD is a 65K IPS LCD 160x80, color order is BGR and a offset 1,26 pixel.
+    // LCD controller can correct this by settings the order bit (bit 3) in MADCTL register.
+    // Also the colours are inverted, LCD controller can also correct this by writing to INVON register with no paramters.
+    // All this is handled by the ST7735 crate.
+    let mut display = ST7735::new(spi, lcd_dc, lcd_rst, false, true, LCD_WIDTH, LCD_HEIGHT);
+
+    display.init(&mut delay).unwrap();
+    display.set_orientation(&Orientation::Landscape).unwrap();
+
+    display.set_offset(1, 26);
+
+    let lcd_zero = Point::zero();
+    let lcd_max_corner = Point::new((LCD_WIDTH - 1) as i32, (LCD_HEIGHT - 1) as i32);
+
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb565::BLUE)
+        .build();
+
+    Rectangle::with_corners(lcd_zero, lcd_max_corner)
+        .into_styled(style)
+        .draw(&mut display)
+        .unwrap();
+
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb565::BLACK)
+        .build();
+
+    Rectangle::with_corners(
+        Point::new(1, 1),
+        Point::new((LCD_WIDTH - 2) as i32, (LCD_HEIGHT - 2) as i32),
+    )
+    .into_styled(style)
+    .draw(&mut display)
+    .unwrap();
+
+    Line::new(lcd_zero, lcd_max_corner)
+        .into_styled(PrimitiveStyle::with_stroke(Rgb565::RED, 1))
+        .draw(&mut display)
+        .unwrap();
+
+    Line::new(
+        Point::new(0, (LCD_HEIGHT - 1) as i32),
+        Point::new((LCD_WIDTH - 1) as i32, 0),
+    )
+    .into_styled(PrimitiveStyle::with_stroke(Rgb565::GREEN, 1))
+    .draw(&mut display)
+    .unwrap();
+
+    // Infinite colour wheel loop
+    let mut l: i32 = 0;
+    let mut c = Rgb565::RED;
+    loop {
+        Line::new(Point::new(0, l), Point::new((LCD_WIDTH - 1) as i32, l))
+            .into_styled(PrimitiveStyle::with_stroke(c, 1))
+            .draw(&mut display)
+            .unwrap();
+        delay.delay_ms(10);
+        l += 1;
+        if l == LCD_HEIGHT as i32 {
+            l = 0;
+            c = match c {
+                Rgb565::RED => Rgb565::GREEN,
+                Rgb565::GREEN => Rgb565::BLUE,
+                _ => Rgb565::RED,
+            }
+        }
+    }
+}

--- a/boards/waveshare-rp2040-lcd-0-96/src/lib.rs
+++ b/boards/waveshare-rp2040-lcd-0-96/src/lib.rs
@@ -1,0 +1,785 @@
+#![no_std]
+
+pub extern crate rp2040_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use hal::entry;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+#[cfg(feature = "boot2")]
+#[link_section = ".boot2"]
+#[no_mangle]
+#[used]
+pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
+
+pub use hal::pac;
+
+hal::bsp_pins!(
+    /// GPIO 0 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp0Spi0Rx]          |
+    /// | `UART0 TX`   | [crate::Gp0Uart0Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp0I2C0Sda]         |
+    /// | `PWM0 A`     | [crate::Gp0Pwm0A]           |
+    /// | `PIO0`       | [crate::Gp0Pio0]            |
+    /// | `PIO1`       | [crate::Gp0Pio1]            |
+    Gpio0 {
+        name: gp0,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio0].
+            FunctionUart: Gp0Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio0].
+            FunctionSpi: Gp0Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio0].
+            FunctionI2C: Gp0I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio0].
+            FunctionPwm: Gp0Pwm0A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio0: Gp0Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio0].
+            FunctionPio1: Gp0Pio1
+        }
+    },
+
+    /// GPIO 1 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp1Spi0Csn]         |
+    /// | `UART0 RX`   | [crate::Gp1Uart0Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp1I2C0Scl]         |
+    /// | `PWM0 B`     | [crate::Gp1Pwm0B]           |
+    /// | `PIO0`       | [crate::Gp1Pio0]            |
+    /// | `PIO1`       | [crate::Gp1Pio1]            |
+    Gpio1 {
+        name: gp1,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio1].
+            FunctionUart: Gp1Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio1].
+            FunctionSpi: Gp1Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio1].
+            FunctionI2C: Gp1I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio1].
+            FunctionPwm: Gp1Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio0: Gp1Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio1].
+            FunctionPio1: Gp1Pio1
+        }
+    },
+
+    /// GPIO 2 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp2Spi0Sck]         |
+    /// | `UART0 CTS`  | [crate::Gp2Uart0Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp2I2C1Sda]         |
+    /// | `PWM1 A`     | [crate::Gp2Pwm1A]           |
+    /// | `PIO0`       | [crate::Gp2Pio0]            |
+    /// | `PIO1`       | [crate::Gp2Pio1]            |
+    Gpio2 {
+        name: gp2,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio2].
+            FunctionUart: Gp2Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio2].
+            FunctionSpi: Gp2Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio2].
+            FunctionI2C: Gp2I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio2].
+            FunctionPwm: Gp2Pwm1A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio2].
+            FunctionPio0: Gp2Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio2].
+            FunctionPio1: Gp2Pio1
+        }
+    },
+
+    /// GPIO 3 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp3Spi0Tx]          |
+    /// | `UART0 RTS`  | [crate::Gp3Uart0Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp3I2C1Scl]         |
+    /// | `PWM1 B`     | [crate::Gp3Pwm1B]           |
+    /// | `PIO0`       | [crate::Gp3Pio0]            |
+    /// | `PIO1`       | [crate::Gp3Pio1]            |
+    Gpio3 {
+        name: gp3,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio3].
+            FunctionUart: Gp3Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio3].
+            FunctionSpi: Gp3Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio3].
+            FunctionI2C: Gp3I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio3].
+            FunctionPwm: Gp3Pwm1B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio3].
+            FunctionPio0: Gp3Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio3].
+            FunctionPio1: Gp3Pio1
+        }
+    },
+
+    /// GPIO 4 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp4Spi0Rx]          |
+    /// | `UART1 TX`   | [crate::Gp4Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp4I2C0Sda]         |
+    /// | `PWM2 A`     | [crate::Gp4Pwm2A]           |
+    /// | `PIO0`       | [crate::Gp4Pio0]            |
+    /// | `PIO1`       | [crate::Gp4Pio1]            |
+    Gpio4 {
+        name: gp4,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio4].
+            FunctionUart: Gp4Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio4].
+            FunctionSpi: Gp4Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio4].
+            FunctionI2C: Gp4I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio4].
+            FunctionPwm: Gp4Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio0: Gp4Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio4].
+            FunctionPio1: Gp4Pio1
+        }
+    },
+
+    /// GPIO 5 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp5Spi0Csn]         |
+    /// | `UART1 RX`   | [crate::Gp5Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp5I2C0Scl]         |
+    /// | `PWM2 B`     | [crate::Gp5Pwm2B]           |
+    /// | `PIO0`       | [crate::Gp5Pio0]            |
+    /// | `PIO1`       | [crate::Gp5Pio1]            |
+    Gpio5 {
+        name: gp5,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio5].
+            FunctionUart: Gp5Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio5].
+            FunctionSpi: Gp5Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio5].
+            FunctionI2C: Gp5I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio5].
+            FunctionPwm: Gp5Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio0: Gp5Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio5].
+            FunctionPio1: Gp5Pio1
+        }
+    },
+
+    /// GPIO 6 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp6Spi0Sck]         |
+    /// | `UART1 CTS`  | [crate::Gp6Uart1Cts]        |
+    /// | `I2C1 SDA`   | [crate::Gp6I2C1Sda]         |
+    /// | `PWM3 A`     | [crate::Gp6Pwm3A]           |
+    /// | `PIO0`       | [crate::Gp6Pio0]            |
+    /// | `PIO1`       | [crate::Gp6Pio1]            |
+    Gpio6 {
+        name: gp6,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio6].
+            FunctionUart: Gp6Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio6].
+            FunctionSpi: Gp6Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio6].
+            FunctionI2C: Gp6I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio6].
+            FunctionPwm: Gp6Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio0: Gp6Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio6].
+            FunctionPio1: Gp6Pio1
+        }
+    },
+
+    /// GPIO 7 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp7Spi0Tx]          |
+    /// | `UART1 RTS`  | [crate::Gp7Uart1Rts]        |
+    /// | `I2C1 SCL`   | [crate::Gp7I2C1Scl]         |
+    /// | `PWM3 B`     | [crate::Gp7Pwm3B]           |
+    /// | `PIO0`       | [crate::Gp7Pio0]            |
+    /// | `PIO1`       | [crate::Gp7Pio1]            |
+    Gpio7 {
+        name: gp7,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio7].
+            FunctionUart: Gp7Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio7].
+            FunctionSpi: Gp7Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio7].
+            FunctionI2C: Gp7I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio7].
+            FunctionPwm: Gp7Pwm3B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio0: Gp7Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio7].
+            FunctionPio1: Gp7Pio1
+        }
+    },
+
+    /// GPIO 8 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp8Spi1Rx]          |
+    /// | `UART1 TX`   | [crate::Gp8Uart1Tx]         |
+    /// | `I2C0 SDA`   | [crate::Gp8I2C0Sda]         |
+    /// | `PWM4 A`     | [crate::Gp8Pwm4A]           |
+    /// | `PIO0`       | [crate::Gp8Pio0]            |
+    /// | `PIO1`       | [crate::Gp8Pio1]            |
+    Gpio8 {
+        name: gp8,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio8].
+            FunctionUart: Gp8Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio8].
+            FunctionSpi: Gp8Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio8].
+            FunctionI2C: Gp8I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio8].
+            FunctionPwm: Gp8Pwm4A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio0: Gp8Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio8].
+            FunctionPio1: Gp8Pio1
+        }
+    },
+
+    /// GPIO 9 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp9Spi1Csn]         |
+    /// | `UART1 RX`   | [crate::Gp9Uart1Rx]         |
+    /// | `I2C0 SCL`   | [crate::Gp9I2C0Scl]         |
+    /// | `PWM4 B`     | [crate::Gp9Pwm4B]           |
+    /// | `PIO0`       | [crate::Gp9Pio0]            |
+    /// | `PIO1`       | [crate::Gp9Pio1]            |
+    Gpio9 {
+        name: gp9,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio9].
+            FunctionUart: Gp9Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio9].
+            FunctionSpi: Gp9Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio9].
+            FunctionI2C: Gp9I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio9].
+            FunctionPwm: Gp9Pwm4B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio0: Gp9Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio9].
+            FunctionPio1: Gp9Pio1
+        }
+    },
+
+    /// GPIO 10 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp10Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp10Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp10I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp10Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp10Pio0]           |
+    /// | `PIO1`       | [crate::Gp10Pio1]           |
+    Gpio10 {
+        name: gp10,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio10].
+            FunctionUart: Gp10Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio10].
+            FunctionSpi: Gp10Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio10].
+            FunctionI2C: Gp10I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio10].
+            FunctionPwm: Gp10Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio10].
+            FunctionPio0: Gp10Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio10].
+            FunctionPio1: Gp10Pio1
+        }
+    },
+
+    /// GPIO 11 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp11Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp11Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp11I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp11Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp11Pio0]           |
+    /// | `PIO1`       | [crate::Gp11Pio1]           |
+    Gpio11 {
+        name: gp11,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio11].
+            FunctionUart: Gp11Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio11].
+            FunctionSpi: Gp11Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio11].
+            FunctionI2C: Gp11I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio11].
+            FunctionPwm: Gp11Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio11].
+            FunctionPio0: Gp11Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio11].
+            FunctionPio1: Gp11Pio1
+        }
+    },
+
+    /// GPIO 12 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp12Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp12Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp12I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp12Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp12Pio0]           |
+    /// | `PIO1`       | [crate::Gp12Pio1]           |
+    Gpio12 {
+        name: gp12,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio12].
+            FunctionUart: Gp12Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio12].
+            FunctionSpi: Gp12Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio12].
+            FunctionI2C: Gp12I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio12].
+            FunctionPwm: Gp12Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio12].
+            FunctionPio0: Gp12Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio12].
+            FunctionPio1: Gp12Pio1
+        }
+    },
+
+    /// GPIO 13 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 CSn`   | [crate::Gp13Spi1Csn]        |
+    /// | `UART0 RX`   | [crate::Gp13Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp13I2C0Scl]        |
+    /// | `PWM6 B`     | [crate::Gp13Pwm6B]          |
+    /// | `PIO0`       | [crate::Gp13Pio0]           |
+    /// | `PIO1`       | [crate::Gp13Pio1]           |
+    Gpio13 {
+        name: gp13,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio13].
+            FunctionUart: Gp13Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio13].
+            FunctionSpi: Gp13Spi1Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio13].
+            FunctionI2C: Gp13I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio13].
+            FunctionPwm: Gp13Pwm6B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio13].
+            FunctionPio0: Gp13Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio13].
+            FunctionPio1: Gp13Pio1
+        }
+    },
+
+    /// GPIO 14 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp14Spi1Sck]        |
+    /// | `UART0 CTS`  | [crate::Gp14Uart0Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp14I2C1Sda]        |
+    /// | `PWM7 A`     | [crate::Gp14Pwm7A]          |
+    /// | `PIO0`       | [crate::Gp14Pio0]           |
+    /// | `PIO1`       | [crate::Gp14Pio1]           |
+    Gpio14 {
+        name: gp14,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio14].
+            FunctionUart: Gp14Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio14].
+            FunctionSpi: Gp14Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio14].
+            FunctionI2C: Gp14I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio14].
+            FunctionPwm: Gp14Pwm7A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio14].
+            FunctionPio0: Gp14Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio14].
+            FunctionPio1: Gp14Pio1
+        }
+    },
+
+    /// GPIO 15 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp15Spi1Tx]         |
+    /// | `UART0 RTS`  | [crate::Gp15Uart0Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp15I2C1Scl]        |
+    /// | `PWM7 B`     | [crate::Gp15Pwm7B]          |
+    /// | `PIO0`       | [crate::Gp15Pio0]           |
+    /// | `PIO1`       | [crate::Gp15Pio1]           |
+    Gpio15 {
+        name: gp15,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio15].
+            FunctionUart: Gp15Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio15].
+            FunctionSpi: Gp15Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio15].
+            FunctionI2C: Gp15I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio15].
+            FunctionPwm: Gp15Pwm7B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio15].
+            FunctionPio0: Gp15Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio15].
+            FunctionPio1: Gp15Pio1
+        }
+    },
+
+    /// GPIO 16 is connected internally to a single Neopixel RGB LED
+    Gpio16 { name: neopixel },
+
+    /// GPIO 17 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp17Spi0Csn]        |
+    /// | `UART0 RX`   | [crate::Gp17Uart0Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp17I2C0Scl]        |
+    /// | `PWM0 B`     | [crate::Gp17Pwm0B]          |
+    /// | `PIO0`       | [crate::Gp17Pio0]           |
+    /// | `PIO1`       | [crate::Gp17Pio1]           |
+    Gpio17 {
+        name: gpio17,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio17].
+            FunctionUart: Gp17Uart0Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio17].
+            FunctionSpi: Gp17Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio17].
+            FunctionI2C: Gp17I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio17].
+            FunctionPwm: Gp17Pwm0B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio0: Gp17Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio17].
+            FunctionPio1: Gp17Pio1
+        }
+    },
+
+    /// GPIO 18 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp18Spi0Sck]        |
+    /// | `UART0 CTS`  | [crate::Gp18Uart0Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp18I2C1Sda]        |
+    /// | `PWM1 A`     | [crate::Gp18Pwm1A]          |
+    /// | `PIO0`       | [crate::Gp18Pio0]           |
+    /// | `PIO1`       | [crate::Gp18Pio1]           |
+    Gpio18 {
+        name: gpio18,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio18].
+            FunctionUart: Gp18Uart0Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio18].
+            FunctionSpi: Gp18Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio18].
+            FunctionI2C: Gp18I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio18].
+            FunctionPwm: Gp18Pwm1A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio18].
+            FunctionPio0: Gp18Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio18].
+            FunctionPio1: Gp18Pio1
+        }
+    },
+
+    /// GPIO 19 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 TX`    | [crate::Gp19Spi0Tx]         |
+    /// | `UART0 RTS`  | [crate::Gp19Uart0Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp19I2C1Scl]        |
+    /// | `PWM1 B`     | [crate::Gp19Pwm1B]          |
+    /// | `PIO0`       | [crate::Gp19Pio0]           |
+    /// | `PIO1`       | [crate::Gp19Pio1]           |
+    Gpio19 {
+        name: gpio19,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio19].
+            FunctionUart: Gp19Uart0Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio19].
+            FunctionSpi: Gp19Spi0Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio19].
+            FunctionI2C: Gp19I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio19].
+            FunctionPwm: Gp19Pwm1B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio19].
+            FunctionPio0: Gp19Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio19].
+            FunctionPio1: Gp19Pio1
+        }
+    },
+
+    /// GPIO 20 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 RX`    | [crate::Gp20Spi0Rx]         |
+    /// | `UART1 TX`   | [crate::Gp20Uart1Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp20I2C0Sda]        |
+    /// | `PWM2 A`     | [crate::Gp20Pwm2A]          |
+    /// | `PIO0`       | [crate::Gp20Pio0]           |
+    /// | `PIO1`       | [crate::Gp20Pio1]           |
+    Gpio20 {
+        name: gpio20,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio20].
+            FunctionUart: Gp20Uart1Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio20].
+            FunctionSpi: Gp20Spi0Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio20].
+            FunctionI2C: Gp20I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio20].
+            FunctionPwm: Gp20Pwm2A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio0: Gp20Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio20].
+            FunctionPio1: Gp20Pio1
+        }
+    },
+
+    /// GPIO 21 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 CSn`   | [crate::Gp21Spi0Csn]        |
+    /// | `UART1 RX`   | [crate::Gp21Uart1Rx]        |
+    /// | `I2C0 SCL`   | [crate::Gp21I2C0Scl]        |
+    /// | `PWM2 B`     | [crate::Gp21Pwm2B]          |
+    /// | `PIO0`       | [crate::Gp21Pio0]           |
+    /// | `PIO1`       | [crate::Gp21Pio1]           |
+    Gpio21 {
+        name: gpio21,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio21].
+            FunctionUart: Gp21Uart1Rx,
+            /// SPI Function alias for pin [crate::Pins::gpio21].
+            FunctionSpi: Gp21Spi0Csn,
+            /// I2C Function alias for pin [crate::Pins::gpio21].
+            FunctionI2C: Gp21I2C0Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio21].
+            FunctionPwm: Gp21Pwm2B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio0: Gp21Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio21].
+            FunctionPio1: Gp21Pio1
+        }
+    },
+
+    /// GPIO 22 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI0 SCK`   | [crate::Gp22Spi0Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp22Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp22I2C1Sda]        |
+    /// | `PWM3 A`     | [crate::Gp22Pwm3A]          |
+    /// | `PIO0`       | [crate::Gp22Pio0]           |
+    /// | `PIO1`       | [crate::Gp22Pio1]           |
+    Gpio22 {
+        name: gpio22,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio22].
+            FunctionUart: Gp22Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio22].
+            FunctionSpi: Gp22Spi0Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio22].
+            FunctionI2C: Gp22I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio22].
+            FunctionPwm: Gp22Pwm3A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio0: Gp22Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio22].
+            FunctionPio1: Gp22Pio1
+        }
+    },
+
+    /// GPIO 23
+    Gpio23 {
+        name: gp23,
+        aliases: {
+            FunctionUart: Gp23Uart1Rts,
+            FunctionSpi: Gp23Spi0Tx,
+            FunctionI2C: Gp23I2C1Scl,
+            FunctionPwm: Gp23Pwm3B,
+            FunctionPio0: Gp23Pio0,
+            FunctionPio1: Gp23Pio1
+        }
+    },
+
+    /// GPIO 24
+    Gpio24 {
+        name: gp24,
+        aliases: {
+            FunctionUart: Gp24Uart1Tx,
+            FunctionSpi: Gp24Spi1Rx,
+            FunctionI2C: Gp24I2C0Sda,
+            FunctionPwm: Gp24Pwm4A,
+            FunctionPio0: Gp24Pio0,
+            FunctionPio1: Gp24Pio1
+        }
+    },
+
+    /// GPIO 25
+    Gpio25 {
+        name: gp25,
+        aliases: {
+            FunctionUart: Gp25Uart1Rx,
+            FunctionSpi: Gp25Spi1Csn,
+            FunctionI2C: Gp25I2C0Scl,
+            FunctionPwm: Gp25Pwm4B,
+            FunctionPio0: Gp25Pio0,
+            FunctionPio1: Gp25Pio1
+        }
+    },
+
+    /// GPIO 26 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 SCK`   | [crate::Gp26Spi1Sck]        |
+    /// | `UART1 CTS`  | [crate::Gp26Uart1Cts]       |
+    /// | `I2C1 SDA`   | [crate::Gp26I2C1Sda]        |
+    /// | `PWM5 A`     | [crate::Gp26Pwm5A]          |
+    /// | `PIO0`       | [crate::Gp26Pio0]           |
+    /// | `PIO1`       | [crate::Gp26Pio1]           |
+    ///
+    /// ADC0
+    Gpio26 {
+        name: gp26,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio26].
+            FunctionUart: Gp26Uart1Cts,
+            /// SPI Function alias for pin [crate::Pins::gpio26].
+            FunctionSpi: Gp26Spi1Sck,
+            /// I2C Function alias for pin [crate::Pins::gpio26].
+            FunctionI2C: Gp26I2C1Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio26].
+            FunctionPwm: Gp26Pwm5A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio0: Gp26Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio26].
+            FunctionPio1: Gp26Pio1
+        }
+    },
+
+    /// GPIO 27 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 TX`    | [crate::Gp27Spi1Tx]         |
+    /// | `UART1 RTS`  | [crate::Gp27Uart1Rts]       |
+    /// | `I2C1 SCL`   | [crate::Gp27I2C1Scl]        |
+    /// | `PWM5 B`     | [crate::Gp27Pwm5B]          |
+    /// | `PIO0`       | [crate::Gp27Pio0]           |
+    /// | `PIO1`       | [crate::Gp27Pio1]           |
+    ///
+    /// ADC1
+    Gpio27 {
+        name: gp27,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio27].
+            FunctionUart: Gp27Uart1Rts,
+            /// SPI Function alias for pin [crate::Pins::gpio27].
+            FunctionSpi: Gp27Spi1Tx,
+            /// I2C Function alias for pin [crate::Pins::gpio27].
+            FunctionI2C: Gp27I2C1Scl,
+            /// PWM Function alias for pin [crate::Pins::gpio27].
+            FunctionPwm: Gp27Pwm5B,
+            /// PIO0 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio0: Gp27Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio27].
+            FunctionPio1: Gp27Pio1
+        }
+    },
+
+    /// GPIO 28 supports following functions:
+    ///
+    /// | Function     | Alias with applied function |
+    /// |--------------|-----------------------------|
+    /// | `SPI1 RX`    | [crate::Gp28Spi1Rx]         |
+    /// | `UART0 TX`   | [crate::Gp28Uart0Tx]        |
+    /// | `I2C0 SDA`   | [crate::Gp28I2C0Sda]        |
+    /// | `PWM6 A`     | [crate::Gp28Pwm6A]          |
+    /// | `PIO0`       | [crate::Gp28Pio0]           |
+    /// | `PIO1`       | [crate::Gp28Pio1]           |
+    ///
+    /// ADC2
+    Gpio28 {
+        name: gp28,
+        aliases: {
+            /// UART Function alias for pin [crate::Pins::gpio28].
+            FunctionUart: Gp28Uart0Tx,
+            /// SPI Function alias for pin [crate::Pins::gpio28].
+            FunctionSpi: Gp28Spi1Rx,
+            /// I2C Function alias for pin [crate::Pins::gpio28].
+            FunctionI2C: Gp28I2C0Sda,
+            /// PWM Function alias for pin [crate::Pins::gpio28].
+            FunctionPwm: Gp28Pwm6A,
+            /// PIO0 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio0: Gp28Pio0,
+            /// PIO1 Function alias for pin [crate::Pins::gpio28].
+            FunctionPio1: Gp28Pio1
+        }
+    },
+
+    /// GPIO 29
+    ///
+    /// ADC3
+    Gpio29 {
+        name: gp29,
+        aliases: {
+            FunctionUart: Gp29Uart0Rx,
+            FunctionSpi: Gp29Spi1Csn,
+            FunctionI2C: Gp29I2C0Scl,
+            FunctionPwm: Gp29Pwm6B,
+            FunctionPio0: Gp29Pio0,
+            FunctionPio1: Gp29Pio1
+        }
+    },
+);
+
+pub const XOSC_CRYSTAL_FREQ: u32 = 12_000_000;


### PR DESCRIPTION
This adds the board config for the Waveshare RP2040 LCD 0.96" board.

Board has:
* 0.96inch 160×80 pixels 65K colorful IPS LCD display with ST7735S controller
* Lithium battery recharge/discharge header, suitable for mobile devices
* Onboard DC-DC chip TPS63000, high-efficiency DC-DC buck-boost chip, 1.8A current switch
* 16MBit W25Q16JVUXIQ flash chip.

I successfully compiled and ran the waveshare_rp2040_lcd_demo example on the board.