### PR TITLE
Minor usability improvement

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -43,6 +43,12 @@ impl From<embedded_hal::spi::Mode> for Mode {
     }
 }
 
+impl From<&embedded_hal::spi::Mode> for Mode {
+    fn from(f: &embedded_hal::spi::Mode) -> Self {
+        Mode(*f)
+    }
+}
+
 #[cfg(feature = "eh1_0_alpha")]
 impl From<eh1_0_alpha::spi::Mode> for Mode {
     fn from(f: eh1_0_alpha::spi::Mode) -> Self {


### PR DESCRIPTION
Add `impl From<&embedded_hal::spi::Mode> for Mode`.

This unbreaks code like this, which did work with rp2040-hal 0.8:

```
    let spi = spi.init(
        &mut pac.RESETS,
        clocks.peripheral_clock.freq(),
        16_000_000u32.Hz(),
        &embedded_hal::spi::MODE_0,
    );
```