### PR TITLE
Document MSRV as 1.62 and add CI check

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,3 +51,9 @@ jobs:
         run: curl --location "https://github.com/est31/cargo-udeps/releases/download/v0.1.35/cargo-udeps-v0.1.35-x86_64-unknown-linux-gnu.tar.gz" --output - | tar --strip-components=2 -C ~/.cargo/bin -xzvvf - ./cargo-udeps-v0.1.35-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Check unused deps
         run: cargo udeps ${{ matrix.mode }} --workspace ${{ matrix.features }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.61
+          target: thumbv6m-none-eabi
+      - name: Verifiy MSRV
+        run: cargo build --workspace --examples ${{ matrix.features }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,7 +53,7 @@ jobs:
         run: cargo udeps ${{ matrix.mode }} --workspace ${{ matrix.features }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.61
+          toolchain: 1.62
           target: thumbv6m-none-eabi
       - name: Verifiy MSRV
         run: cargo build --workspace --examples ${{ matrix.features }}

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2022-12-11
 
+### MSRV
+
+The Minimum-Supported Rust Version (MSRV) for this release is 1.62
+
 ### Changed
 
 - Fixed: First frame is getting lost on a USB-CDC device - @MuratUrsavas

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"
 description = "A Rust Embeded-HAL impl for the rp2040 microcontroller"
 license = "MIT OR Apache-2.0"
-rust-version = "1.61"
+rust-version = "1.62"
 
 [package.metadata.docs.rs]
 features = ["rt", "rom-v2-intrinsics", "defmt", "rtic-monotonic"]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"
 description = "A Rust Embeded-HAL impl for the rp2040 microcontroller"
 license = "MIT OR Apache-2.0"
+rust-version = "1.61"
 
 [package.metadata.docs.rs]
 features = ["rt", "rom-v2-intrinsics", "defmt", "rtic-monotonic"]


### PR DESCRIPTION
We don't have a documented MSRV policy for rp-hal, but I think https://github.com/rust-embedded/embedded-hal/blob/master/docs/msrv.md is a reasonable approach.

Without any checks in CI we won't notice if we accidentally break compatibility with the documented MSRV. Therefore, I added a (simple) check, which just runs `cargo build --workspace --examples ${{ matrix.features }}` with the old compiler version.

This should not block future changes breaking MSRV compatibility. It's just for awareness, so we can properly document the minimum rust version necessary to build rp2040-hal.