### PR TITLE
Update usb-device implementation.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.64
+          toolchain: 1.65
           target: thumbv6m-none-eabi
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v2

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- bump MSRV to 1.65
+
 ## [0.9.1]
 
 ### Added

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 homepage = "https://github.com/rp-rs/rp-hal"
 description = "A Rust Embeded-HAL impl for the rp2040 microcontroller"
 license = "MIT OR Apache-2.0"
-rust-version = "1.64"
+rust-version = "1.65"
 repository = "https://github.com/rp-rs/rp-hal"
 
 [package.metadata.docs.rs]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -28,7 +28,7 @@ rp2040-pac = { version = "0.5.0", features = ["critical-section"] }
 paste = "1.0"
 pio = "0.2.0"
 rp2040-hal-macros = { version = "0.1.0", path = "../rp2040-hal-macros" }
-usb-device = "0.2.9"
+usb-device = "0.3"
 vcell = "0.1"
 void = { version = "1.0.2", default-features = false }
 rand_core = "0.6.3"

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -236,7 +236,8 @@ impl Inner {
         // Data Buffers are typically 64 bytes long as this is the max normal packet size for most FS packets.
         // For Isochronous endpoints a maximum buffer size of 1023 bytes is supported.
         // For other packet types the maximum size is 64 bytes per buffer.
-        if (ep_type != EndpointType::Isochronous && max_packet_size > 64) || max_packet_size > 1023
+        if (!matches!(ep_type, EndpointType::Isochronous { .. }) && max_packet_size > 64)
+            || max_packet_size > 1023
         {
             return Err(UsbError::Unsupported);
         }
@@ -288,7 +289,7 @@ impl Inner {
             use crate::pac::usbctrl_dpram::ep_control::ENDPOINT_TYPE_A;
             let ep_type = match ep.ep_type {
                 EndpointType::Bulk => ENDPOINT_TYPE_A::BULK,
-                EndpointType::Isochronous => ENDPOINT_TYPE_A::ISOCHRONOUS,
+                EndpointType::Isochronous { .. } => ENDPOINT_TYPE_A::ISOCHRONOUS,
                 EndpointType::Control => ENDPOINT_TYPE_A::CONTROL,
                 EndpointType::Interrupt => ENDPOINT_TYPE_A::INTERRUPT,
             };


### PR DESCRIPTION
Next usb-device release has some changes around isochronous endpoint type.

(only to be merged once the new version of usb-device gets published)