### PR TITLE
Cloneable timer

### DIFF
--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -141,13 +141,9 @@ macro_rules! impl_delay_traits {
     ($($t:ty),+) => {
         $(
         impl embedded_hal::blocking::delay::DelayUs<$t> for Timer {
-            fn delay_us(&mut self, mut us: $t) {
+            fn delay_us(&mut self, us: $t) {
                 #![allow(unused_comparisons)]
                 assert!(us >= 0); // Only meaningful for i32
-                while <$t>::MAX as u64 > u32::MAX as u64 && us > u32::MAX as $t {
-                    self.delay_us_internal(u32::MAX);
-                    us -= u32::MAX as $t;
-                }
                 self.delay_us_internal(us as u32)
             }
         }
@@ -165,7 +161,7 @@ macro_rules! impl_delay_traits {
 }
 
 // The implementation for i32 is a workaround to allow `delay_ms(42)` construction without specifying a type.
-impl_delay_traits!(u8, u16, u32, u64, i32);
+impl_delay_traits!(u8, u16, u32, i32);
 
 #[cfg(feature = "eh1_0_alpha")]
 impl eh1_0_alpha::delay::DelayUs for Timer {

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -113,7 +113,7 @@ impl Timer {
     }
 
     /// Pauses execution for at minimum `us` microseconds.
-    fn delay_us(&self, mut us: u32) {
+    fn delay_us_internal(&self, mut us: u32) {
         let mut start = self.get_counter_low();
         // If we knew that the loop ran at least once per timer tick,
         // this could be simplified to:
@@ -145,10 +145,10 @@ macro_rules! impl_delay_traits {
                 #![allow(unused_comparisons)]
                 assert!(us >= 0); // Only meaningful for i32
                 while <$t>::MAX as u64 > u32::MAX as u64 && us > u32::MAX as $t {
-                    (*self).delay_us(u32::MAX);
+                    self.delay_us_internal(u32::MAX);
                     us -= u32::MAX as $t;
                 }
-                (*self).delay_us(us as u32)
+                self.delay_us_internal(us as u32)
             }
         }
         impl embedded_hal::blocking::delay::DelayMs<$t> for Timer {
@@ -156,7 +156,7 @@ macro_rules! impl_delay_traits {
                 #![allow(unused_comparisons)]
                 assert!(ms >= 0); // Only meaningful for i32
                 for _ in 0..ms {
-                    self.delay_us(1000);
+                    self.delay_us_internal(1000);
                 }
             }
         }
@@ -170,7 +170,7 @@ impl_delay_traits!(u8, u16, u32, u64, i32);
 #[cfg(feature = "eh1_0_alpha")]
 impl eh1_0_alpha::delay::DelayUs for Timer {
     fn delay_us(&mut self, us: u32) {
-        (*self).delay_us(us)
+        self.delay_us_internal(us)
     }
 }
 

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -144,7 +144,7 @@ macro_rules! impl_delay_traits {
             fn delay_us(&mut self, mut us: $t) {
                 #![allow(unused_comparisons)]
                 assert!(us >= 0); // Only meaningful for i32
-                while us > u32::MAX as $t {
+                while <$t>::MAX as u64 > u32::MAX as u64 && us > u32::MAX as $t {
                     (*self).delay_us(u32::MAX);
                     us -= u32::MAX as $t;
                 }

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -170,7 +170,7 @@ impl_delay_traits!(u8, u16, u32, u64, i32);
 #[cfg(feature = "eh1_0_alpha")]
 impl eh1_0_alpha::delay::DelayUs for Timer {
     fn delay_us(&mut self, us: u32) {
-        (*self).delay_us(us.into())
+        (*self).delay_us(us)
     }
 }
 

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -35,16 +35,16 @@ fn release_alarm(mask: u8) {
 }
 
 /// Timer peripheral
-///
-/// This struct logically wraps a `pac::TIMER`, but doesn't actually store it:
-/// As after initialization all accesses are read-only anyways, the `pac::TIMER` can
-/// be summoned unsafely instead. This allows timer to be cloned.
-///
-/// (Alarms do use write operations, but they are local to the respective alarm, and
-/// those are still owned singletons.)
-///
-/// As the timer peripheral needs to be started first, this struct can only be
-/// constructed by calling `Timer::new(...)`.
+//
+// This struct logically wraps a `pac::TIMER`, but doesn't actually store it:
+// As after initialization all accesses are read-only anyways, the `pac::TIMER` can
+// be summoned unsafely instead. This allows timer to be cloned.
+//
+// (Alarms do use write operations, but they are local to the respective alarm, and
+// those are still owned singletons.)
+//
+// As the timer peripheral needs to be started first, this struct can only be
+// constructed by calling `Timer::new(...)`.
 #[derive(Clone, Copy)]
 pub struct Timer {
     _private: (),


### PR DESCRIPTION
Make `Timer` a cloneable type:

We don't support de-initializing a `Timer` anyways. And once it's initialized, all operations on it are either read-only, or already wrapped in the separate alarm structures.

Therefore, we can safely allow for `Timer` to be cloned, and implement the delay functions directly on it. That makes the API more ergonomic.

Co-authored-by: Wilfried Chauveau <wilfried.chauveau@ithinuel.me>
