### PR TITLE
Add specific build-dependency on is-terminal = "=0.4.7"

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -47,6 +47,9 @@ hd44780-driver = "0.4.0"
 pio-proc = "0.2.0"
 dht-sensor = "0.2.1"
 
+[build-dependencies]
+is-terminal = "=0.4.7"
+
 [features]
 # Minimal startup / runtime for Cortex-M microcontrollers
 rt = ["rp2040-pac/rt"]


### PR DESCRIPTION
With is-terminal 0.4.8, the MSRV was changed from 1.48 to 1.63. This implicitly affects the MSRV of lalrpop, breaking existing builds.

As is-terminal has a policy of changing MSRV in a minor release, and actively suggests to pin a specific version to avoid that, I think lalrpop should do that and use exactly version 0.4.7. (So I opened https://github.com/lalrpop/lalrpop/pull/805, but it's not clear if that's a good solution either.)

To work around this issue, add a specific build-dependency to rp2040-hal. This should be removed with the next major release of rp2040-hal.