### PR TITLE
Disable clippy warning

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,6 +13,7 @@ jobs:
           target: thumbv6m-none-eabi
           components: clippy
       - run: cargo clippy --workspace --examples -- -Dwarnings
+      - run: cargo clippy --workspace --examples --all-features -- -Dwarnings
       - run: |
           cd on-target-tests
           cargo clippy -- -Dwarnings

--- a/rp2040-hal/src/rtc/datetime_chrono.rs
+++ b/rp2040-hal/src/rtc/datetime_chrono.rs
@@ -10,6 +10,7 @@ pub type DayOfWeek = chrono::Weekday;
 ///
 /// [`DateTimeFilter`]: struct.DateTimeFilter.html
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub enum Error {
     /// The [DateTime] has an invalid year. The year must be between 0 and 4095.
     InvalidYear,


### PR DESCRIPTION
When called with `--all-features`, clippy complains about the naming of these enum variants:

```
warning: all variants have the same prefix: `Invalid`
  --> rp2040-hal/src/rtc/datetime_chrono.rs:13:1
   |
13 | / pub enum Error {
14 | |     /// The [DateTime] has an invalid year. The year must be between 0 and 4095.
15 | |     InvalidYear,
16 | |     /// The [DateTime] contains an invalid date.
...  |
19 | |     InvalidTime,
20 | | }
   | |_^
   |
   = help: remove the prefixes and use full paths to the variants instead of glob imports
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
   = note: `#[warn(clippy::enum_variant_names)]` on by default
```

As I think the naming is fine as it is, I'd consider this a false positive and just add `#[allow(clippy::enum_variant_names)]`.

This pull request also adds a clippy run with the `--all-features` flag to CI.