### PR TITLE
Avoid missing docs warning on pub extern crate

### DIFF
--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -43,6 +43,7 @@ extern crate embedded_hal as hal;
 extern crate nb;
 pub use paste;
 
+/// Re-export of the PAC
 pub extern crate rp2040_pac as pac;
 
 #[macro_use]


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust/issues/112308, the public re-export of the pac will trigger a missing docs warning in rust 1.71.0.

This is bogus, as the doc string would not be shown in the rendered docs anyway. However, the warning would be annoying, so add a short doc string to the item.