### PR TITLE
Fix DMA IRQ issue for bidirectional DMA transfer

### DIFF
--- a/rp2040-hal/src/dma/bidirectional.rs
+++ b/rp2040-hal/src/dma/bidirectional.rs
@@ -103,7 +103,7 @@ where
     /// Check if an interrupt is pending for either channel and clear the corresponding pending bit
     pub fn check_irq0(&mut self) -> bool {
         let a = self.ch.0.check_irq0();
-        let b = self.ch.1.check_irq1();
+        let b = self.ch.1.check_irq0();
         a | b
     }
 


### PR DESCRIPTION
By reading the code, this seems to be a bug, caused by a typo. The function `check_irq0()` seems to be intended to check `irq0` for both channels. But for channel 1, it is set to check `irq1`.

The corresponding function `check_irq1()` does check `irq1` for both channels.