### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,18 +8,12 @@ jobs:
       matrix:
         mode: ["", "--release"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: thumbv6m-none-eabi
-          override: true
-          profile: minimal
       - name: Build rp2040-hal's examples
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p rp2040-hal ${{ matrix.mode }} --examples --features rt,critical-section-impl
+        run: cargo build -p rp2040-hal ${{ matrix.mode }} --examples --features rt,critical-section-impl
   builds:
     name: Build checks
     runs-on: ubuntu-20.04


### PR DESCRIPTION
PR #532 updated some github actions. A later merge of some older branch reintroduced some of the deprecated actions. This updates those instances in the same way as #532 did.