### PR TITLE
example name type wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ specified 'runner'. As the 'runner' is the elf2uf2-rs tool, it will build a UF2
 file and copy it to your RP2040.
 
 ```console
-$ cargo run --release --example pico_pwm_blink
+$ cargo run --release --example pico_blink
 ```
 
 ### Loading with probe-run


### PR DESCRIPTION
error: no example target named `pico_pwm_blink`.
Available example targets:
    gpio_irq_example
    vector_table
    adc
    watchdog
    rom_funcs
    pio_synchronized
    pio_proc_blink
    multicore_fifo_blink
    gpio_in_out
    multicore_polyblink
    pio_blink
    uart
    spi
    blinky
    lcd_display
    dht11
    i2c
    pio_side_set
    pwm_blink