### PR TITLE
Add set_base_1and0 used by simple_blend3 interp example

### DIFF
--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -816,6 +816,8 @@ pub trait Interp {
     fn set_base(&mut self, v: u32);
     ///Read the interpolator Base register (Base2 in the datasheet)
     fn get_base(&self) -> u32;
+    ///Write the lower 16 bits to BASE0 and the upper bits to BASE1 simultaneously. Each half is sign-extended to 32 bits if that lane's SIGNED flag is set
+    fn set_base_1and0(&mut self, v: u32);
 }
 
 macro_rules! interpolators {
@@ -905,7 +907,10 @@ macro_rules! interpolators {
                             let sio = unsafe { &*pac::SIO::ptr() };
                             sio.[<$interp:lower _base2>].read().bits()
                         }
-
+                        fn set_base_1and0(&mut self, v:u32){
+                            let sio = unsafe { &*pac::SIO::ptr() };
+                            sio.[<$interp:lower _base_1and0>].write(|w| unsafe { w.bits(v)});
+                        }
                     }
 
                 )+


### PR DESCRIPTION
The C/C++ SDK (and datasheet) make use of `base01` (called `base_1and0` in PAC and `INTERP0_BASE_1AND0`/`INTERP1_BASE_1AND0` in datasheet)

https://github.com/raspberrypi/pico-examples/blob/master/interp/hello_interp/hello_interp.c#L132-L140

This PR adds access to this register which is needed for the `simple_blend3` example from the C/C++ SDK.
The `simple_blend3` and `linear_interpolation` examples are also currently missing from https://github.com/rp-rs/rp-hal-boards/blob/main/boards/rp-pico/examples/pico_interpolator.rs .  I'll be opening a PR to addd these shortly.
