### PR TITLE
Fix integer over-flow on using low UART baudrate 

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -23,7 +23,7 @@ embedded-dma = "0.2.0"
 fugit = "0.3.6"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
-rp2040-pac = { git = "https://github.com/ArchUsr64/rp2040-pac", rev = "25a5a8b" }
+rp2040-pac = "0.4.0"
 paste = "1.0"
 pio = "0.2.0"
 rp2040-hal-macros = { version = "0.1.0", path = "../rp2040-hal-macros" }

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -23,7 +23,7 @@ embedded-dma = "0.2.0"
 fugit = "0.3.6"
 itertools = { version = "0.10.1", default-features = false }
 nb = "1.0"
-rp2040-pac = "0.4.0"
+rp2040-pac = { git = "https://github.com/ArchUsr64/rp2040-pac", rev = "25a5a8b" }
 paste = "1.0"
 pio = "0.2.0"
 rp2040-hal-macros = { version = "0.1.0", path = "../rp2040-hal-macros" }

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -255,7 +255,7 @@ impl<P: ValidUartPinout<UART1>> UartPeripheral<Enabled, UART1, P> {
 fn calculate_baudrate_dividers(
     wanted_baudrate: HertzU32,
     frequency: HertzU32,
-) -> Result<(u32, u32), Error> {
+) -> Result<(u16, u16), Error> {
     // See Chapter 4, Section 2 §7.1 from the datasheet for an explanation of how baudrate is
     // calculated
     let baudrate_div = frequency
@@ -269,7 +269,7 @@ fn calculate_baudrate_dividers(
 
         (int_part, _) if int_part >= 65535 => (65535, 0),
 
-        (int_part, frac_part) => (int_part as u32, frac_part as u32),
+        (int_part, frac_part) => (int_part as u16, frac_part as u16),
     })
 }
 
@@ -298,7 +298,7 @@ fn configure_baudrate(
     device.uartlcr_h.modify(|_, w| w);
 
     Ok(HertzU32::from_raw(
-        (4 * frequency.to_Hz()) / (64 * baud_div_int + baud_div_frac),
+        (4 * frequency.to_Hz()) / (64 * baud_div_int as u32 + baud_div_frac as u32),
     ))
 }
 

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -255,7 +255,7 @@ impl<P: ValidUartPinout<UART1>> UartPeripheral<Enabled, UART1, P> {
 fn calculate_baudrate_dividers(
     wanted_baudrate: HertzU32,
     frequency: HertzU32,
-) -> Result<(u16, u16), Error> {
+) -> Result<(u32, u32), Error> {
     // See Chapter 4, Section 2 §7.1 from the datasheet for an explanation of how baudrate is
     // calculated
     let baudrate_div = frequency
@@ -269,7 +269,7 @@ fn calculate_baudrate_dividers(
 
         (int_part, _) if int_part >= 65535 => (65535, 0),
 
-        (int_part, frac_part) => (int_part as u16, frac_part as u16),
+        (int_part, frac_part) => (int_part as u32, frac_part as u32),
     })
 }
 

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -298,7 +298,7 @@ fn configure_baudrate(
     device.uartlcr_h.modify(|_, w| w);
 
     Ok(HertzU32::from_raw(
-        (4 * frequency.to_Hz()) / (64 * baud_div_int + baud_div_frac) as u32,
+        (4 * frequency.to_Hz()) / (64 * baud_div_int + baud_div_frac),
     ))
 }
 


### PR DESCRIPTION
In the current implementation of [`configure_buadrate`](https://github.com/rp-rs/rp-hal/blob/8f6cbd85c255bcd902e32bf41f33be85cd532ca1/rp2040-hal/src/uart/peripheral.rs#L277) used to configure the UART registers for a given `wanted_baudrate`, the variable `baud_div_int` and `baud_div_frac` are both `u16`.

This causes an integer overflow leads to a panic when executing the following line at `64 * baud_div_int`:
https://github.com/rp-rs/rp-hal/blob/8f6cbd85c255bcd902e32bf41f33be85cd532ca1/rp2040-hal/src/uart/peripheral.rs#L301

This PR modifies it to be similar to the official SDK implementation :
https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_uart/uart.c#L73-L99

### Note:
I'm currently using my own fork of `rp2040-pac` as the current implementation of [`bits`](https://github.com/rp-rs/rp2040-pac/blob/a2a86af34d18018fd7312a23257decc23159aa38/src/uart0/uartibrd.rs#L59) requires `u16` as argument here:
https://github.com/rp-rs/rp-hal/blob/8f6cbd85c255bcd902e32bf41f33be85cd532ca1/rp2040-hal/src/uart/peripheral.rs#L286