### PR TITLE
Mark ReadTarget and WriteTarget as unsafe

### DIFF
--- a/rp2040-hal/src/dma/mod.rs
+++ b/rp2040-hal/src/dma/mod.rs
@@ -149,7 +149,18 @@ impl<CH: ChannelIndex> ChannelRegs for Channel<CH> {
 }
 
 /// Trait which is implemented by anything that can be read via DMA.
-
+///
+/// # Safety
+///
+/// The implementing type must be safe to use for DMA reads. This means:
+///
+/// - The range returned by rx_address_count must pointer to a valid address,
+///   and if rx_increment is true, count must fit into the allocated buffer.
+/// - As long as no `&mut self` method is called on the implementing object:
+///   - `rx_address_count` must always return the same value, if called multiple
+///     times.
+///   - The memory specified by the pointer and size returned by `rx_address_count`
+///     must not be freed during the transfer it is used in as long as `self` is not dropped.
 pub unsafe trait ReadTarget {
     /// Type which is transferred in a single DMA transfer.
     type ReceivedWord;
@@ -199,6 +210,18 @@ unsafe impl<B: ReadBuffer> ReadTarget for B {
 }
 
 /// Trait which is implemented by anything that can be written via DMA.
+///
+/// # Safety
+///
+/// The implementing type must be safe to use for DMA writes. This means:
+///
+/// - The range returned by tx_address_count must pointer to a valid address,
+///   and if tx_increment is true, count must fit into the allocated buffer.
+/// - As long as no other `&mut self` method is called on the implementing object:
+///   - `tx_address_count` must always return the same value, if called multiple
+///     times.
+///   - The memory specified by the pointer and size returned by `tx_address_count`
+///     must not be freed during the transfer it is used in as long as `self` is not dropped.
 pub unsafe trait WriteTarget {
     /// Type which is transferred in a single DMA transfer.
     type TransmittedWord;

--- a/rp2040-hal/src/dma/mod.rs
+++ b/rp2040-hal/src/dma/mod.rs
@@ -154,7 +154,7 @@ impl<CH: ChannelIndex> ChannelRegs for Channel<CH> {
 ///
 /// The implementing type must be safe to use for DMA reads. This means:
 ///
-/// - The range returned by rx_address_count must pointer to a valid address,
+/// - The range returned by rx_address_count must point to a valid address,
 ///   and if rx_increment is true, count must fit into the allocated buffer.
 /// - As long as no `&mut self` method is called on the implementing object:
 ///   - `rx_address_count` must always return the same value, if called multiple
@@ -215,7 +215,7 @@ unsafe impl<B: ReadBuffer> ReadTarget for B {
 ///
 /// The implementing type must be safe to use for DMA writes. This means:
 ///
-/// - The range returned by tx_address_count must pointer to a valid address,
+/// - The range returned by tx_address_count must point to a valid address,
 ///   and if tx_increment is true, count must fit into the allocated buffer.
 /// - As long as no other `&mut self` method is called on the implementing object:
 ///   - `tx_address_count` must always return the same value, if called multiple

--- a/rp2040-hal/src/dma/mod.rs
+++ b/rp2040-hal/src/dma/mod.rs
@@ -149,7 +149,8 @@ impl<CH: ChannelIndex> ChannelRegs for Channel<CH> {
 }
 
 /// Trait which is implemented by anything that can be read via DMA.
-pub trait ReadTarget {
+
+pub unsafe trait ReadTarget {
     /// Type which is transferred in a single DMA transfer.
     type ReceivedWord;
 
@@ -179,7 +180,8 @@ pub trait ReadTarget {
 /// two DMA channels. In the case of peripherals, the function can always return the same values.
 pub trait EndlessReadTarget: ReadTarget {}
 
-impl<B: ReadBuffer> ReadTarget for B {
+/// Safety: ReadBuffer and ReadTarget have the same safety requirements.
+unsafe impl<B: ReadBuffer> ReadTarget for B {
     type ReceivedWord = <B as ReadBuffer>::Word;
 
     fn rx_treq() -> Option<u8> {
@@ -197,7 +199,7 @@ impl<B: ReadBuffer> ReadTarget for B {
 }
 
 /// Trait which is implemented by anything that can be written via DMA.
-pub trait WriteTarget {
+pub unsafe trait WriteTarget {
     /// Type which is transferred in a single DMA transfer.
     type TransmittedWord;
 
@@ -221,7 +223,8 @@ pub trait WriteTarget {
 /// two DMA channels. In the case of peripherals, the function can always return the same values.
 pub trait EndlessWriteTarget: WriteTarget {}
 
-impl<B: WriteBuffer> WriteTarget for B {
+/// Safety: WriteBuffer and WriteTarget have the same safety requirements.
+unsafe impl<B: WriteBuffer> WriteTarget for B {
     type TransmittedWord = <B as WriteBuffer>::Word;
 
     fn tx_treq() -> Option<u8> {

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1394,7 +1394,9 @@ impl<SM: ValidStateMachine> Rx<SM> {
     }
 }
 
-impl<SM: ValidStateMachine> ReadTarget for Rx<SM> {
+// Safety: This only reads from the state machine fifo, so it doesn't
+// interact with rust-managed memory.
+unsafe impl<SM: ValidStateMachine> ReadTarget for Rx<SM> {
     type ReceivedWord = u32;
 
     fn rx_treq() -> Option<u8> {
@@ -1586,7 +1588,9 @@ impl<SM: ValidStateMachine> Tx<SM> {
     }
 }
 
-impl<SM: ValidStateMachine> WriteTarget for Tx<SM> {
+// Safety: This only writes to the state machine fifo, so it doesn't
+// interact with rust-managed memory.
+unsafe impl<SM: ValidStateMachine> WriteTarget for Tx<SM> {
     type TransmittedWord = u32;
 
     fn tx_treq() -> Option<u8> {

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -449,7 +449,9 @@ macro_rules! impl_write {
             }
         }
 
-        impl<D: SpiDevice, P: ValidSpiPinout<D>> ReadTarget for Spi<Enabled, D, P, $nr> {
+        // Safety: This only reads from the RX fifo, so it doesn't
+        // interact with rust-managed memory.
+        unsafe impl<D: SpiDevice, P: ValidSpiPinout<D>> ReadTarget for Spi<Enabled, D, P, $nr> {
             type ReceivedWord = $type;
 
             fn rx_treq() -> Option<u8> {
@@ -470,7 +472,9 @@ macro_rules! impl_write {
 
         impl<D: SpiDevice, P: ValidSpiPinout<D>> EndlessReadTarget for Spi<Enabled, D, P, $nr> {}
 
-        impl<D: SpiDevice, P: ValidSpiPinout<D>> WriteTarget for Spi<Enabled, D, P, $nr> {
+        // Safety: This only writes to the TX fifo, so it doesn't
+        // interact with rust-managed memory.
+        unsafe impl<D: SpiDevice, P: ValidSpiPinout<D>> WriteTarget for Spi<Enabled, D, P, $nr> {
             type TransmittedWord = $type;
 
             fn tx_treq() -> Option<u8> {

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -236,7 +236,9 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Read<u8> for Reader<D, P> {
     }
 }
 
-impl<D: UartDevice, P: ValidUartPinout<D>> ReadTarget for Reader<D, P> {
+// Safety: This only reads from the RX fifo, so it doesn't
+// interact with rust-managed memory.
+unsafe impl<D: UartDevice, P: ValidUartPinout<D>> ReadTarget for Reader<D, P> {
     type ReceivedWord = u8;
 
     fn rx_treq() -> Option<u8> {

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -184,7 +184,9 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Write<u8> for Writer<D, P> {
     }
 }
 
-impl<D: UartDevice, P: ValidUartPinout<D>> WriteTarget for Writer<D, P> {
+// Safety: This only writes to the TX fifo, so it doesn't
+// interact with rust-managed memory.
+unsafe impl<D: UartDevice, P: ValidUartPinout<D>> WriteTarget for Writer<D, P> {
     type TransmittedWord = u8;
 
     fn tx_treq() -> Option<u8> {


### PR DESCRIPTION
This implements the "mark traits as unsafe" part of https://github.com/rp-rs/rp-hal/issues/620#issuecomment-1558767880