### PR TITLE
Improve testing

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
-      - name: Build rp2040-hal's examples
+      - name: Build rp2040-hal's workspace (without the examples)
         run: cargo hack build --optional-deps --each-feature
   examples-builds:
     name: Build rp2040-hal's examples

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,52 +2,98 @@ on: [push, pull_request]
 name: Build and Test check
 jobs:
   rp2040-hal-builds:
-    name: Build rp2040-hal examples without bsp
+    name: Build rp2040-hal's features
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        mode: ["", "--release"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: thumbv6m-none-eabi
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
       - name: Build rp2040-hal's examples
-        run: cargo build -p rp2040-hal ${{ matrix.mode }} --examples --features rt,critical-section-impl
-  builds:
-    name: Build checks
+        run: cargo hack build --optional-deps --each-feature
+  examples-builds:
+    name: Build rp2040-hal's examples
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        features: ["", "--features eh1_0_alpha", "--features chrono", "--features rp2040-e5"]
-        mode: ["", "--release"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: thumbv6m-none-eabi
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
       - name: Build workspace
-        run: cargo build ${{ matrix.mode }} --workspace ${{ matrix.features }}
-      - name: Build workspace and examples
-        run: cargo build ${{ matrix.mode }} --workspace --examples ${{ matrix.features }}
-      - name: List built examples and clean
-        run: rm -vrf target/thumbv6m-none-eabi/*/examples/* | sed -e "s/removed '\(.*\)'/\1/" | xargs -l basename | grep -Ev '(-|\.d)'
+        run: cargo hack build --examples --optional-deps --each-feature
+  tests:
+    name: Execute host-runable tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: thumbv6m-none-eabi
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
       - name: Test
-        run: cargo test --tests --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+        run: cargo hack test --tests --target x86_64-unknown-linux-gnu  --optional-deps --each-feature
       - name: Test docs
-        run: cargo test --doc --target x86_64-unknown-linux-gnu ${{ matrix.features }}
+        run: cargo hack test --doc --target x86_64-unknown-linux-gnu  --optional-deps --each-feature
       - name: Clean
         run: cargo clean
-      - uses: dtolnay/rust-toolchain@nightly
+  udeps:
+    name: Check rp2040-hal for unused dependencies
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: nightly
           target: thumbv6m-none-eabi
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
       - name: Install cargo-udeps
-        run: curl --location "https://github.com/est31/cargo-udeps/releases/download/v0.1.35/cargo-udeps-v0.1.35-x86_64-unknown-linux-gnu.tar.gz" --output - | tar --strip-components=2 -C ~/.cargo/bin -xzvvf - ./cargo-udeps-v0.1.35-x86_64-unknown-linux-gnu/cargo-udeps
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-udeps
       - name: Check unused deps
-        run: cargo udeps ${{ matrix.mode }} --workspace ${{ matrix.features }}
-      - uses: dtolnay/rust-toolchain@master
+        run: cargo hack udeps --optional-deps --each-feature
+  msrv:
+    name: Verifiy build on MSRV
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.62
           target: thumbv6m-none-eabi
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
       - name: Verifiy MSRV
-        run: cargo build --workspace --examples ${{ matrix.features }}
+        run: cargo hack build --examples --optional-deps --each-feature
+  on-target-build:
+    name: Build on-target-tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: thumbv6m-none-eabi
+      - name: Install cargo-hack
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-hack
+      - name: Build on-target-tests
+        run: |
+          cd on-target-tests
+          cargo hack build --each-feature --exclude-all-features

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,6 +2,7 @@ on: [push, pull_request]
 name: Clippy check
 jobs:
   clippy_check:
+    name: Run Clippy
     runs-on: ubuntu-20.04
     env:
       RUSTFLAGS: "-D warnings"
@@ -12,3 +13,6 @@ jobs:
           target: thumbv6m-none-eabi
           components: clippy
       - run: cargo clippy --workspace --examples -- -Dwarnings
+      - run: |
+          cd on-target-tests
+          cargo clippy -- -Dwarnings

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -13,3 +13,6 @@ jobs:
           target: thumbv6m-none-eabi
           components: rustfmt
       - run: cargo fmt -- --check
+      - run: |
+          cd on-target-tests
+          cargo fmt -- --check

--- a/on-target-tests/Cargo.toml
+++ b/on-target-tests/Cargo.toml
@@ -46,7 +46,7 @@ defmt-rtt = "0.4"
 defmt-test = "0.3"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-rp2040-hal = { path = "../rp2040-hal", version = "0.6", features = [
+rp2040-hal = { path = "../rp2040-hal", version = "0.8", features = [
     "defmt",
     "critical-section-impl",
 ] }
@@ -55,7 +55,6 @@ fugit = "0.3.6"
 
 rp2040-boot2 = "0.2"
 critical-section = "1.0.0"
-
 
 [features]
 default = ['defmt-trace']


### PR DESCRIPTION
Use `cargo-hack` to save some maintenance effort on CI/test maintenance by auto-discovering features and optional deps.
Use `cargo-install` to benefit from its caching feature and shorten CI run time.