### PR TITLE
Rename `dma::SingleChannel::listen_irq*` to `enable_irq*`

### DIFF
--- a/rp2040-hal/examples/adc_fifo_dma.rs
+++ b/rp2040-hal/examples/adc_fifo_dma.rs
@@ -149,7 +149,7 @@ fn main() -> ! {
     let timer = hal::Timer::new(pac.TIMER, &mut pac.RESETS, &clocks);
 
     // NOTE: in a real-world program, instead of calling `wait` now, you would probably:
-    // 1. Enable one of the DMA interrupts for the channel (e.g. `dma.ch0.listen_irq0()`)
+    // 1. Enable one of the DMA interrupts for the channel (e.g. `dma.ch0.enable_irq0()`)
     // 2. Set up a handler for the respective `DMA_IRQ_*` interrupt
     // 3. Call `wait` only within that interrupt, which will be fired once the transfer is complete.
 

--- a/rp2040-hal/src/dma/single_channel.rs
+++ b/rp2040-hal/src/dma/single_channel.rs
@@ -17,16 +17,28 @@ pub trait SingleChannel: Sealed {
     /// Returns the index of the DMA channel.
     fn id(&self) -> u8;
 
+    #[deprecated(note = "Renamed to enable_irq0")]
     /// Enables the DMA_IRQ_0 signal for this channel.
     fn listen_irq0(&mut self) {
+        self.enable_irq0();
+    }
+
+    /// Enables the DMA_IRQ_0 signal for this channel.
+    fn enable_irq0(&mut self) {
         // Safety: We only use the atomic alias of the register.
         unsafe {
             write_bitmask_set((*DMA::ptr()).inte0.as_ptr(), 1 << self.id());
         }
     }
 
+    #[deprecated(note = "Renamed to disable_irq0")]
     /// Disables the DMA_IRQ_0 signal for this channel.
     fn unlisten_irq0(&mut self) {
+        self.disable_irq0();
+    }
+
+    /// Disables the DMA_IRQ_0 signal for this channel.
+    fn disable_irq0(&mut self) {
         // Safety: We only use the atomic alias of the register.
         unsafe {
             write_bitmask_clear((*DMA::ptr()).inte0.as_ptr(), 1 << self.id());
@@ -49,16 +61,28 @@ pub trait SingleChannel: Sealed {
         }
     }
 
+    #[deprecated(note = "Renamed to enable_irq1")]
     /// Enables the DMA_IRQ_1 signal for this channel.
     fn listen_irq1(&mut self) {
+        self.enable_irq1();
+    }
+
+    /// Enables the DMA_IRQ_1 signal for this channel.
+    fn enable_irq1(&mut self) {
         // Safety: We only use the atomic alias of the register.
         unsafe {
             write_bitmask_set((*DMA::ptr()).inte1.as_ptr(), 1 << self.id());
         }
     }
 
+    #[deprecated(note = "Renamed to disable_irq1")]
     /// Disables the DMA_IRQ_1 signal for this channel.
     fn unlisten_irq1(&mut self) {
+        self.disable_irq1();
+    }
+
+    /// Disables the DMA_IRQ_1 signal for this channel.
+    fn disable_irq1(&mut self) {
         // Safety: We only use the atomic alias of the register.
         unsafe {
             write_bitmask_clear((*DMA::ptr()).inte1.as_ptr(), 1 << self.id());


### PR DESCRIPTION
My motivation for this change is that the first time I encountered the `listen_irq*` methods, the name invoked a misleading picture in my mind:
`channel.listen_irq0()` sounds like the channel is "listening" for the IRQ, and will do something once it triggers.

That's not the case though: calling this method will cause the channel to *trigger* the interrupt -- some other part of the program must do the listening.

Reasons to call it `enable_irq*` / `disable_irq*` instead:
- The corresponding function in pico-sdk is called `dma_channel_set_irqX_enabled`
- The INTEx register documentation also uses this terminology: "Interrupt Enables for IRQ X"