### PR TITLE
Add Pin::id()

### DIFF
--- a/rp2040-hal/examples/pio_side_set.rs
+++ b/rp2040-hal/examples/pio_side_set.rs
@@ -38,9 +38,9 @@ fn main() -> ! {
     );
 
     // configure LED pin for Pio0.
-    let _led: Pin<_, FunctionPio0> = pins.gpio25.into_mode();
+    let led: Pin<_, FunctionPio0> = pins.gpio25.into_mode();
     // PIN id for use inside of PIO
-    let led_pin_id = 25;
+    let led_pin_id = led.id().num;
 
     // Define some simple PIO program.
     let program = pio_proc::pio_asm!(

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -476,6 +476,21 @@ where
         }
     }
 
+    /// Return the [`DynPinId`] corresponding to this pin.
+    ///
+    /// To get the numeric pin number, access the num field
+    /// directly:
+    ///
+    /// ```no_run
+    /// # fn get_id<I: PinId, M> (pin: Pin<I, M>) -> u8 {
+    ///      pin.id().num
+    /// # }
+    /// ````
+    #[inline]
+    pub fn id(&self) -> DynPinId {
+        I::DYN
+    }
+
     /// Convert the pin to the requested [`PinMode`]
     #[inline]
     pub fn into_mode<N: PinMode + ValidPinMode<I>>(mut self) -> Pin<I, N> {

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -482,7 +482,8 @@ where
     /// directly:
     ///
     /// ```no_run
-    /// # fn get_id<I: PinId, M> (pin: Pin<I, M>) -> u8 {
+    /// # use rp2040_hal::gpio::{Pin, PinId, PinMode, ValidPinMode};
+    /// # fn get_id<I: PinId, M: PinMode + ValidPinMode<I>> (pin: Pin<I, M>) -> u8 {
     ///      pin.id().num
     /// # }
     /// ````


### PR DESCRIPTION
Some thoughts about the API, `pub fn id(&self) -> DynPinId`

Pro:
- identical to `DynPin::id`
- provides full information about the pin id, including the group (`Bank0` vs. `Qspi`)


Contra:
- the name `DynPinId` of the return type doesn't fit well
- most users won't be interested in the pin id, but only the pin number, requiring a slightly ugly invocation, like `pin.id().num`

Alternatives:
- Just returning the pin number as the result of `id()` could be confusing because of the difference to `DynPin::id`.
- We could add `pub fn num(&self) -> u8` instead, or in addition to `pub fn id(&self) -> DynPinId`

