### PR TITLE
Fix broken link to team list

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,4 +36,4 @@ The enforcement policies listed above apply to all official embedded rp-rs venue
 
 *Text kindly borrowed from the Rust Embedded Working Group*
 
-[team]: https://github.com/orgs/rp-rs/teams/rp-rs
+[team]: https://github.com/orgs/rp-rs/people

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Conduct][CoC], and the maintainer of this crate, the [rp-rs team], promises
 to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md
-[rp-rs team]: https://github.com/orgs/rp-rs/teams/rp-rs
+[rp-rs team]: https://github.com/orgs/rp-rs/people
 
 <!-- LICENSE -->
 ## License


### PR DESCRIPTION
I did a quick check of other links.  http://citizencodeofconduct.org is also broken right now but seems like it is maybe temporary.