### PR TITLE
Fix probe-run command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ programming pins on your RP2040 board. Check the probe has been found by
 running:
 
 ```console
-$ probe-run --chip RP2040 --list-probes
+$ probe-run --list-probes
 The following devices were found:
 [0]: J-Link (J-Link) (VID: 1366, PID: 0101, Serial: 000099999999, JLink)
 ```


### PR DESCRIPTION
The current command gives an error,
the `--chip` and `--list-probes` flags cannot be used at the same time.

This patch fixes the command in the readme.