### PR TITLE
Install cargo-udeps manually

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,9 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           target: thumbv6m-none-eabi
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
       - name: Check unused deps
-        uses: aig787/cargo-udeps-action@v1
-        with:
-          version: latest
-          args: ${{ matrix.mode }} --workspace ${{ matrix.features }}
-
+        run: cargo udeps ${{ matrix.mode }} --workspace ${{ matrix.features }}


### PR DESCRIPTION
This avoids using cargo-udeps-action. Build times will probably increase, as  installs from source,\nbut cargo-udeps-action is very unreliable at the moment.

See https://github.com/aig787/cargo-udeps-action/issues/2