### PR TITLE
fixed example pwm_blink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ specified 'runner'. As the 'runner' is the elf2uf2-rs tool, it will build a UF2
 file and copy it to your RP2040.
 
 ```console
-$ cargo run --release --example pico_pwm_blink
+$ cargo run --release --example pwm_blink
 ```
 
 ### Loading with probe-run
@@ -213,7 +213,7 @@ RP2040 via the first probe it finds, and install your firmware into the Flash
 connected to the RP2040.
 
 ```console
-$ cargo run --release --example pico_pwm_blink
+$ cargo run --release --example pwm_blink
 ```
 
 ### Loading with picotool


### PR DESCRIPTION
I noticed, that the example pico_pwm_blink does not exist. However, there is a pwm_blink example. I fixed the README with the examples there accordingly.