### PR TITLE
ADC free-running mode & FIFO

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -44,6 +44,7 @@ frunk = { version = "0.4.1", default-features = false }
 
 [dev-dependencies]
 cortex-m-rt = "0.7"
+cortex-m-rtic = "1.1.4"
 panic-halt = "0.2.0"
 rp2040-boot2 = "0.3.0"
 hd44780-driver = "0.4.0"
@@ -90,4 +91,9 @@ required-features = ["rt", "critical-section-impl"]
 [[example]]
 # vector_table example uses cortex-m-rt::interrupt, need rt feature for that
 name = "vector_table"
+required-features = ["rt", "critical-section-impl"]
+
+[[example]]
+# adc_fifo_irq example uses cortex-m-rt::interrupt, need rt feature for that
+name = "adc_fifo_irq"
 required-features = ["rt", "critical-section-impl"]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -39,6 +39,7 @@ chrono = { version = "0.4", default-features = false, optional = true }
 defmt = { version = ">=0.2.0, <0.4", optional = true }
 
 rtic-monotonic = { version = "1.0.0", optional = true }
+num-traits = { version = "0.2.15", default-features = false }
 
 frunk = { version = "0.4.1", default-features = false }
 

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -39,7 +39,6 @@ chrono = { version = "0.4", default-features = false, optional = true }
 defmt = { version = ">=0.2.0, <0.4", optional = true }
 
 rtic-monotonic = { version = "1.0.0", optional = true }
-num-traits = { version = "0.2.15", default-features = false }
 
 frunk = { version = "0.4.1", default-features = false }
 

--- a/rp2040-hal/examples/adc_fifo_irq.rs
+++ b/rp2040-hal/examples/adc_fifo_irq.rs
@@ -40,26 +40,20 @@ mod app {
 
     const SAMPLE_COUNT: usize = 1000;
 
+    type Uart = hal::uart::UartPeripheral<
+        hal::uart::Enabled,
+        hal::pac::UART0,
+        (
+            hal::gpio::Pin<hal::gpio::bank0::Gpio0, hal::gpio::FunctionUart, hal::gpio::PullDown>,
+            hal::gpio::Pin<hal::gpio::bank0::Gpio1, hal::gpio::FunctionUart, hal::gpio::PullDown>,
+        ),
+    >;
+
     #[shared]
     struct Shared {
         done: bool,
         buf: [u16; SAMPLE_COUNT],
-        uart: hal::uart::UartPeripheral<
-            hal::uart::Enabled,
-            hal::pac::UART0,
-            (
-                hal::gpio::Pin<
-                    hal::gpio::bank0::Gpio0,
-                    hal::gpio::FunctionUart,
-                    hal::gpio::PullDown,
-                >,
-                hal::gpio::Pin<
-                    hal::gpio::bank0::Gpio1,
-                    hal::gpio::FunctionUart,
-                    hal::gpio::PullDown,
-                >,
-            ),
-        >,
+        uart: Uart,
     }
 
     #[local]
@@ -152,8 +146,8 @@ mod app {
             let finished = (&mut c.shared.done, &mut c.shared.buf, &mut c.shared.uart).lock(
                 |done, buf, uart| {
                     if *done {
-                        for i in 0..SAMPLE_COUNT {
-                            writeln!(uart, "Sample: {}\r", buf[i]).unwrap();
+                        for sample in buf {
+                            writeln!(uart, "Sample: {}\r", sample).unwrap();
                         }
                         writeln!(uart, "All done, going to sleep 😴\r").unwrap();
                         true
@@ -168,6 +162,7 @@ mod app {
             }
         }
 
+        #[allow(clippy::empty_loop)]
         loop {}
     }
 

--- a/rp2040-hal/examples/adc_fifo_irq.rs
+++ b/rp2040-hal/examples/adc_fifo_irq.rs
@@ -1,0 +1,185 @@
+//! # ADC FIFO Interrupt Example
+//!
+//! This application demonstrates how to read ADC samples in free-running mode,
+//! using the FIFO interrupt.
+//!
+//! It utilizes `rtic` (cortex-m-rtic crate) to safely share peripheral access between
+//! initialization code and interrupt handlers.
+//!
+//! It may need to be adapted to your particular board layout and/or pin assignment.
+//!
+//! See the `Cargo.toml` file for Copyright and license details.
+
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
+
+#[rtic::app(device = rp2040_hal::pac)]
+mod app {
+    use rp2040_hal as hal;
+    use fugit::RateExtU32;
+    use hal::Clock;
+    use core::fmt::Write;
+    use embedded_hal::digital::v2::OutputPin;
+
+    /// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+    /// if your board has a different frequency
+    const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+    // This example will capture 1000 samples to `shared.buf`.
+    // When it is done, it will stop the ADC, set `shared.done` to true,
+    // print the result and loop forever.
+
+    const SAMPLE_COUNT: usize = 1000;
+
+    #[shared]
+    struct Shared {
+        done: bool,
+        buf: [u16; SAMPLE_COUNT],
+        uart: hal::uart::UartPeripheral<
+                hal::uart::Enabled,
+            hal::pac::UART0,
+            (
+                hal::gpio::Pin<hal::gpio::bank0::Gpio0, hal::gpio::Function<hal::gpio::Uart>>,
+                hal::gpio::Pin<hal::gpio::bank0::Gpio1, hal::gpio::Function<hal::gpio::Uart>>,
+            )>,
+    }
+
+    #[local]
+    struct Local {
+        adc_fifo: Option<hal::adc::AdcFifo<'static>>,
+        led_pin: hal::gpio::Pin<hal::gpio::bank0::Gpio25, hal::gpio::PushPullOutput>,
+    }
+
+    #[init(local = [adc: Option<hal::Adc> = None])]
+    fn init(c: init::Context) -> (Shared, Local, init::Monotonics) {
+        // Soft-reset does not release the hardware spinlocks
+        // Release them now to avoid a deadlock after debug or watchdog reset
+        unsafe {
+            hal::sio::spinlock_reset();
+        }
+
+        let mut resets = c.device.RESETS;
+        let mut watchdog = hal::Watchdog::new(c.device.WATCHDOG);
+        let clocks = hal::clocks::init_clocks_and_plls(
+            XTAL_FREQ_HZ,
+            c.device.XOSC,
+            c.device.CLOCKS,
+            c.device.PLL_SYS,
+            c.device.PLL_USB,
+            &mut resets,
+            &mut watchdog,
+        )
+        .ok()
+        .unwrap();
+        let sio = hal::Sio::new(c.device.SIO);
+        let pins = hal::gpio::Pins::new(
+            c.device.IO_BANK0,
+            c.device.PADS_BANK0,
+            sio.gpio_bank0,
+            &mut resets,
+        );
+
+
+        // UART TX (characters sent from pico) on pin 1 (GPIO0) and RX (on pin 2 (GPIO1)
+        let uart_pins = (
+            pins.gpio0.into_mode::<hal::gpio::FunctionUart>(),
+            pins.gpio1.into_mode::<hal::gpio::FunctionUart>(),
+        );
+
+        // Create a UART driver
+        let uart = hal::uart::UartPeripheral::new(c.device.UART0, uart_pins, &mut resets)
+            .enable(
+                hal::uart::UartConfig::new(115200.Hz(), hal::uart::DataBits::Eight, None, hal::uart::StopBits::One),
+                clocks.peripheral_clock.freq(),
+            )
+            .unwrap();
+        
+        // the ADC is put into a local, to gain static lifetime
+        *c.local.adc = Some(hal::Adc::new(c.device.ADC, &mut resets));
+        let adc = c.local.adc.as_mut().unwrap();
+
+        let mut adc_pin_0 = pins.gpio26.into_floating_input();
+
+        uart.write_full_blocking(b"ADC FIFO interrupt example\r\n");
+
+        let adc_fifo = adc.build_fifo()
+            .clock_divider(47999, 0)
+            .set_channel(&mut adc_pin_0)
+            .enable_interrupt(1)
+            .start();
+
+        let mut led_pin = pins.gpio25.into_push_pull_output();
+
+        led_pin.set_low();
+        
+        (Shared {
+            done: false,
+            buf: [0; SAMPLE_COUNT],
+            uart,
+        },
+         Local {
+             adc_fifo: Some(adc_fifo),
+             led_pin,
+         },
+         init::Monotonics())
+    }
+
+    #[idle(shared = [done, buf, uart])]
+    fn idle(mut c: idle::Context) -> ! {
+        loop {
+            let finished = (&mut c.shared.done, &mut c.shared.buf, &mut c.shared.uart).lock(|done, buf, uart| {
+                if *done {
+                    for i in 0..SAMPLE_COUNT {
+                        writeln!(uart, "Sample: {}\r", buf[i]).unwrap();
+                    }
+                    writeln!(uart, "All done, going to sleep 😴\r");
+                    true
+                } else {
+                    false
+                }
+            });
+
+            if finished {
+                break
+            }
+        }
+
+        loop {}
+    }
+
+    #[task(
+        binds = ADC_IRQ_FIFO,
+        priority = 1,
+        shared = [done, buf, uart],
+        local = [adc_fifo, counter: usize = 0, led_pin]
+    )]
+    fn adc_irq_fifo(mut c: adc_irq_fifo::Context) {
+        if let Some(adc_fifo) = c.local.adc_fifo.as_mut() {
+            let sample = adc_fifo.read();
+            let i = *c.local.counter;
+            c.shared.buf.lock(|buf| buf[i] = sample);
+            *c.local.counter += 1;
+            
+            if *c.local.counter == SAMPLE_COUNT {
+                c.local.adc_fifo.take().unwrap().stop();
+                c.shared.done.lock(|done| *done = true);
+            }
+        } else {
+            // this should never be reached
+            c.local.led_pin.set_high();
+            c.shared.uart.lock(|uart| {
+                uart.write_full_blocking(b"???");
+            });
+        }
+    }
+}

--- a/rp2040-hal/examples/adc_fifo_irq.rs
+++ b/rp2040-hal/examples/adc_fifo_irq.rs
@@ -111,6 +111,9 @@ mod app {
         uart.write_full_blocking(b"ADC FIFO interrupt example\r\n");
 
         let adc_fifo = adc.build_fifo()
+            // Set clock divider to target a sample rate of 1000 samples per second (1ksps).
+            // The value was calculated by `(48MHz / 1ksps) - 1 = 47999.0`.
+            // Please check the `clock_divider` method documentation for details.
             .clock_divider(47999, 0)
             .set_channel(&mut adc_pin_0)
             .enable_interrupt(1)

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -1,0 +1,190 @@
+//! # ADC FIFO Example
+//!
+//! This application demonstrates how to read ADC samples in free-running mode,
+//! and reading them from the FIFO by polling the fifo's `len()`.
+//!
+//! It may need to be adapted to your particular board layout and/or pin assignment.
+//!
+//! See the `Cargo.toml` file for Copyright and license details.
+
+#![no_std]
+#![no_main]
+
+// Ensure we halt the program on panic (if we don't mention this crate it won't
+// be linked)
+use panic_halt as _;
+
+// Alias for our HAL crate
+use rp2040_hal as hal;
+
+// Some traits we need
+use core::fmt::Write;
+use fugit::RateExtU32;
+use rp2040_hal::Clock;
+
+// UART related types
+use hal::uart::{DataBits, StopBits, UartConfig};
+
+// A shorter alias for the Peripheral Access Crate, which provides low-level
+// register access
+use hal::pac;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
+
+/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+/// if your board has a different frequency
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+/// Entry point to our bare-metal application.
+///
+/// The `#[rp2040_hal::entry]` macro ensures the Cortex-M start-up code calls this function
+/// as soon as all global variables and the spinlock are initialised.
+///
+/// The function configures the RP2040 peripherals, then prints the temperature
+/// in an infinite loop.
+#[rp2040_hal::entry]
+fn main() -> ! {
+    // Grab our singleton objects
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+
+    // Configure the clocks
+    let clocks = hal::clocks::init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // The delay object lets us wait for specified amounts of time (in
+    // milliseconds)
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(pac.SIO);
+
+    // Set the pins to their default state
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // UART TX (characters sent from pico) on pin 1 (GPIO0) and RX (on pin 2 (GPIO1)
+    let uart_pins = (
+        pins.gpio0.into_mode::<hal::gpio::FunctionUart>(),
+        pins.gpio1.into_mode::<hal::gpio::FunctionUart>(),
+    );
+
+    // Create a UART driver
+    let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
+        .enable(
+            UartConfig::new(115200.Hz(), DataBits::Eight, None, StopBits::One),
+            clocks.peripheral_clock.freq(),
+        )
+        .unwrap();
+
+    // Write to the UART
+    uart.write_full_blocking(b"ADC FIFO poll example\r\n");
+
+    // Enable ADC
+    let mut adc = hal::Adc::new(pac.ADC, &mut pac.RESETS);
+
+    // Enable the temperature sense channel
+    let mut temperature_sensor = adc.enable_temp_sensor();
+
+    // Configure GPIO26 as an ADC input
+    let mut adc_pin_0 = pins.gpio26.into_floating_input();
+
+    // Configure free-running mode:
+    let mut adc_fifo = adc.build_fifo()
+        // set clock divider to configure sample rate of 1ksps
+        .clock_divider(47999, 0)
+        // sample the temperature sensor first
+        .set_channel(&mut temperature_sensor)
+        // then alternate between GPIO26 and the temperature sensor
+        .round_robin((&mut adc_pin_0, &mut temperature_sensor))
+        // start sampling
+        .start();
+
+    // we'll capture 1000 samples in total (500 per channel)
+    let mut temp_samples = [0; 500];
+    let mut pin_samples = [0; 500];
+    let mut i = 0;
+
+    // initialize a timer, to measure the total sampling time (printed below)
+    let timer = hal::Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
+
+    loop {
+        // busy-wait until the FIFO contains at least two samples:
+        while adc_fifo.len() < 2 {}
+
+        // fetch two values from the fifo
+        let temp_result = adc_fifo.read();
+        let pin_result = adc_fifo.read();
+
+        // uncomment this line, to trigger an "underrun" condition
+        //let _extra_sample = adc_fifo.read();
+
+        if adc_fifo.is_over() {
+            // samples were pushed into the fifo faster they were read
+            uart.write_full_blocking(b"FIFO overrun!\r\n");
+        }
+        if adc_fifo.is_under() {
+            // we tried to read samples more quickly than they were pushed into the fifo
+            uart.write_full_blocking(b"FIFO underrun!\r\n");
+        }
+
+        temp_samples[i] = temp_result;
+        pin_samples[i] = pin_result;
+
+        i += 1;
+
+        // uncomment this line to trigger an "overrun" condition
+        //delay.delay_ms(1000);
+
+        if i == 500 {
+            break;
+        }
+    }
+
+    let time_taken = timer.get_counter();
+
+    uart.write_full_blocking(b"Done sampling, printing results:\r\n");
+
+    // Stop free-running mode (the returned `adc` can be reused for future captures)
+    let _adc = adc_fifo.stop();
+
+    // Print the measured values
+    for i in 0..500 {
+        writeln!(
+            uart,
+            "Temp:\t{}\tPin\t{}\r",
+            temp_samples[i],
+            pin_samples[i]
+        ).unwrap();
+    }
+
+    writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();
+
+    loop {
+        delay.delay_ms(1000);
+    }
+}
+
+// End of file

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -112,7 +112,8 @@ fn main() -> ! {
     let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input());
 
     // Configure free-running mode:
-    let mut adc_fifo = adc.build_fifo()
+    let mut adc_fifo = adc
+        .build_fifo()
         // Set clock divider to target a sample rate of 1000 samples per second (1ksps).
         // The value was calculated by `(48MHz / 1ksps) - 1 = 47999.0`.
         // Please check the `clock_divider` method documentation for details.
@@ -179,9 +180,9 @@ fn main() -> ! {
         writeln!(
             uart,
             "Temp:\t{}\tPin\t{}\r",
-            temp_samples[i],
-            pin_samples[i]
-        ).unwrap();
+            temp_samples[i], pin_samples[i]
+        )
+        .unwrap();
     }
 
     writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -119,6 +119,8 @@ fn main() -> ! {
         .set_channel(&mut temperature_sensor)
         // then alternate between GPIO26 and the temperature sensor
         .round_robin((&mut adc_pin_0, &mut temperature_sensor))
+        // Uncomment this line to produce 8-bit samples, instead of 12 bit (lower bits are discarded)
+        //.shift_8bit()
         // start sampling
         .start();
 

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -113,7 +113,9 @@ fn main() -> ! {
 
     // Configure free-running mode:
     let mut adc_fifo = adc.build_fifo()
-        // set clock divider to configure sample rate of 1ksps
+        // Set clock divider to target a sample rate of 1000 samples per second (1ksps).
+        // The value was calculated by `(48MHz / 1ksps) - 1 = 47999.0`.
+        // Please check the `clock_divider` method documentation for details.
         .clock_divider(47999, 0)
         // sample the temperature sensor first
         .set_channel(&mut temperature_sensor)

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -87,8 +87,8 @@ fn main() -> ! {
 
     // UART TX (characters sent from pico) on pin 1 (GPIO0) and RX (on pin 2 (GPIO1)
     let uart_pins = (
-        pins.gpio0.into_mode::<hal::gpio::FunctionUart>(),
-        pins.gpio1.into_mode::<hal::gpio::FunctionUart>(),
+        pins.gpio0.into_function::<hal::gpio::FunctionUart>(),
+        pins.gpio1.into_function::<hal::gpio::FunctionUart>(),
     );
 
     // Create a UART driver
@@ -106,10 +106,10 @@ fn main() -> ! {
     let mut adc = hal::Adc::new(pac.ADC, &mut pac.RESETS);
 
     // Enable the temperature sense channel
-    let mut temperature_sensor = adc.enable_temp_sensor();
+    let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let mut adc_pin_0 = pins.gpio26.into_floating_input();
+    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input());
 
     // Configure free-running mode:
     let mut adc_fifo = adc.build_fifo()

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -470,7 +470,7 @@ impl<'a, const SHIFTED: bool> AdcFifo<'a, SHIFTED> {
     /// want to incur the 96 cycle delay of a one-off read.
     ///
     /// Example:
-    /// ```no_run
+    /// ```ignore
     /// // start continously sampling values:
     /// let mut fifo = adc.build_fifo().set_channel(&mut adc_pin).start();
     ///

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -72,7 +72,6 @@ use core::convert::Infallible;
 
 use hal::adc::{Channel, OneShot};
 use pac::{ADC, RESETS};
-use num_traits::float::FloatCore;
 
 use crate::{
     gpio::{

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -449,6 +449,39 @@ impl<'a, const SHIFTED: bool> AdcFifo<'a, SHIFTED> {
         under
     }
 
+    /// Read the most recently sampled ADC value
+    ///
+    /// Returns the most recently sampled value, bypassing the FIFO.
+    ///
+    /// This can be used if you want to read samples occasionally, but don't
+    /// want to incur the 96 cycle delay of a one-off read.
+    ///
+    /// Example:
+    /// ```
+    /// // start continously sampling values:
+    /// let fifo = adc.build_fifo().set_channel(&mut adc_pin).start();
+    ///
+    /// loop {
+    ///   do_something_timing_critical();
+    ///
+    ///   // read the most recent value:
+    ///   if fifo.read_single() > THRESHOLD {
+    ///     led.set_high().unwrap();
+    ///   } else {
+    ///     led.set_low().unwrap();
+    ///   }
+    /// }
+    ///
+    /// // stop sampling, when it's no longer needed
+    /// fifo.stop();
+    /// ```
+    ///
+    /// Note that when round-robin sampling is used, there is no way
+    /// to tell from which channel this sample came.
+    pub fn read_single(&mut self) -> u16 {
+        self.adc.read_single()
+    }
+
     /// Stop capturing in free running mode.
     ///
     /// Resets all capture options that can be set via [`AdcFifoBuilder`] to

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -324,7 +324,7 @@ impl<'a> AdcFifoBuilder<'a> {
     /// If round-robin mode is used, this will only affect the first sample.
     ///
     /// The given `pin` can either be one of the ADC inputs (GPIO26-28) or the
-    /// internal temperature sensor (retrieved via [`Adc.enable_temp_sensor`]).
+    /// internal temperature sensor (retrieved via [`Adc::enable_temp_sensor`]).
     pub fn set_channel<PIN: Channel<Adc, ID = u8>>(self, _pin: &mut PIN) -> Self {
         self.adc.device.cs.modify(|_, w| unsafe { w.ainsel().bits(PIN::channel()) });
         self
@@ -414,7 +414,7 @@ impl<'a> AdcFifo<'a> {
     /// Resets all capture options that can be set via [`AdcFifoBuilder`] to
     /// their defaults.
     ///
-    /// Returns the underlying `Adc` instance.
+    /// Returns the underlying [`Adc`], to be reused.
     pub fn stop(self) -> &'a mut Adc {
         // stop capture and clear channel selection
         self.adc.device.cs.modify(|_, w| unsafe {


### PR DESCRIPTION
An attempt to come up with an API for the ADC in free-running mode.

Inspired by #326.

Overview of changes:
- Adds two new structs to the `adc` module: `FreeRunning` and `Fifo` (EDIT: naming changed to `AdcFifoBuilder` and `AdcFifo`)
- `FreeRunning` represents the `Adc` configuration for free-running mode:
  - it is obtained by calling `adc.free_running()`
  - it provides methods to configure things that only make sense in this mode: set clock_divider (DIV.INT, DIV.FRAC), set round_robin (CS.RROBIN), ...
  - and methods to start enable the FIFO and start the capture (CS.START_MANY): `start_fifo`, `start_fifo_with_dma(thresh)`
- the `Fifo` struct represents the ADC Fifo while capture is running:
  - it is returned by the `start_*` methods from `FreeRunning`
  - `fifo.len()` and `fifo.read()` give access to the FCS.LEVEL and FIFO register values
  - `fifo.is_over()` and `fifo.is_under()` expose the FCS.OVER and FCS.UNDER flags (and reset them on read)
  - `fifo.stop()` stops the capture and disables the fifo

Brief example:
```
    let mut adc = Adc::new(dp.ADC, &mut resets);
    let mut adc_pin_0 = pins.gpio26.into_floating_input();
    let mut adc_pin_1 = pins.gpio27.into_floating_input();

    let mut fifo = adc.free_running()
        .clock_divider(0, 0)
        // first conversion is from pin 26
        .initial_input(&mut adc_pin_0)
        // cycle between pin 26 and 27
        .round_robin((&mut adc_pin_0, &mut adc_pin_1))
        // enable fifo and starts capture
        .start_fifo();

    // alternative to .start_fifo(), which also enables FCS.DREQ (with given FCS.THRESH of 1):
    //  .start_fifo_with_dma(1)

    let mut i = 0;

    while i < 100 {
        if fifo.len() >= 2 {
            // a comes from pin 26, b from pin 27
            let (a, b) = (fifo.read(), fifo.read());

            // ... do something with `a` and `b`

            i += 1;
        }
    }

    // Stop capturing (CS.START_MANY = 0).
    // Returns the Adc, so it can be reused for single capture or another free-running capture.
    let adc = fifo.stop();
```