### PR TITLE
ADC fifo DMA

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -97,3 +97,8 @@ required-features = ["rt", "critical-section-impl"]
 # adc_fifo_irq example uses cortex-m-rt::interrupt, need rt feature for that
 name = "adc_fifo_irq"
 required-features = ["rt", "critical-section-impl"]
+
+[[example]]
+# adc_fifo_dma example uses cortex-m-rt::interrupt, need rt feature for that
+name = "adc_fifo_dma"
+required-features = ["rt", "critical-section-impl"]

--- a/rp2040-hal/examples/adc_fifo_dma.rs
+++ b/rp2040-hal/examples/adc_fifo_dma.rs
@@ -1,7 +1,7 @@
-//! # ADC FIFO Example
+//! # ADC FIFO DMA Example
 //!
 //! This application demonstrates how to read ADC samples in free-running mode,
-//! and reading them from the FIFO by polling the fifo's `len()`.
+//! and reading them from the FIFO by using a DMA transfer.
 //!
 //! It may need to be adapted to your particular board layout and/or pin assignment.
 //!
@@ -102,7 +102,7 @@ fn main() -> ! {
         .unwrap();
 
     // Write to the UART
-    uart.write_full_blocking(b"ADC FIFO poll example\r\n");
+    uart.write_full_blocking(b"ADC FIFO DMA example\r\n");
 
     // Initialize DMA
     let dma = pac.DMA.split(&mut pac.RESETS);
@@ -147,6 +147,11 @@ fn main() -> ! {
 
     // initialize a timer, to measure the total sampling time (printed below)
     let timer = hal::Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
+
+    // NOTE: in a real-world program, instead of calling `wait` now, you would probably:
+    // 1. Enable one of the DMA interrupts for the channel (e.g. `dma.ch0.listen_irq0()`)
+    // 2. Set up a handler for the respective `DMA_IRQ_*` interrupt
+    // 3. Call `wait` only within that interrupt, which will be fired once the transfer is complete.
 
     // the DMA unit takes care of shuffling data from the FIFO into the buffer.
     // We just sit here and wait... 😴

--- a/rp2040-hal/examples/adc_fifo_dma.rs
+++ b/rp2040-hal/examples/adc_fifo_dma.rs
@@ -1,0 +1,174 @@
+//! # ADC FIFO Example
+//!
+//! This application demonstrates how to read ADC samples in free-running mode,
+//! and reading them from the FIFO by polling the fifo's `len()`.
+//!
+//! It may need to be adapted to your particular board layout and/or pin assignment.
+//!
+//! See the `Cargo.toml` file for Copyright and license details.
+
+#![no_std]
+#![no_main]
+
+// Ensure we halt the program on panic (if we don't mention this crate it won't
+// be linked)
+use panic_halt as _;
+
+// Alias for our HAL crate
+use rp2040_hal as hal;
+
+// Some traits we need
+use core::fmt::Write;
+use fugit::RateExtU32;
+use rp2040_hal::Clock;
+use hal::dma::{single_buffer, DMAExt};
+use cortex_m::singleton;
+
+// UART related types
+use hal::uart::{DataBits, StopBits, UartConfig};
+
+// A shorter alias for the Peripheral Access Crate, which provides low-level
+// register access
+use hal::pac;
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
+
+/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+/// if your board has a different frequency
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+/// Entry point to our bare-metal application.
+///
+/// The `#[rp2040_hal::entry]` macro ensures the Cortex-M start-up code calls this function
+/// as soon as all global variables and the spinlock are initialised.
+///
+/// The function configures the RP2040 peripherals, then prints the temperature
+/// in an infinite loop.
+#[rp2040_hal::entry]
+fn main() -> ! {
+    // Grab our singleton objects
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+
+    // Configure the clocks
+    let clocks = hal::clocks::init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // The delay object lets us wait for specified amounts of time (in
+    // milliseconds)
+    let mut delay = cortex_m::delay::Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(pac.SIO);
+
+    // Set the pins to their default state
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // UART TX (characters sent from pico) on pin 1 (GPIO0) and RX (on pin 2 (GPIO1)
+    let uart_pins = (
+        pins.gpio0.into_function::<hal::gpio::FunctionUart>(),
+        pins.gpio1.into_function::<hal::gpio::FunctionUart>(),
+    );
+
+    // Create a UART driver
+    let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
+        .enable(
+            UartConfig::new(115200.Hz(), DataBits::Eight, None, StopBits::One),
+            clocks.peripheral_clock.freq(),
+        )
+        .unwrap();
+
+    // Write to the UART
+    uart.write_full_blocking(b"ADC FIFO poll example\r\n");
+
+    // Initialize DMA
+    let dma = pac.DMA.split(&mut pac.RESETS);
+
+    // Enable ADC
+    let mut adc = hal::Adc::new(pac.ADC, &mut pac.RESETS);
+
+    // Enable the temperature sense channel
+    let mut temperature_sensor = adc.take_temp_sensor().unwrap();
+
+    // Configure GPIO26 as an ADC input
+    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input());
+
+    // NOTE: when calling `shift_8bit` below, the type here must be changed from `u16` to `u8`
+    let buf_for_samples = singleton!(: [u16; 1000] = [0; 1000]).unwrap();
+
+    // Configure free-running mode:
+    let (dma_transfer, adc_fifo) = adc
+        .build_fifo()
+        // Set clock divider to target a sample rate of 1000 samples per second (1ksps).
+        // The value was calculated by `(48MHz / 1ksps) - 1 = 47999.0`.
+        // Please check the `clock_divider` method documentation for details.
+        .clock_divider(47999, 0)
+        // sample the temperature sensor first
+        .set_channel(&mut temperature_sensor)
+        // then alternate between GPIO26 and the temperature sensor
+        .round_robin((&mut adc_pin_0, &mut temperature_sensor))
+        // Uncomment this line to produce 8-bit samples, instead of 12 bit (lower bits are discarded)
+        //.shift_8bit()
+        // Start DMA channel & start sampling
+        .start_dma(|read_target| single_buffer::Config::new(dma.ch0, read_target, buf_for_samples).start());
+
+    // we'll capture 1000 samples in total (500 per channel)
+
+    // initialize a timer, to measure the total sampling time (printed below)
+    let timer = hal::Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
+
+    // the DMA unit takes care of shuffling data from the FIFO into the buffer.
+    // We just sit here and wait... 😴
+    let (_ch, _adc_read_target, buf_for_samples) = dma_transfer.wait();
+
+    // ^^^ the three results here (channel, AdcReadTarget, write target) can be reused
+    // right away to start another transfer.
+
+    let time_taken = timer.get_counter();
+
+    uart.write_full_blocking(b"Done sampling, printing results:\r\n");
+
+    // Stop free-running mode (the returned `adc` can be reused for future captures)
+    let _adc = adc_fifo.stop();
+
+    // Print the measured values
+    for i in 0..500 {
+        writeln!(
+            uart,
+            "Temp:\t{}\tPin\t{}\r",
+            buf_for_samples[i*2], buf_for_samples[i*2+1]
+        )
+        .unwrap();
+    }
+
+    writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();
+
+    loop {
+        delay.delay_ms(1000);
+    }
+}
+
+// End of file

--- a/rp2040-hal/examples/adc_fifo_irq.rs
+++ b/rp2040-hal/examples/adc_fifo_irq.rs
@@ -58,7 +58,7 @@ mod app {
 
     #[local]
     struct Local {
-        adc_fifo: Option<hal::adc::AdcFifo<'static, false>>,
+        adc_fifo: Option<hal::adc::AdcFifo<'static, u16>>,
     }
 
     #[init(local = [adc: Option<hal::Adc> = None])]

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -79,7 +79,8 @@
 //!
 //! Example:
 //! ```no_run
-//! use rp2040_hal::{adc::Adc, gpio::Pins, pac, Sio, dma::single_buffer};
+//! use rp2040_hal::{adc::Adc, gpio::Pins, pac, Sio, dma::{single_buffer, DMAExt}};
+//! use cortex_m::singleton;
 //! let mut peripherals = pac::Peripherals::take().unwrap();
 //! let sio = Sio::new(peripherals.SIO);
 //! let pins = Pins::new(peripherals.IO_BANK0, peripherals.PADS_BANK0, sio.gpio_bank0, &mut peripherals.RESETS);
@@ -97,13 +98,13 @@
 //!   .prepare();
 //!
 //! // Set up a buffer, where the samples should be written:
-//! let buf = singleton!(: [u16; 500] = [0; 500]);
+//! let buf = singleton!(: [u16; 500] = [0; 500]).unwrap();
 //!
 //! // Start DMA transfer
 //! let transfer = single_buffer::Config::new(dma.ch0, fifo.dma_read_target(), buf).start();
 //!
 //! // Resume the FIFO to start capturing
-//! adc_fifo.resume();
+//! fifo.resume();
 //!
 //! // Wait for the transfer to complete:
 //! let (ch, adc_read_target, buf) = transfer.wait();

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -117,10 +117,10 @@
 use core::convert::Infallible;
 use core::marker::PhantomData;
 
-use hal::adc::{Channel, OneShot};
-use pac::{ADC, RESETS};
 use crate::dma;
+use hal::adc::{Channel, OneShot};
 use pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;
+use pac::{ADC, RESETS};
 
 use crate::{
     gpio::{
@@ -293,7 +293,10 @@ impl Adc {
     /// Capturing is started by calling [`AdcFifoBuilder::start`], which
     /// returns an [`AdcFifo`] to read from.
     pub fn build_fifo(&mut self) -> AdcFifoBuilder<'_, u16> {
-        AdcFifoBuilder { adc: self, marker: PhantomData }
+        AdcFifoBuilder {
+            adc: self,
+            marker: PhantomData,
+        }
     }
 
     fn read(&mut self, chan: u8) -> u16 {
@@ -455,7 +458,10 @@ impl<'a, Word> AdcFifoBuilder<'a, Word> {
     /// When this method has been called, the resulting fifo's `read` method returns u8.
     pub fn shift_8bit(self) -> AdcFifoBuilder<'a, u8> {
         self.adc.device.fcs.modify(|_, w| w.shift().set_bit());
-        AdcFifoBuilder { adc: self.adc, marker: PhantomData }
+        AdcFifoBuilder {
+            adc: self.adc,
+            marker: PhantomData,
+        }
     }
 
     /// Enable DMA for the FIFO.
@@ -466,9 +472,10 @@ impl<'a, Word> AdcFifoBuilder<'a, Word> {
     /// The threshold is the same one as set by [`AdcFifoBuilder::enable_interrupt`]. If you want to enable FIFO
     /// interrupts, but also use DMA, the `threshold` parameter passed to `enable_interrupt` *must* be set to `1` as well.*
     pub fn enable_dma(self) -> Self {
-        self.adc.device.fcs.modify(|_, w| unsafe {
-            w.dreq_en().set_bit().thresh().bits(1)
-        });
+        self.adc
+            .device
+            .fcs
+            .modify(|_, w| unsafe { w.dreq_en().set_bit().thresh().bits(1) });
         self
     }
 
@@ -482,7 +489,10 @@ impl<'a, Word> AdcFifoBuilder<'a, Word> {
     pub fn start(self) -> AdcFifo<'a, Word> {
         self.adc.device.fcs.modify(|_, w| w.en().set_bit());
         self.adc.device.cs.modify(|_, w| w.start_many().set_bit());
-        AdcFifo { adc: self.adc, marker: PhantomData }
+        AdcFifo {
+            adc: self.adc,
+            marker: PhantomData,
+        }
     }
 
     /// Enable ADC FIFO, but do not start conversion yet
@@ -492,7 +502,10 @@ impl<'a, Word> AdcFifoBuilder<'a, Word> {
     /// Use [`AdcFifo::resume`] to start conversion.
     pub fn prepare(self) -> AdcFifo<'a, Word> {
         self.adc.device.fcs.modify(|_, w| w.en().set_bit());
-        AdcFifo { adc: self.adc, marker: PhantomData }
+        AdcFifo {
+            adc: self.adc,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -72,9 +72,9 @@
 //! When the ADC is in free-running mode, it's possible to use DMA to transfer data from the FIFO elsewhere, without having to read the FIFO manually.
 //!
 //! This requires a number of steps:
-//! 1. Build and `AdcFifo`, with DMA enabled ([`AdcFifoBuilder::enable_dma`])
+//! 1. Build an `AdcFifo`, with DMA enabled ([`AdcFifoBuilder::enable_dma`])
 //! 2. Use [`AdcFifoBuilder::prepare`] instead of [`AdcFifoBuilder::start`], so that the FIFO is created in `paused` state
-//! 3. Start a DMA transfer ([`dma::single_buffer::Transfer`], [`dma::double_buffer::Transfer`], ...), using the [`AdcFifo::dma_read_target`] as the source
+//! 3. Start a DMA transfer ([`dma::single_buffer::Transfer`], [`dma::double_buffer::Transfer`], ...), using the [`AdcFifo::dma_read_target`] as the source (`from` parameter)
 //! 4. Finally unpause the FIFO by calling [`AdcFifo::resume`], to start capturing
 //!
 //! Example:

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -112,6 +112,7 @@
 //! //...
 //!
 //! ```
+//! //! See [examples/adc_fifo_dma.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/adc_fifo_dma.rs) for a more complete example.
 //!
 
 use core::convert::Infallible;


### PR DESCRIPTION
DMA support for free-running ADC capture.

The basic API looks like this:
```
// without DMA:
let adc_fifo = adc.build_fifo()
    .something_something()
    .start();

do_something_with_fifo(adc_fifo);

// with DMA:
let adc_fifo = adc.build_fifo()
    .something_something()
    .enable_dma()
    .prepare();

let transfer = dma::single_buffer::Config::new(dma.ch0, adc_fifo.dma_read_target(), some_write_target).start();
adc_fifo.resume();

do_something_else_while_dma_does_all_the_work();
```

To enable this functionality, the following methods were added:
- `AdcFifoBuilder::enable_dma`: sets `FCS.DREQ_EN = 1` and `FCS.THRESH = 1`
- `AdcFifoBuilder::prepare`: same as `start`, but does not set `CS.START_MANY` just yet
- `AdcFifo::resume` / `AdcFifo::pause`: control if capturing is active (`CS.START_MANY`) without reconfiguring the FIFO in any other way
- `AdcFifo::is_paused`: can be used to check the current state
- `AdcFifo::clear`: reads the FIFO until empty, discarding values
- `AdcFifo::dma_read_target`: returns a struct that implements `dma::ReadTarget`, and can be used to construct the transfer. (If `dma::ReadTarget` were implemented on `AdcFifo` directly, it wouldn't be possible to `resume()` the FIFO after starting the DMA transfer, because the transfer would take ownership of the `AdcFifo`)
