### PR TITLE
bump hal's version

### DIFF
--- a/on-target-tests/Cargo.toml
+++ b/on-target-tests/Cargo.toml
@@ -38,7 +38,7 @@ defmt-rtt = "0.4"
 defmt-test = "0.3"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-rp2040-hal = { path = "../rp2040-hal", version = "0.8", features = [
+rp2040-hal = { path = "../rp2040-hal", version = "0.9", features = [
     "defmt",
     "critical-section-impl",
 ] }

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-hal"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["The rp-rs Developers"]
 edition = "2018"
 homepage = "https://github.com/rp-rs/rp-hal"


### PR DESCRIPTION
We already introduced some breaking changes so we might as well already increase the version number on git a while before the release.

That may help users using the git repo be warned about more upcoming breakage.