### PR TITLE
Fix typo

### DIFF
--- a/rp2040-hal/src/dma/mod.rs
+++ b/rp2040-hal/src/dma/mod.rs
@@ -1,4 +1,4 @@
-//! Direct memory acces (DMA).
+//! Direct memory access (DMA).
 //!
 //! The DMA unit of the RP2040 seems very simplistic at first when compared to other MCUs. For
 //! example, the individual DMA channels do not support chaining multiple buffers. However, within

--- a/rp2040-hal/src/gpio/dynpin.rs
+++ b/rp2040-hal/src/gpio/dynpin.rs
@@ -240,7 +240,7 @@ pub struct DynPinId {
 /// Provide a safe register interface for [`DynPin`]s
 ///
 /// This `struct` takes ownership of a [`DynPinId`] and provides an API to
-/// access the corresponding regsiters.
+/// access the corresponding registers.
 struct DynRegisters {
     id: DynPinId,
 }

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -408,7 +408,7 @@ impl<I: PinId> SomePinId for I {}
 /// Provide a safe register interface for [`Pin`]s
 ///
 /// This `struct` takes ownership of a [`PinId`] and provides an API to
-/// access the corresponding regsiters.
+/// access the corresponding registers.
 struct Registers<I: PinId> {
     id: PhantomData<I>,
 }

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1848,7 +1848,7 @@ pub struct PIOBuilder<P> {
 
     /// Continuously assert the most recent OUT/SET to the pins.
     out_sticky: bool,
-    /// Use a bit of OUT data as an auxilary write enable.
+    /// Use a bit of OUT data as an auxiliary write enable.
     ///
     /// When [`out_sticky`](Self::out_sticky) is enabled, setting the bit to 0 deasserts for that instr.
     inline_out: Option<u8>,
@@ -2010,7 +2010,7 @@ impl<P: PIOExt> PIOBuilder<P> {
         self
     }
 
-    /// The clock is based on the `sys_clk` and will execute an intruction every `int + (frac/256)` ticks.
+    /// The clock is based on the `sys_clk` and will execute an instruction every `int + (frac/256)` ticks.
     ///
     /// A clock divisor of `n` will cause the state machine to run 1 cycle every `n` clock cycles. If the integer part
     /// is 0 then the fractional part must be 0. This is interpreted by the device as the integer 65536.

--- a/rp2040-hal/src/rom_data.rs
+++ b/rp2040-hal/src/rom_data.rs
@@ -27,7 +27,7 @@ const DATA_TABLE: *const u16 = 0x0000_0016 as _;
 /// Address of the version number of the ROM.
 const VERSION_NUMBER: *const u8 = 0x0000_0013 as _;
 
-/// Retrive rom content from a table using a code.
+/// Retrieve rom content from a table using a code.
 fn rom_table_lookup<T>(table: *const u16, tag: RomFnTableCode) -> T {
     unsafe {
         let rom_table_lookup_ptr: *const u32 = rom_hword_as_ptr(ROM_TABLE_LOOKUP_PTR);


### PR DESCRIPTION
Fixed a typo in a comment.
The changes have no effect the operation.