### PR TITLE
Fix typo using `impl_write!`, 22 should be 12

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -496,4 +496,4 @@ macro_rules! impl_write {
 }
 
 impl_write!(u8, [4, 5, 6, 7, 8]);
-impl_write!(u16, [9, 10, 11, 22, 13, 14, 15, 16]);
+impl_write!(u16, [9, 10, 11, 12, 13, 14, 15, 16]);


### PR DESCRIPTION
I'm pretty sure this is a typo right?