### PR TITLE
Re-export fugit

### DIFF
--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -20,7 +20,7 @@ use rp2040_hal as hal;
 // Some traits we need
 use core::fmt::Write;
 use embedded_hal::adc::OneShot;
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use rp2040_hal::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -13,12 +13,12 @@
 // be linked)
 use panic_halt as _;
 
-// Some traits we need
-use embedded_hal::blocking::i2c::Write;
-use fugit::RateExtU32;
-
 // Alias for our HAL crate
 use rp2040_hal as hal;
+
+// Some traits we need
+use embedded_hal::blocking::i2c::Write;
+use hal::fugit::RateExtU32;
 
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access and a gpio related types.

--- a/rp2040-hal/examples/rom_funcs.rs
+++ b/rp2040-hal/examples/rom_funcs.rs
@@ -22,7 +22,7 @@ use hal::pac;
 
 // Some traits we need
 use core::fmt::Write;
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use hal::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -21,8 +21,8 @@ use rp2040_hal as hal;
 
 // Some traits we need
 use cortex_m::prelude::*;
-use fugit::RateExtU32;
-use rp2040_hal::clocks::Clock;
+use hal::clocks::Clock;
+use hal::fugit::RateExtU32;
 
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access

--- a/rp2040-hal/examples/spi_dma.rs
+++ b/rp2040-hal/examples/spi_dma.rs
@@ -12,8 +12,8 @@
 use cortex_m::singleton;
 use cortex_m_rt::entry;
 use embedded_hal::digital::v2::OutputPin;
-use fugit::RateExtU32;
 use hal::dma::{bidirectional, DMAExt};
+use hal::fugit::RateExtU32;
 use hal::pac;
 use panic_halt as _;
 use rp2040_hal as hal;

--- a/rp2040-hal/examples/uart.rs
+++ b/rp2040-hal/examples/uart.rs
@@ -24,7 +24,7 @@ use hal::pac;
 
 // Some traits we need
 use core::fmt::Write;
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use rp2040_hal::clocks::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/uart_dma.rs
+++ b/rp2040-hal/examples/uart_dma.rs
@@ -24,7 +24,7 @@ use rp2040_hal as hal;
 use hal::{dma::DMAExt, pac};
 
 // Some traits we need
-use fugit::RateExtU32;
+use hal::fugit::RateExtU32;
 use rp2040_hal::clocks::Clock;
 
 // UART related types

--- a/rp2040-hal/examples/vector_table.rs
+++ b/rp2040-hal/examples/vector_table.rs
@@ -22,7 +22,7 @@ use hal::pac;
 use core::cell::RefCell;
 use critical_section::Mutex;
 use embedded_hal::digital::v2::ToggleableOutputPin;
-use fugit::MicrosDurationU32;
+use hal::fugit::MicrosDurationU32;
 use pac::interrupt;
 use rp2040_hal::clocks::Clock;
 use rp2040_hal::timer::Alarm;

--- a/rp2040-hal/examples/watchdog.rs
+++ b/rp2040-hal/examples/watchdog.rs
@@ -23,7 +23,7 @@ use hal::pac;
 // Some traits we need
 use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::watchdog::{Watchdog, WatchdogEnable};
-use fugit::ExtU32;
+use hal::fugit::ExtU32;
 use rp2040_hal::clocks::Clock;
 
 /// The linker will place this boot block at the start of our program image. We

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -38,6 +38,7 @@
 #![warn(missing_docs)]
 #![no_std]
 
+#[doc(hidden)]
 pub use paste;
 
 /// Re-export of the PAC

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -93,6 +93,8 @@ pub use sio::Sio;
 pub use spi::Spi;
 pub use timer::Timer;
 pub use watchdog::Watchdog;
+// Re-export crates used in rp2040-hal's public API
+pub extern crate fugit;
 
 /// Trigger full reset of the RP2040.
 ///


### PR DESCRIPTION
Closes #572

I also had a quick look for other crates to re-export:

One candidate would be `embedded-hal`, but I think a re-export is not appropriate there: That crate is, in general, not used to access features of `rp2040-hal`, but it's the other way around: Some driver expects a type implementing a trait from `embedded-hal`, and `rp2040-hal` provides that type. In that chase, the needed version of `embedded-hal` is selected by the driver, not by `rp2040-hal`, and a re-export would not help with that.

There are probably more, but it needs to be checked manually which dependencies are actually used in exposed APIs. I don't want to re-export something unnecessarily.

On other small change: I hid the re-export of `paste` from the docs. It's only there because it's used in macros provided by rp2040-hal. No need to list it in the docs.