### PR TITLE
Document RAM banks in memory.x

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -1,7 +1,28 @@
 MEMORY {
     BOOT2 : ORIGIN = 0x10000000, LENGTH = 0x100
     FLASH : ORIGIN = 0x10000100, LENGTH = 2048K - 0x100
-    RAM   : ORIGIN = 0x20000000, LENGTH = 256K
+    /*
+     * RAM consists of 4 banks, SRAM0-SRAM3, with a striped mapping.
+     * This is usually good for performance, as it distributes load on
+     * those banks evenly.
+     */
+    RAM : ORIGIN = 0x20000000, LENGTH = 256K
+    /*
+     * RAM banks 4 and 5 use a direct mapping. They can be used to have
+     * memory areas dedicated for some specific job, improving predictability
+     * of access times.
+     * Example: Separate stacks for core0 and core1.
+     */
+    SRAM4 : ORIGIN = 0x20040000, LENGTH = 4k
+    SRAM5 : ORIGIN = 0x20041000, LENGTH = 4k
+
+    /* SRAM banks 0-3 can also be accessed directly. However, those ranges
+       alias with the RAM mapping, above. So don't use them at the same time!
+    SRAM0 : ORIGIN = 0x21000000, LENGTH = 64k
+    SRAM1 : ORIGIN = 0x21010000, LENGTH = 64k
+    SRAM2 : ORIGIN = 0x21020000, LENGTH = 64k
+    SRAM3 : ORIGIN = 0x21030000, LENGTH = 64k
+    */
 }
 
 EXTERN(BOOT2_FIRMWARE)


### PR DESCRIPTION
This defines new memory regions SRAM4, SRAM5.

Without a linker section referring to those regions, they will not actually be used.