### PR TITLE
Activate clippy checks on exported APIs

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/rp2040-hal/src/dma/bidirectional.rs
+++ b/rp2040-hal/src/dma/bidirectional.rs
@@ -44,11 +44,13 @@ where
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     /// Set the transfer pacing for the DMA transfer from the source
     pub fn from_pace(&mut self, pace: Pace) {
         self.from_pace = pace;
     }
 
+    #[allow(clippy::wrong_self_convention)]
     /// Set the transfer pacing for the DMA transfer to the target
     pub fn to_pace(&mut self, pace: Pace) {
         self.to_pace = pace;

--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -41,6 +41,7 @@ pub use dynpin::*;
 
 mod reg;
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 /// The amount of current that a pin can drive when used as an output
 pub enum OutputDriveStrength {

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -78,6 +78,7 @@ impl PIOExt for PIO1 {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 /// Programmable IO Block
 pub struct PIO<P: PIOExt> {
     used_instruction_space: u32, // bit for each PIO_INSTRUCTION_COUNT

--- a/rp2040-hal/src/rtc/datetime_no_deps.rs
+++ b/rp2040-hal/src/rtc/datetime_no_deps.rs
@@ -3,6 +3,7 @@ use rp2040_pac::rtc::{rtc_0, rtc_1, setup_0, setup_1};
 /// Errors regarding the [`DateTime`] and [`DateTimeFilter`] structs.
 ///
 /// [`DateTimeFilter`]: struct.DateTimeFilter.html
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {


### PR DESCRIPTION
Today I learned about the `avoid-breaking-exported-api = false` clippy config.

https://doc.rust-lang.org/stable/clippy/lint_configuration.html?highlight=avoid-breaking-exported-api#avoid-breaking-exported-api

While a clippy warning probably is not a good justification for a breaking change, such warnings can be useful to avoid issues in new APIs.

The number of issues clipply flags for existing APIs is managable, so I propose adding that config, and add matching allow annotations to override warnings in the current API.