### PR TITLE
Added set_mov_status_config function to PIOBuilder

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1931,7 +1931,8 @@ impl<P: PIOExt> PIOBuilder<P> {
     }
 
     /// Set the config for when the status register is set to true.
-    /// See MovStatusConfig for more info.
+    ///
+    /// See `MovStatusConfig` for more info.
     pub fn set_mov_status_config(mut self, mov_status: MovStatusConfig) -> Self {
         self.mov_status = mov_status;
 

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1930,6 +1930,14 @@ impl<P: PIOExt> PIOBuilder<P> {
         }
     }
 
+    /// Set the config for when the status register is set to true.
+    /// See MovStatusConfig for more info.
+    pub fn set_mov_status_config(mut self, mov_status: MovStatusConfig) -> Self {
+        self.mov_status = mov_status;
+
+        self
+    }
+
     /// Set the pins asserted by `SET` instruction.
     ///
     /// The least-significant bit of `SET` instruction asserts the state of the pin indicated by `base`, the next bit


### PR DESCRIPTION
There is no way to set mov_status with the base hal. Added set_mov_status to allow config of the mov_status variable.