### PR TITLE
Seal several traits

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Several documentation improvements - @nmattia, @tianrking
 - CI improvements - @ithinuel, @jannic
+- Marked several traits as Sealed - @jannic
 
 ## [0.7.0] - 2022-12-11
 

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -155,7 +155,7 @@ pub struct ChangingClockToken<G: Clock> {
 }
 
 /// For clocks that can be disabled
-pub trait StoppableClock {
+pub trait StoppableClock: Sealed {
     /// Enables the clock.
     fn enable(&mut self);
 

--- a/rp2040-hal/src/dma/mod.rs
+++ b/rp2040-hal/src/dma/mod.rs
@@ -22,7 +22,7 @@
 //! automatic continous ring buffers consisting of two aligned buffers being read or written
 //! alternatingly.
 
-use crate::resets::SubsystemReset;
+use crate::{resets::SubsystemReset, typelevel::Sealed};
 use core::marker::PhantomData;
 use embedded_dma::{ReadBuffer, WriteBuffer};
 use rp2040_pac::DMA;
@@ -37,7 +37,7 @@ mod single_channel;
 pub use crate::dma::single_channel::SingleChannel;
 
 /// DMA unit.
-pub trait DMAExt {
+pub trait DMAExt: Sealed {
     /// Splits the DMA unit into its individual channels.
     fn split(self, resets: &mut pac::RESETS) -> Channels;
     /// Splits the DMA unit into its individual channels with runtime ownership
@@ -50,7 +50,7 @@ pub struct Channel<CH: ChannelIndex> {
 }
 
 /// DMA channel identifier.
-pub trait ChannelIndex {
+pub trait ChannelIndex: Sealed {
     /// Numerical index of the DMA channel (0..11).
     fn id() -> u8;
 }
@@ -87,6 +87,8 @@ macro_rules! channels {
             }
         }
 
+        impl Sealed for DMA {}
+
         /// Set of DMA channels.
         pub struct Channels {
             $(
@@ -102,6 +104,8 @@ macro_rules! channels {
                     $x
                 }
             }
+
+            impl Sealed for $CHX {}
         )+
 
         /// Set of DMA channels with runtime ownership.

--- a/rp2040-hal/src/float/mod.rs
+++ b/rp2040-hal/src/float/mod.rs
@@ -1,5 +1,7 @@
 use core::ops;
 
+use crate::typelevel::Sealed;
+
 // Borrowed and simplified from compiler-builtins so we can use bit ops
 // on floating point without macro soup.
 pub trait Int:
@@ -23,6 +25,7 @@ pub trait Int:
     + ops::BitXor<Output = Self>
     + ops::BitAnd<Output = Self>
     + ops::Not<Output = Self>
+    + Sealed
 {
     const ZERO: Self;
 }
@@ -32,6 +35,8 @@ macro_rules! int_impl {
         impl Int for $ty {
             const ZERO: Self = 0;
         }
+
+        impl Sealed for $ty {}
     };
 }
 
@@ -49,6 +54,7 @@ pub trait Float:
     + ops::Sub<Output = Self>
     + ops::Div<Output = Self>
     + ops::Rem<Output = Self>
+    + Sealed
 {
     /// A uint of the same with as the float
     type Int: Int;
@@ -132,6 +138,8 @@ macro_rules! float_impl {
                 -self
             }
         }
+
+        impl Sealed for $ty {}
     };
 }
 

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -386,7 +386,7 @@ macro_rules! pin_id {
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait OptionalPinId {}
+pub trait OptionalPinId: Sealed {}
 
 impl OptionalPinId for NoneT {}
 
@@ -397,7 +397,7 @@ impl<I: PinId> OptionalPinId for I {}
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait SomePinId: OptionalPinId + PinId {}
+pub trait SomePinId: OptionalPinId + PinId + Sealed {}
 
 impl<I: PinId> SomePinId for I {}
 
@@ -803,7 +803,7 @@ impl<P: AnyPin> OptionalPin for P {
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait SomePin: AnyPin {}
+pub trait SomePin: AnyPin + Sealed {}
 impl<P: AnyPin> SomePin for P {}
 
 //==============================================================================

--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -12,10 +12,10 @@ use fugit::{HertzU32, RateExtU32};
 use nb::Error::WouldBlock;
 use pac::RESETS;
 
-use crate::{clocks::ClocksManager, resets::SubsystemReset};
+use crate::{clocks::ClocksManager, resets::SubsystemReset, typelevel::Sealed};
 
 /// State of the PLL
-pub trait State {}
+pub trait State: Sealed {}
 
 /// PLL is disabled.
 pub struct Disabled {
@@ -39,17 +39,22 @@ pub struct Locked {
 }
 
 impl State for Disabled {}
+impl Sealed for Disabled {}
 impl State for Locked {}
+impl Sealed for Locked {}
 impl State for Locking {}
+impl Sealed for Locking {}
 
 /// Trait to handle both underlying devices from the PAC (PLL_SYS & PLL_USB)
 pub trait PhaseLockedLoopDevice:
-    Deref<Target = rp2040_pac::pll_sys::RegisterBlock> + SubsystemReset
+    Deref<Target = rp2040_pac::pll_sys::RegisterBlock> + SubsystemReset + Sealed
 {
 }
 
 impl PhaseLockedLoopDevice for rp2040_pac::PLL_SYS {}
+impl Sealed for rp2040_pac::PLL_SYS {}
 impl PhaseLockedLoopDevice for rp2040_pac::PLL_USB {}
+impl Sealed for rp2040_pac::PLL_USB {}
 
 /// A PLL.
 pub struct PhaseLockedLoop<S: State, D: PhaseLockedLoopDevice> {

--- a/rp2040-hal/src/rosc.rs
+++ b/rp2040-hal/src/rosc.rs
@@ -3,8 +3,10 @@
 
 use fugit::HertzU32;
 
+use crate::typelevel::Sealed;
+
 /// State of the Ring Oscillator (typestate trait)
-pub trait State {}
+pub trait State: Sealed {}
 
 /// ROSC is disabled (typestate)
 pub struct Disabled;
@@ -18,8 +20,11 @@ pub struct Enabled {
 pub struct Dormant;
 
 impl State for Disabled {}
+impl Sealed for Disabled {}
 impl State for Enabled {}
+impl Sealed for Enabled {}
 impl State for Dormant {}
+impl Sealed for Dormant {}
 
 /// A Ring Oscillator.
 pub struct RingOscillator<S: State> {

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -18,6 +18,8 @@
 //! let pins = Pins::new(peripherals.IO_BANK0, peripherals.PADS_BANK0, sio.gpio_bank0, &mut peripherals.RESETS);
 //! ```
 
+use crate::typelevel::Sealed;
+
 use super::*;
 use core::convert::Infallible;
 
@@ -380,7 +382,7 @@ intrinsics! {
 }
 
 /// This type is just used to limit us to Spinlocks `0..=31`
-pub trait SpinlockValid {}
+pub trait SpinlockValid: Sealed {}
 
 /// Hardware based spinlock.
 ///
@@ -482,160 +484,48 @@ where
     }
 }
 
-/// Spinlock number 0
-pub type Spinlock0 = Spinlock<0>;
+macro_rules! spinlock {
+    ($id:expr) => {
+        $crate::paste::paste! {
+            /// Spinlock number $id
+            pub type [<Spinlock $id>] = Spinlock<$id>;
+            impl SpinlockValid for Spinlock<$id> {}
+            impl Sealed for Spinlock<$id> {}
+        }
+    };
+}
 
-impl SpinlockValid for Spinlock<0> {}
-
-/// Spinlock number 1
-pub type Spinlock1 = Spinlock<1>;
-
-impl SpinlockValid for Spinlock<1> {}
-
-/// Spinlock number 2
-pub type Spinlock2 = Spinlock<2>;
-
-impl SpinlockValid for Spinlock<2> {}
-
-/// Spinlock number 3
-pub type Spinlock3 = Spinlock<3>;
-
-impl SpinlockValid for Spinlock<3> {}
-
-/// Spinlock number 4
-pub type Spinlock4 = Spinlock<4>;
-
-impl SpinlockValid for Spinlock<4> {}
-
-/// Spinlock number 5
-pub type Spinlock5 = Spinlock<5>;
-
-impl SpinlockValid for Spinlock<5> {}
-
-/// Spinlock number 6
-pub type Spinlock6 = Spinlock<6>;
-
-impl SpinlockValid for Spinlock<6> {}
-
-/// Spinlock number 7
-pub type Spinlock7 = Spinlock<7>;
-
-impl SpinlockValid for Spinlock<7> {}
-
-/// Spinlock number 8
-pub type Spinlock8 = Spinlock<8>;
-
-impl SpinlockValid for Spinlock<8> {}
-
-/// Spinlock number 9
-pub type Spinlock9 = Spinlock<9>;
-
-impl SpinlockValid for Spinlock<9> {}
-
-/// Spinlock number 10
-pub type Spinlock10 = Spinlock<10>;
-
-impl SpinlockValid for Spinlock<10> {}
-
-/// Spinlock number 11
-pub type Spinlock11 = Spinlock<11>;
-
-impl SpinlockValid for Spinlock<11> {}
-
-/// Spinlock number 12
-pub type Spinlock12 = Spinlock<12>;
-
-impl SpinlockValid for Spinlock<12> {}
-
-/// Spinlock number 13
-pub type Spinlock13 = Spinlock<13>;
-
-impl SpinlockValid for Spinlock<13> {}
-
-/// Spinlock number 14
-pub type Spinlock14 = Spinlock<14>;
-
-impl SpinlockValid for Spinlock<14> {}
-
-/// Spinlock number 15
-pub type Spinlock15 = Spinlock<15>;
-
-impl SpinlockValid for Spinlock<15> {}
-
-/// Spinlock number 16
-pub type Spinlock16 = Spinlock<16>;
-
-impl SpinlockValid for Spinlock<16> {}
-
-/// Spinlock number 17
-pub type Spinlock17 = Spinlock<17>;
-
-impl SpinlockValid for Spinlock<17> {}
-
-/// Spinlock number 18
-pub type Spinlock18 = Spinlock<18>;
-
-impl SpinlockValid for Spinlock<18> {}
-
-/// Spinlock number 19
-pub type Spinlock19 = Spinlock<19>;
-
-impl SpinlockValid for Spinlock<19> {}
-
-/// Spinlock number 20
-pub type Spinlock20 = Spinlock<20>;
-
-impl SpinlockValid for Spinlock<20> {}
-
-/// Spinlock number 21
-pub type Spinlock21 = Spinlock<21>;
-
-impl SpinlockValid for Spinlock<21> {}
-
-/// Spinlock number 22
-pub type Spinlock22 = Spinlock<22>;
-
-impl SpinlockValid for Spinlock<22> {}
-
-/// Spinlock number 23
-pub type Spinlock23 = Spinlock<23>;
-
-impl SpinlockValid for Spinlock<23> {}
-
-/// Spinlock number 24
-pub type Spinlock24 = Spinlock<24>;
-
-impl SpinlockValid for Spinlock<24> {}
-
-/// Spinlock number 25
-pub type Spinlock25 = Spinlock<25>;
-
-impl SpinlockValid for Spinlock<25> {}
-
-/// Spinlock number 26
-pub type Spinlock26 = Spinlock<26>;
-
-impl SpinlockValid for Spinlock<26> {}
-
-/// Spinlock number 27
-pub type Spinlock27 = Spinlock<27>;
-
-impl SpinlockValid for Spinlock<27> {}
-
-/// Spinlock number 28
-pub type Spinlock28 = Spinlock<28>;
-
-impl SpinlockValid for Spinlock<28> {}
-
-/// Spinlock number 29
-pub type Spinlock29 = Spinlock<29>;
-
-impl SpinlockValid for Spinlock<29> {}
-
-/// Spinlock number 30
-pub type Spinlock30 = Spinlock<30>;
-
-impl SpinlockValid for Spinlock<30> {}
+spinlock!(0);
+spinlock!(1);
+spinlock!(2);
+spinlock!(3);
+spinlock!(4);
+spinlock!(5);
+spinlock!(6);
+spinlock!(7);
+spinlock!(8);
+spinlock!(9);
+spinlock!(10);
+spinlock!(11);
+spinlock!(12);
+spinlock!(13);
+spinlock!(14);
+spinlock!(15);
+spinlock!(16);
+spinlock!(17);
+spinlock!(18);
+spinlock!(19);
+spinlock!(20);
+spinlock!(21);
+spinlock!(22);
+spinlock!(23);
+spinlock!(24);
+spinlock!(25);
+spinlock!(26);
+spinlock!(27);
+spinlock!(28);
+spinlock!(29);
+spinlock!(30);
 
 /// Spinlock number 31 - used by critical section implementation
 #[cfg(feature = "critical-section-impl")]
@@ -646,6 +536,7 @@ pub(crate) type Spinlock31 = Spinlock<31>;
 pub type Spinlock31 = Spinlock<31>;
 
 impl SpinlockValid for Spinlock<31> {}
+impl Sealed for Spinlock<31> {}
 
 /// Returns the current state of the spinlocks. Each index corresponds to the associated spinlock, e.g. if index `5` is set to `true`, it means that [`Spinlock5`] is currently locked.
 ///
@@ -760,7 +651,7 @@ impl LaneCtrl {
 }
 
 ///Trait representing the functionnality of a single lane of an interpolator.
-pub trait Lane {
+pub trait Lane: Sealed {
     ///Read the lane result, and simultaneously write lane results to both accumulators.
     fn pop(&mut self) -> u32;
     ///Read the lane result without altering any internal state
@@ -807,7 +698,7 @@ pub trait Lane {
 /// sio.interp0.get_lane0().pop();  // returns 2
 /// sio.interp0.get_lane0().pop();  // returns 3
 /// ```
-pub trait Interp {
+pub trait Interp: Sealed {
     ///Read the interpolator result (Result 2 in the datasheet), and simultaneously write lane results to both accumulators.
     fn pop(&mut self) -> u32;
     ///Read the interpolator result (Result 2 in the datasheet) without altering any internal state
@@ -875,6 +766,7 @@ macro_rules! interpolators {
                                 sio.[<$interp:lower _accum $lane_id _add>].read().bits()
                             }
                         }
+                        impl Sealed for [<$interp $lane>] {}
                     )+
                     #[doc = "Interpolator " $interp]
                     pub struct $interp {
@@ -912,7 +804,7 @@ macro_rules! interpolators {
                             sio.[<$interp:lower _base_1and0>].write(|w| unsafe { w.bits(v)});
                         }
                     }
-
+                    impl Sealed for $interp {}
                 )+
             }
         }

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -485,6 +485,10 @@ where
 }
 
 macro_rules! spinlock {
+    ($first:expr, $($rest:tt),+) => {
+        spinlock!($first);
+        spinlock!($($rest),+);
+    };
     ($id:expr) => {
         $crate::paste::paste! {
             /// Spinlock number $id
@@ -494,38 +498,10 @@ macro_rules! spinlock {
         }
     };
 }
-
-spinlock!(0);
-spinlock!(1);
-spinlock!(2);
-spinlock!(3);
-spinlock!(4);
-spinlock!(5);
-spinlock!(6);
-spinlock!(7);
-spinlock!(8);
-spinlock!(9);
-spinlock!(10);
-spinlock!(11);
-spinlock!(12);
-spinlock!(13);
-spinlock!(14);
-spinlock!(15);
-spinlock!(16);
-spinlock!(17);
-spinlock!(18);
-spinlock!(19);
-spinlock!(20);
-spinlock!(21);
-spinlock!(22);
-spinlock!(23);
-spinlock!(24);
-spinlock!(25);
-spinlock!(26);
-spinlock!(27);
-spinlock!(28);
-spinlock!(29);
-spinlock!(30);
+spinlock!(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30
+);
 
 /// Spinlock number 31 - used by critical section implementation
 #[cfg(feature = "critical-section-impl")]

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -21,6 +21,7 @@
 
 use crate::dma::{EndlessReadTarget, EndlessWriteTarget, ReadTarget, WriteTarget};
 use crate::resets::SubsystemReset;
+use crate::typelevel::Sealed;
 use core::{convert::Infallible, marker::PhantomData, ops::Deref};
 #[cfg(feature = "eh1_0_alpha")]
 use eh1_0_alpha::spi as eh1;
@@ -32,7 +33,7 @@ use pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;
 use pac::RESETS;
 
 /// State of the SPI
-pub trait State {}
+pub trait State: Sealed {}
 
 /// Spi is disabled
 pub struct Disabled {
@@ -45,10 +46,12 @@ pub struct Enabled {
 }
 
 impl State for Disabled {}
+impl Sealed for Disabled {}
 impl State for Enabled {}
+impl Sealed for Enabled {}
 
 /// Pac SPI device
-pub trait SpiDevice: Deref<Target = pac::spi0::RegisterBlock> + SubsystemReset {
+pub trait SpiDevice: Deref<Target = pac::spi0::RegisterBlock> + SubsystemReset + Sealed {
     /// The DREQ number for which TX DMA requests are triggered.
     fn tx_dreq() -> u8;
     /// The DREQ number for which RX DMA requests are triggered.
@@ -63,6 +66,7 @@ impl SpiDevice for pac::SPI0 {
         TREQ_SEL_A::SPI0_RX.into()
     }
 }
+impl Sealed for pac::SPI0 {}
 impl SpiDevice for pac::SPI1 {
     fn tx_dreq() -> u8 {
         TREQ_SEL_A::SPI1_TX.into()
@@ -71,12 +75,15 @@ impl SpiDevice for pac::SPI1 {
         TREQ_SEL_A::SPI1_RX.into()
     }
 }
+impl Sealed for pac::SPI1 {}
 
 /// Data size used in spi
-pub trait DataSize {}
+pub trait DataSize: Sealed {}
 
 impl DataSize for u8 {}
 impl DataSize for u16 {}
+impl Sealed for u8 {}
+impl Sealed for u16 {}
 
 /// Spi
 pub struct Spi<S: State, D: SpiDevice, const DS: u8> {

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -13,6 +13,7 @@ use fugit::{MicrosDurationU32, MicrosDurationU64, TimerInstantU64};
 use crate::atomic_register_access::{write_bitmask_clear, write_bitmask_set};
 use crate::pac::{RESETS, TIMER};
 use crate::resets::SubsystemReset;
+use crate::typelevel::Sealed;
 use core::marker::PhantomData;
 use core::sync::atomic::{AtomicU8, Ordering};
 
@@ -174,7 +175,7 @@ impl embedded_hal::timer::Cancel for CountDown<'_> {
 }
 
 /// Alarm abstraction.
-pub trait Alarm {
+pub trait Alarm: Sealed {
     /// Clear the interrupt flag.
     ///
     /// The interrupt is unable to trigger a 2nd time until this interrupt is cleared.
@@ -362,6 +363,8 @@ macro_rules! impl_alarm {
                 Ok(())
             }
         }
+
+        impl Sealed for $name {}
 
         impl Drop for $name {
             fn drop(&mut self) {

--- a/rp2040-hal/src/uart/pins.rs
+++ b/rp2040-hal/src/uart/pins.rs
@@ -1,5 +1,6 @@
 use crate::gpio::{bank0, FunctionUart, Pin};
 use crate::pac::{UART0, UART1};
+use crate::typelevel::Sealed;
 
 use super::UartDevice;
 
@@ -141,22 +142,22 @@ impl<TX, RX, CTS, RTS> Pins<TX, RX, CTS, RTS> {
 }
 
 /// Indicates a valid TX pin for UART0 or UART1
-pub trait Tx<UART: UartDevice> {
+pub trait Tx<UART: UartDevice>: Sealed {
     #[allow(missing_docs)]
     const ENABLED: bool;
 }
 /// Indicates a valid RX pin for UART0 or UART1
-pub trait Rx<UART: UartDevice> {
+pub trait Rx<UART: UartDevice>: Sealed {
     #[allow(missing_docs)]
     const ENABLED: bool;
 }
 /// Indicates a valid CTS pin for UART0 or UART1
-pub trait Cts<UART: UartDevice> {
+pub trait Cts<UART: UartDevice>: Sealed {
     #[allow(missing_docs)]
     const ENABLED: bool;
 }
 /// Indicates a valid RTS pin for UART0 or UART1
-pub trait Rts<UART: UartDevice> {
+pub trait Rts<UART: UartDevice>: Sealed {
     #[allow(missing_docs)]
     const ENABLED: bool;
 }
@@ -173,6 +174,7 @@ impl<UART: UartDevice> Cts<UART> for () {
 impl<UART: UartDevice> Rts<UART> for () {
     const ENABLED: bool = false;
 }
+impl Sealed for () {}
 
 macro_rules! impl_valid_uart {
     ($($uart:ident: {

--- a/rp2040-hal/src/uart/utils.rs
+++ b/rp2040-hal/src/uart/utils.rs
@@ -1,5 +1,6 @@
 use crate::pac::{uart0::RegisterBlock, UART0, UART1};
 use crate::resets::SubsystemReset;
+use crate::typelevel::Sealed;
 use core::ops::Deref;
 use fugit::HertzU32;
 use rp2040_pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;
@@ -12,10 +13,10 @@ pub enum Error {
     BadArgument,
 }
 /// State of the UART Peripheral.
-pub trait State {}
+pub trait State: Sealed {}
 
 /// Trait to handle both underlying devices (UART0 & UART1)
-pub trait UartDevice: Deref<Target = RegisterBlock> + SubsystemReset + 'static {
+pub trait UartDevice: Deref<Target = RegisterBlock> + SubsystemReset + Sealed + 'static {
     /// The DREQ number for which TX DMA requests are triggered.
     fn tx_dreq() -> u8
     where
@@ -36,6 +37,7 @@ impl UartDevice for UART0 {
         TREQ_SEL_A::UART0_RX.into()
     }
 }
+impl Sealed for UART0 {}
 impl UartDevice for UART1 {
     /// The DREQ number for which TX DMA requests are triggered.
     fn tx_dreq() -> u8 {
@@ -46,6 +48,7 @@ impl UartDevice for UART1 {
         TREQ_SEL_A::UART1_RX.into()
     }
 }
+impl Sealed for UART1 {}
 
 /// UART is enabled.
 pub struct Enabled;
@@ -54,7 +57,9 @@ pub struct Enabled;
 pub struct Disabled;
 
 impl State for Enabled {}
+impl Sealed for Enabled {}
 impl State for Disabled {}
+impl Sealed for Disabled {}
 
 /// Data bits
 pub enum DataBits {

--- a/rp2040-hal/src/xosc.rs
+++ b/rp2040-hal/src/xosc.rs
@@ -7,8 +7,10 @@ use core::{convert::Infallible, ops::RangeInclusive};
 use fugit::HertzU32;
 use nb::Error::WouldBlock;
 
+use crate::typelevel::Sealed;
+
 /// State of the Crystal Oscillator (typestate trait)
-pub trait State {}
+pub trait State: Sealed {}
 
 /// XOSC is disabled (typestate)
 pub struct Disabled;
@@ -27,9 +29,13 @@ pub struct Stable {
 pub struct Dormant;
 
 impl State for Disabled {}
+impl Sealed for Disabled {}
 impl State for Initialized {}
+impl Sealed for Initialized {}
 impl State for Stable {}
+impl Sealed for Stable {}
 impl State for Dormant {}
+impl Sealed for Dormant {}
 
 /// Possible errors when initializing the CrystalOscillator
 #[derive(Debug)]


### PR DESCRIPTION
Sealing traits allows for later extensions without causing a breaking change.
Reference: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed