### PR TITLE
Upgrade syn to version 2.0

### DIFF
--- a/rp2040-hal-macros/Cargo.toml
+++ b/rp2040-hal-macros/Cargo.toml
@@ -14,6 +14,6 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dependencies.syn]
-features = ["extra-traits", "full"]
+features = ["full"]
 version = "2.0"
 

--- a/rp2040-hal-macros/Cargo.toml
+++ b/rp2040-hal-macros/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro2 = "1.0"
 
 [dependencies.syn]
 features = ["extra-traits", "full"]
-version = "1.0"
+version = "2.0"
 


### PR DESCRIPTION
Right now this doesn't improve anything: While other dependencies still use syn version 1, it just causes both versions to be built, increasing the build time. So we might not yet want to merge this.

Once dependencies start to migrate to version 2, we should do so as well, to complete the migration to version 2 as quickly as possible.