### PR TITLE
Fix Spi for EH1 alpha

### DIFF
--- a/rp2040-hal/examples/spi.rs
+++ b/rp2040-hal/examples/spi.rs
@@ -90,7 +90,7 @@ fn main() -> ! {
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
         16.MHz(),
-        &embedded_hal::spi::MODE_0,
+        embedded_hal::spi::MODE_0,
     );
 
     // Write out 0, ignore return value

--- a/rp2040-hal/examples/spi_dma.rs
+++ b/rp2040-hal/examples/spi_dma.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
         &mut pac.RESETS,
         clocks.peripheral_clock.freq(),
         16_000_000u32.Hz(),
-        &embedded_hal::spi::MODE_0,
+        embedded_hal::spi::MODE_0,
     );
 
     // Initialize DMA.

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -36,7 +36,7 @@ use pac::RESETS;
 
 /// Spi mode
 #[derive(Clone)]
-pub struct Mode(pub embedded_hal::spi::Mode);
+pub struct Mode(embedded_hal::spi::Mode);
 
 impl From<embedded_hal::spi::Mode> for Mode {
     fn from(f: embedded_hal::spi::Mode) -> Self {

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -23,12 +23,18 @@ use crate::dma::{EndlessReadTarget, EndlessWriteTarget, ReadTarget, WriteTarget}
 use crate::resets::SubsystemReset;
 use crate::typelevel::Sealed;
 use core::{convert::Infallible, marker::PhantomData, ops::Deref};
+use embedded_hal::blocking::spi;
+use embedded_hal::spi::FullDuplex;
+
+#[cfg(feature = "eh1_0_alpha")]
+use eh1::{Mode, Phase, Polarity};
 #[cfg(feature = "eh1_0_alpha")]
 use eh1_0_alpha::spi as eh1;
 #[cfg(feature = "eh1_0_alpha")]
 use eh_nb_1_0_alpha::spi as eh1nb;
-use embedded_hal::blocking::spi;
-use embedded_hal::spi::{FullDuplex, Mode, Phase, Polarity};
+#[cfg(not(feature = "eh1_0_alpha"))]
+use embedded_hal::spi::{Mode, Phase, Polarity};
+
 use fugit::HertzU32;
 use fugit::RateExtU32;
 use pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -200,7 +200,6 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
 
     /// Set format and datasize
     fn set_format(&mut self, data_bits: u8, mode: Mode) {
-        let mode: Mode = mode;
         self.device.sspcr0.modify(|_, w| unsafe {
             w.dss()
                 .bits(data_bits - 1)

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -199,8 +199,8 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
     }
 
     /// Set format and datasize
-    fn set_format<M: Into<Mode>>(&mut self, data_bits: u8, mode: M) {
-        let mode: Mode = mode.into();
+    fn set_format(&mut self, data_bits: u8, mode: Mode) {
+        let mode: Mode = mode;
         self.device.sspcr0.modify(|_, w| unsafe {
             w.dss()
                 .bits(data_bits - 1)
@@ -220,12 +220,12 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
         }
     }
 
-    fn init_spi<F: Into<HertzU32>, B: Into<HertzU32>, M: Into<Mode>>(
+    fn init_spi<F: Into<HertzU32>, B: Into<HertzU32>>(
         mut self,
         resets: &mut RESETS,
         peri_frequency: F,
         baudrate: B,
-        mode: M,
+        mode: Mode,
         slave: bool,
     ) -> Spi<Enabled, D, DS> {
         self.device.reset_bring_down(resets);
@@ -253,7 +253,7 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
         baudrate: B,
         mode: M,
     ) -> Spi<Enabled, D, DS> {
-        self.init_spi(resets, peri_frequency, baudrate, mode, false)
+        self.init_spi(resets, peri_frequency, baudrate, mode.into(), false)
     }
 
     /// Initialize the SPI in slave mode
@@ -261,7 +261,7 @@ impl<D: SpiDevice, const DS: u8> Spi<Disabled, D, DS> {
         // Use dummy values for frequency and baudrate.
         // With both values 0, set_baudrate will set prescale == u8::MAX, which will break if debug assertions are enabled.
         // u8::MAX is outside the allowed range 2..=254 for CPSDVSR, which might interfere with proper operation in slave mode.
-        self.init_spi(resets, 1000u32.Hz(), 1000u32.Hz(), mode, true)
+        self.init_spi(resets, 1000u32.Hz(), 1000u32.Hz(), mode.into(), true)
     }
 }
 


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> src/main.rs:72:9
    |
68  |     let mut spi = spi.init(
    |                       ---- arguments to this method are incorrect
...
72  |         &embedded_hal::spi::MODE_0,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `embedded_hal::spi::Mode`, found `Mode`
    |
    = note: `Mode` and `embedded_hal::spi::Mode` have similar names, but are actually distinct types
```

I was getting an error.  Not sure if these are the right changes but fixes the issue for me.  Potentially the feature conditionals could be tidied up.