### PR TITLE
Implement WriteTarget for PWM top and cc registers.

### DIFF
--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -79,12 +79,14 @@
 use core::marker::PhantomData;
 
 use crate::{
+    dma::{EndlessWriteTarget, WriteTarget},
     gpio::{bank0::*, AnyPin, FunctionPwm, Pin, ValidFunction},
     resets::SubsystemReset,
     typelevel::{Is, Sealed},
 };
+use embedded_dma::Word;
 use embedded_hal::PwmPin;
-use pac::PWM;
+use pac::{dma::ch::ch_al1_ctrl::TREQ_SEL_A, PWM};
 
 use crate::atomic_register_access::{write_bitmask_clear, write_bitmask_set};
 
@@ -176,6 +178,9 @@ pub trait SliceId: Sealed {
     const DYN: DynSliceId;
     /// [`SliceMode`] at reset
     type Reset;
+
+    /// Get DREQ number of PWM wrap.
+    const WRAP_DREQ: u8 = TREQ_SEL_A::PWM_WRAP0 as u8 + Self::DYN.num;
 }
 
 macro_rules! slice_id {
@@ -764,3 +769,176 @@ impl<S: SliceId, M: ValidSliceInputMode<S>> Slice<S, M> {
         pin.into().into_function()
     }
 }
+
+/// Type representing DMA access to PWM cc register.
+///
+/// Both channels are accessed together, because of narrow write replication.
+///
+/// ```no_run
+/// use cortex_m::singleton;
+/// use rp2040_hal::dma::{double_buffer, DMAExt};
+/// use rp2040_hal::pwm::{CcFormat, SliceDmaWrite, Slices};
+///
+///
+/// let mut pac = rp2040_pac::Peripherals::take().unwrap();
+///
+/// // Init PWMs
+/// let pwm_slices = Slices::new(pac.PWM, &mut pac.RESETS);
+///
+/// // Configure PWM4
+/// let mut pwm = pwm_slices.pwm4;
+/// pwm.enable();
+///
+/// let buf = singleton!(: [CcFormat; 4] = [CcFormat{a: 0x1000, b: 0x9000}; 4]).unwrap();
+/// let buf2 = singleton!(: [CcFormat; 4] = [CcFormat{a: 0xf000, b: 0x5000}; 4]).unwrap();
+///
+/// let dma = pac.DMA.split(&mut pac.RESETS);
+///
+/// let dma_pwm = SliceDmaWrite::from(pwm);
+///
+/// let dma_conf = double_buffer::Config::new((dma.ch0, dma.ch1), buf, dma_pwm.cc);
+/// ```
+pub struct SliceDmaWriteCc<S: SliceId, M: ValidSliceMode<S>> {
+    slice: PhantomData<S>,
+    mode: PhantomData<M>,
+}
+
+/// Type representing DMA access to PWM top register.
+///
+/// ```no_run
+/// use cortex_m::{prelude::*, singleton};
+/// use rp2040_hal::dma::{double_buffer, DMAExt};
+/// use rp2040_hal::pwm::{SliceDmaWrite, Slices};
+///
+///
+/// let mut pac = rp2040_pac::Peripherals::take().unwrap();
+///
+/// // Init PWMs
+/// let pwm_slices = Slices::new(pac.PWM, &mut pac.RESETS);
+///
+/// // Configure PWM4
+/// let mut pwm = pwm_slices.pwm4;
+/// pwm.enable();
+///
+/// // Just set to something mesurable.
+/// pwm.channel_a.set_duty(0x1000);
+/// pwm.channel_b.set_duty(0x1000);
+///
+/// let buf = singleton!(: [u16; 4] = [0x7fff; 4]).unwrap();
+/// let buf2 = singleton!(: [u16; 4] = [0xffff; 4]).unwrap();
+///
+/// let dma = pac.DMA.split(&mut pac.RESETS);
+///
+/// // Reserve PWM slice for dma.
+/// let dma_pwm = SliceDmaWrite::from(pwm);
+///
+/// let dma_conf = double_buffer::Config::new((dma.ch0, dma.ch1), buf, dma_pwm.top);
+/// ```
+
+pub struct SliceDmaWriteTop<S: SliceId, M: ValidSliceMode<S>> {
+    slice: PhantomData<S>,
+    mode: PhantomData<M>,
+}
+
+/// PWM slice while used for DMA writes.
+/// ```no_run
+/// use rp2040_hal::{prelude::*, pwm::{SliceDmaWrite, Slices}};
+///
+///
+/// let mut pac = rp2040_pac::Peripherals::take().unwrap();
+///
+/// // Init PWMs
+/// let pwm_slices = Slices::new(pac.PWM, &mut pac.RESETS);
+///
+/// // Configure PWM4
+/// let mut pwm = pwm_slices.pwm4;
+/// pwm.enable();
+///
+/// // Use for DMA usage
+/// let dma_pwm = SliceDmaWrite::from(pwm);
+/// ```
+///
+pub struct SliceDmaWrite<S: SliceId, M: ValidSliceMode<S>> {
+    /// Part for top writes.
+    pub top: SliceDmaWriteTop<S, M>,
+
+    /// Part for cc writes.
+    pub cc: SliceDmaWriteCc<S, M>,
+    slice: Slice<S, M>,
+}
+
+impl<S: SliceId, M: ValidSliceMode<S>> From<Slice<S, M>> for SliceDmaWrite<S, M> {
+    fn from(value: Slice<S, M>) -> Self {
+        Self {
+            slice: value,
+            top: SliceDmaWriteTop {
+                slice: PhantomData::<S> {},
+                mode: PhantomData::<M> {},
+            },
+            cc: SliceDmaWriteCc {
+                slice: PhantomData::<S> {},
+                mode: PhantomData::<M> {},
+            },
+        }
+    }
+}
+
+impl<S: SliceId, M: ValidSliceMode<S>> From<SliceDmaWrite<S, M>> for Slice<S, M> {
+    fn from(value: SliceDmaWrite<S, M>) -> Self {
+        value.slice
+    }
+}
+
+/// Format for DMA transfers to PWM CC register.
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[repr(C)]
+#[repr(align(4))]
+pub struct CcFormat {
+    /// CC register part for channel a.
+    pub a: u16,
+    /// CC register part for channel b.
+    pub b: u16,
+}
+
+unsafe impl Word for CcFormat {}
+
+impl<S: SliceId, M: ValidSliceMode<S>> WriteTarget for SliceDmaWriteCc<S, M> {
+    type TransmittedWord = CcFormat;
+
+    fn tx_treq() -> Option<u8> {
+        Some(S::WRAP_DREQ)
+    }
+
+    fn tx_address_count(&mut self) -> (u32, u32) {
+        let regs = Registers {
+            id: PhantomData::<S> {},
+        };
+        (regs.ch().cc.as_ptr() as u32, u32::MAX)
+    }
+
+    fn tx_increment(&self) -> bool {
+        false
+    }
+}
+
+impl<S: SliceId, M: ValidSliceMode<S>> WriteTarget for SliceDmaWriteTop<S, M> {
+    type TransmittedWord = u16;
+
+    fn tx_treq() -> Option<u8> {
+        Some(S::WRAP_DREQ)
+    }
+
+    fn tx_address_count(&mut self) -> (u32, u32) {
+        let regs = Registers {
+            id: PhantomData::<S> {},
+        };
+        (regs.ch().top.as_ptr() as u32, u32::MAX)
+    }
+
+    fn tx_increment(&self) -> bool {
+        false
+    }
+}
+
+impl<S: SliceId, M: ValidSliceMode<S>> EndlessWriteTarget for SliceDmaWriteCc<S, M> {}
+impl<S: SliceId, M: ValidSliceMode<S>> EndlessWriteTarget for SliceDmaWriteTop<S, M> {}

--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -905,8 +905,8 @@ unsafe impl Word for CcFormat {}
 /// Format for DMA transfers to PWM TOP register.
 ///
 /// It is forbidden to use it as DMA write destination,
-/// it is safe but it might no be compatible with a future use of reserved register fields.
-#[derive(Clone, Copy, Eq, PartialEq)]
+/// it is safe but it might not be compatible with a future use of reserved register fields.
+#[derive(Clone, Copy, Eq)]
 #[repr(C)]
 #[repr(align(4))]
 pub struct TopFormat {
@@ -915,6 +915,12 @@ pub struct TopFormat {
     /// Reserved part.
     /// Should always be zero
     reserved: u16,
+}
+
+impl PartialEq<TopFormat> for TopFormat {
+    fn eq(&self, other: &TopFormat) -> bool {
+        self.top == other.top
+    }
 }
 
 impl TopFormat {

--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -872,12 +872,12 @@ impl<S: SliceId, M: ValidSliceMode<S>> From<Slice<S, M>> for SliceDmaWrite<S, M>
         Self {
             slice: value,
             top: SliceDmaWriteTop {
-                slice: PhantomData::<S> {},
-                mode: PhantomData::<M> {},
+                slice: PhantomData,
+                mode: PhantomData,
             },
             cc: SliceDmaWriteCc {
-                slice: PhantomData::<S> {},
-                mode: PhantomData::<M> {},
+                slice: PhantomData,
+                mode: PhantomData,
             },
         }
     }


### PR DESCRIPTION
Hello,
Here is an implementation of WriteTarget for PWM slices.

In my opinion this respects the safety requirements described in #621.

The implementation uses `u16` as type for the writes to the top register, which will cause the reserved upper bits to be written to by the same value. Is this problematic? I thought of using a type that has the upper 16 bits set to zero, but this would contradict the safety requirements of the `Word` trait.