### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,12 +10,10 @@ jobs:
         mode: ["", "--release"]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
       - name: Build workspace
         uses: actions-rs/cargo@v1
         with:
@@ -42,12 +40,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clean
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
       - name: Check unused deps
         uses: aig787/cargo-udeps-action@v1
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,9 +10,8 @@ jobs:
         mode: ["", "--release"]
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
       - name: Build workspace
         run: cargo build ${{ matrix.mode }} --workspace ${{ matrix.features }}
@@ -26,9 +25,8 @@ jobs:
         run: cargo test --doc --target x86_64-unknown-linux-gnu ${{ matrix.features }}
       - name: Clean
         run: cargo clean
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           target: thumbv6m-none-eabi
       - name: Check unused deps
         uses: aig787/cargo-udeps-action@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,31 +15,17 @@ jobs:
           toolchain: stable
           target: thumbv6m-none-eabi
       - name: Build workspace
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: ${{ matrix.mode }} --workspace ${{ matrix.features }}
+        run: cargo build ${{ matrix.mode }} --workspace ${{ matrix.features }}
       - name: Build workspace and examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: ${{ matrix.mode }} --workspace --examples ${{ matrix.features }}
+        run: cargo build ${{ matrix.mode }} --workspace --examples ${{ matrix.features }}
       - name: List built examples and clean
         run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --tests --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+        run: cargo test --tests --target x86_64-unknown-linux-gnu ${{ matrix.features }}
       - name: Test docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+        run: cargo test --doc --target x86_64-unknown-linux-gnu ${{ matrix.features }}
       - name: Clean
-        uses: actions-rs/cargo@v1
-        with:
-          command: clean
+        run: cargo clean
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
         features: ["", "--features eh1_0_alpha", "--features chrono", "--features rp2040-e5"]
         mode: ["", "--release"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,9 +7,8 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
           components: clippy
       - run: cargo clippy --workspace --examples -- -Dwarnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,12 +7,10 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
           components: clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,7 +12,4 @@ jobs:
           toolchain: stable
           target: thumbv6m-none-eabi
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --examples -- -Dwarnings
+      - run: cargo clippy --workspace --examples -- -Dwarnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -8,9 +8,8 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
           components: rustfmt
       - run: cargo fmt -- --check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,7 +13,4 @@ jobs:
           toolchain: stable
           target: thumbv6m-none-eabi
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+      - run: cargo fmt -- --check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -8,12 +8,10 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
           components: rustfmt
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
I noticed in https://github.com/rp-rs/rp-hal/actions/runs/3751431401 that the github workflow triggers a lot of deprecation warnings. This pull request should fix some of them.