### PR TITLE
Migrate rp2040-hal to edition 2021

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rp2040-hal"
 version = "0.9.0-alpha.1"
 authors = ["The rp-rs Developers"]
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/rp-rs/rp-hal"
 description = "A Rust Embeded-HAL impl for the rp2040 microcontroller"
 license = "MIT OR Apache-2.0"

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -118,17 +118,15 @@
 
 use core::convert::Infallible;
 use core::marker::PhantomData;
-
-use crate::dma;
-use hal::adc::{Channel, OneShot};
-use pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;
-use pac::{ADC, RESETS};
+use embedded_hal::adc::{Channel, OneShot};
 
 use crate::{
+    dma,
     gpio::{
         bank0::{Gpio26, Gpio27, Gpio28, Gpio29},
         AnyPin, DynPinId, Function, OutputEnableOverride, Pin, PullType, ValidFunction,
     },
+    pac::{dma::ch::ch_ctrl_trig::TREQ_SEL_A, ADC, RESETS},
     resets::SubsystemReset,
 };
 

--- a/rp2040-hal/src/clocks/macros.rs
+++ b/rp2040-hal/src/clocks/macros.rs
@@ -81,7 +81,7 @@ macro_rules! clock {
                     false
                 }
                 fn variant(&self) -> [<$reg:camel SrcType>] {
-                    [<$reg:camel SrcType>]::Src(pac::clocks::[<$reg _ctrl>]::SRC_A::$src_variant)
+                    [<$reg:camel SrcType>]::Src($crate::pac::clocks::[<$reg _ctrl>]::SRC_A::$src_variant)
                 }
             })*
 
@@ -100,12 +100,12 @@ macro_rules! clock {
                 }
             }
 
-            #[doc = "Holds register value for ClockSource for `"$name"`"]
+            #[doc = "Holds register value for ClockSource for `" $name "`"]
             pub enum [<$reg:camel SrcType>] {
-                #[doc = "Contains a valid clock source register value that is to be used to set a clock as glitchless source for `"$name"`"]
-                Src(pac::clocks::[<$reg _ctrl>]::SRC_A),
-                #[doc = "Contains a valid clock source register value that is to be used to set a clock as aux source for `"$name"`"]
-                Aux(pac::clocks::[<$reg _ctrl>]::AUXSRC_A)
+                #[doc = "Contains a valid clock source register value that is to be used to set a clock as glitchless source for `" $name "`"]
+                Src($crate::pac::clocks::[<$reg _ctrl>]::SRC_A),
+                #[doc = "Contains a valid clock source register value that is to be used to set a clock as aux source for `" $name "`"]
+                Aux($crate::pac::clocks::[<$reg _ctrl>]::AUXSRC_A)
             }
 
             impl [<$reg:camel SrcType>] {
@@ -116,14 +116,14 @@ macro_rules! clock {
                     }
                 }
 
-                fn unwrap_src(&self) -> pac::clocks::[<$reg _ctrl>]::SRC_A{
+                fn unwrap_src(&self) -> $crate::pac::clocks::[<$reg _ctrl>]::SRC_A{
                     match self {
                         Self::Src(v) => *v,
                         Self::Aux(_) => panic!(),
                     }
                 }
 
-                fn unwrap_aux(&self) -> pac::clocks::[<$reg _ctrl>]::AUXSRC_A {
+                fn unwrap_aux(&self) -> $crate::pac::clocks::[<$reg _ctrl>]::AUXSRC_A {
                     match self {
                         Self::Src(_) => panic!(),
                         Self::Aux(v) => *v
@@ -166,7 +166,7 @@ macro_rules! clock {
 
                     ChangingClockToken{
                         clock: PhantomData::<$name>,
-                        clock_nr: pac::clocks::clk_ref_ctrl::SRC_A::CLKSRC_CLK_REF_AUX as u8,
+                        clock_nr: $crate::pac::clocks::clk_ref_ctrl::SRC_A::CLKSRC_CLK_REF_AUX as u8,
                     }
                 }
             }
@@ -174,12 +174,12 @@ macro_rules! clock {
             impl Clock for $name {
                 type Variant = [<$reg:camel SrcType>];
 
-                #[doc = "Get operating frequency for `"$name"`"]
+                #[doc = "Get operating frequency for `" $name "`"]
                 fn freq(&self) -> HertzU32 {
                     self.frequency
                 }
 
-                #[doc = "Configure `"$name"`"]
+                #[doc = "Configure `" $name "`"]
                 fn configure_clock<S: ValidSrc<$name>>(&mut self, src: &S, freq: HertzU32) -> Result<(), ClockError>{
                     let src_freq: HertzU32 = src.get_freq().into();
 
@@ -285,14 +285,14 @@ macro_rules! divisable_clock {
 macro_rules! stoppable_clock {
     ($name:ident, $reg:ident) => {
         $crate::paste::paste!{
-            #[doc = "Holds register value for ClockSource for `"$name"`"]
+            #[doc = "Holds register value for ClockSource for `" $name "`"]
             pub enum [<$reg:camel SrcType>] {
-                #[doc = "Contains a valid clock source register value that is to be used to set a clock as aux source for `"$name"`"]
-                Aux(pac::clocks::[<$reg _ctrl>]::AUXSRC_A)
+                #[doc = "Contains a valid clock source register value that is to be used to set a clock as aux source for `" $name "`"]
+                Aux($crate::pac::clocks::[<$reg _ctrl>]::AUXSRC_A)
             }
 
             impl [<$reg:camel SrcType>] {
-                fn unwrap_aux(&self) -> pac::clocks::[<$reg _ctrl>]::AUXSRC_A {
+                fn unwrap_aux(&self) -> $crate::pac::clocks::[<$reg _ctrl>]::AUXSRC_A {
                    match self {
                        Self::Aux(v) => *v
                    }
@@ -325,12 +325,12 @@ macro_rules! stoppable_clock {
             impl Clock for $name {
                 type Variant = [<$reg:camel SrcType>];
 
-                #[doc = "Get operating frequency for `"$name"`"]
+                #[doc = "Get operating frequency for `" $name "`"]
                 fn freq(&self) -> HertzU32 {
                     self.frequency
                 }
 
-                #[doc = "Configure `"$name"`"]
+                #[doc = "Configure `" $name "`"]
                 fn configure_clock<S: ValidSrc<$name>>(&mut self, src: &S, freq: HertzU32) -> Result<(), ClockError>{
                     let src_freq: HertzU32 = src.get_freq().into();
 
@@ -398,7 +398,7 @@ macro_rules! base_clock {
                     true
                 }
                 fn variant(&self) -> [<$reg:camel SrcType>] {
-                    [<$reg:camel SrcType>]::Aux(pac::clocks::[<$reg _ctrl>]::AUXSRC_A::$variant)
+                    [<$reg:camel SrcType>]::Aux($crate::pac::clocks::[<$reg _ctrl>]::AUXSRC_A::$variant)
                 }
             })*
 

--- a/rp2040-hal/src/clocks/mod.rs
+++ b/rp2040-hal/src/clocks/mod.rs
@@ -61,8 +61,11 @@
 //! ```
 //!
 //! See [Chapter 2 Section 15](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
+use core::{convert::Infallible, marker::PhantomData};
+use fugit::{HertzU32, RateExtU32};
 
 use crate::{
+    pac::{self, CLOCKS, PLL_SYS, PLL_USB, RESETS, XOSC},
     pll::{
         common_configs::{PLL_SYS_125MHZ, PLL_USB_48MHZ},
         setup_pll_blocking, Error as PllError, Locked, PhaseLockedLoop,
@@ -71,10 +74,6 @@ use crate::{
     watchdog::Watchdog,
     xosc::{setup_xosc_blocking, CrystalOscillator, Error as XoscError, Stable},
 };
-use core::{convert::Infallible, marker::PhantomData};
-use fugit::HertzU32;
-use fugit::RateExtU32;
-use pac::{CLOCKS, PLL_SYS, PLL_USB, RESETS, XOSC};
 
 #[macro_use]
 mod macros;

--- a/rp2040-hal/src/dma/mod.rs
+++ b/rp2040-hal/src/dma/mod.rs
@@ -22,19 +22,22 @@
 //! automatic continuous ring buffers consisting of two aligned buffers being read or written
 //! alternatingly.
 
-use crate::{resets::SubsystemReset, typelevel::Sealed};
 use core::marker::PhantomData;
 use embedded_dma::{ReadBuffer, WriteBuffer};
-use rp2040_pac::DMA;
+
+use crate::{
+    pac::{self, DMA},
+    resets::SubsystemReset,
+    typelevel::Sealed,
+};
+// Export these types for easier use by external code
+pub use crate::dma::single_channel::SingleChannel;
 
 // Bring in our submodules
 pub mod bidirectional;
 pub mod double_buffer;
 pub mod single_buffer;
 mod single_channel;
-
-// Export these types for easier use by external code
-pub use crate::dma::single_channel::SingleChannel;
 
 /// DMA unit.
 pub trait DMAExt: Sealed {
@@ -134,16 +137,16 @@ channels! {
 }
 
 trait ChannelRegs {
-    unsafe fn ptr() -> *const rp2040_pac::dma::CH;
-    fn regs(&self) -> &rp2040_pac::dma::CH;
+    unsafe fn ptr() -> *const pac::dma::CH;
+    fn regs(&self) -> &pac::dma::CH;
 }
 
 impl<CH: ChannelIndex> ChannelRegs for Channel<CH> {
-    unsafe fn ptr() -> *const rp2040_pac::dma::CH {
-        &(*rp2040_pac::DMA::ptr()).ch[CH::id() as usize] as *const _
+    unsafe fn ptr() -> *const pac::dma::CH {
+        &(*pac::DMA::ptr()).ch[CH::id() as usize] as *const _
     }
 
-    fn regs(&self) -> &rp2040_pac::dma::CH {
+    fn regs(&self) -> &pac::dma::CH {
         unsafe { &*Self::ptr() }
     }
 }

--- a/rp2040-hal/src/dma/single_channel.rs
+++ b/rp2040-hal/src/dma/single_channel.rs
@@ -1,4 +1,4 @@
-use rp2040_pac::DMA;
+use crate::pac::DMA;
 
 use super::{Channel, ChannelIndex, Pace, ReadTarget, WriteTarget};
 use crate::{
@@ -13,7 +13,7 @@ pub trait SingleChannel: Sealed {
     /// Returns the registers associated with this DMA channel.
     ///
     /// In the case of channel pairs, this returns the first channel.
-    fn ch(&self) -> &rp2040_pac::dma::CH;
+    fn ch(&self) -> &crate::pac::dma::CH;
     /// Returns the index of the DMA channel.
     fn id(&self) -> u8;
 
@@ -113,13 +113,13 @@ pub trait SingleChannel: Sealed {
 pub trait ChannelPair: SingleChannel + Sealed {
     /// Returns the registers associated with the second DMA channel associated with this channel
     /// pair.
-    fn ch2(&self) -> &rp2040_pac::dma::CH;
+    fn ch2(&self) -> &crate::pac::dma::CH;
     /// Returns the index of the second DMA channel.
     fn id2(&self) -> u8;
 }
 
 impl<CH: ChannelIndex> SingleChannel for Channel<CH> {
-    fn ch(&self) -> &rp2040_pac::dma::CH {
+    fn ch(&self) -> &crate::pac::dma::CH {
         self.regs()
     }
 
@@ -131,7 +131,7 @@ impl<CH: ChannelIndex> SingleChannel for Channel<CH> {
 impl<CH: ChannelIndex> Sealed for Channel<CH> {}
 
 impl<CH1: ChannelIndex, CH2: ChannelIndex> SingleChannel for (Channel<CH1>, Channel<CH2>) {
-    fn ch(&self) -> &rp2040_pac::dma::CH {
+    fn ch(&self) -> &crate::pac::dma::CH {
         self.0.regs()
     }
 
@@ -245,7 +245,7 @@ impl<CH: SingleChannel> ChannelConfig for CH {
     fn start(&mut self) {
         // Safety: The write does not interfere with any other writes, it only affects this
         // channel.
-        unsafe { &*rp2040_pac::DMA::ptr() }
+        unsafe { &*crate::pac::DMA::ptr() }
             .multi_chan_trigger
             .write(|w| unsafe { w.bits(1 << self.id()) });
     }
@@ -254,7 +254,7 @@ impl<CH: SingleChannel> ChannelConfig for CH {
         // Safety: The write does not interfere with any other writes, it only affects this
         // channel and other (which we have an exclusive borrow of).
         let channel_flags = 1 << self.id() | 1 << other.id();
-        unsafe { &*rp2040_pac::DMA::ptr() }
+        unsafe { &*crate::pac::DMA::ptr() }
             .multi_chan_trigger
             .write(|w| unsafe { w.bits(channel_flags) });
     }

--- a/rp2040-hal/src/float/div.rs
+++ b/rp2040-hal/src/float/div.rs
@@ -1,5 +1,5 @@
 use super::Float;
-use crate::rom_data;
+use crate::{pac, rom_data};
 
 // Make sure this stays as a separate call, because when it's inlined the
 // compiler will move the save of the registers used to contain the divider

--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -43,6 +43,7 @@ pub use embedded_hal::digital::v2::PinState;
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},
+    pac,
     sio::Sio,
     typelevel::{self, Sealed},
 };
@@ -169,8 +170,8 @@ pub struct Pin<I: PinId, F: func::Function, P: PullType> {
 /// The uniqueness of the pin is not verified. User must make sure no other instance of that specific
 /// pin exists at the same time.
 pub unsafe fn new_pin(id: DynPinId) -> Pin<DynPinId, DynFunction, DynPullType> {
+    use pac::io_bank0::gpio::gpio_ctrl::FUNCSEL_A;
     use pin::pin_sealed::PinIdOps;
-    use rp2040_pac::io_bank0::gpio::gpio_ctrl::FUNCSEL_A;
 
     let funcsel = id
         .io_ctrl()
@@ -941,8 +942,8 @@ macro_rules! gpio {
         paste::paste!{
             #[doc = "Pin bank " [<$bank>] ]
             pub mod [<$bank:snake>] {
+                use $crate::pac::{[<IO_ $bank:upper>],[<PADS_ $bank:upper>]};
                 use crate::sio::[<SioGpio $bank>];
-                use pac::{[<IO_ $bank:upper>],[<PADS_ $bank:upper>]};
                 use super::{Pin, pin, pull, func};
                 $(pub use super::pin::[<$bank:lower>]::[<$prefix $id>];)*
 
@@ -956,7 +957,7 @@ macro_rules! gpio {
 
                 impl Pins {
                     /// Take ownership of the PAC peripherals and SIO slice and split it into discrete [`Pin`]s
-                    pub fn new(io : [<IO_ $bank:upper>], pads: [<PADS_ $bank:upper>], sio: [<SioGpio $bank>], reset : &mut pac::RESETS) -> Self {
+                    pub fn new(io : [<IO_ $bank:upper>], pads: [<PADS_ $bank:upper>], sio: [<SioGpio $bank>], reset : &mut $crate::pac::RESETS) -> Self {
                         use crate::resets::SubsystemReset;
                         pads.reset_bring_down(reset);
                         io.reset_bring_down(reset);
@@ -964,7 +965,7 @@ macro_rules! gpio {
                         {
                             use $crate::gpio::pin::DynBankId;
                             // SAFETY: this function owns the whole bank that will be affected.
-                            let sio = unsafe { &*pac::SIO::PTR };
+                            let sio = unsafe { &*$crate::pac::SIO::PTR };
                             if DynBankId::$bank == DynBankId::Bank0 {
                                 sio.gpio_oe.reset();
                                 sio.gpio_out.reset();

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -26,6 +26,8 @@
 //! This modules bridges that gap by adding a trait definition per register type and implementing it
 //! for each of the relevant registers.
 
+use crate::typelevel::Sealed;
+
 use super::{DynFunction, DynPullType};
 
 pub(crate) mod pin_sealed;
@@ -41,16 +43,16 @@ pub enum DynBankId {
 }
 
 /// Type-level `enum` for the pin's bank ID.
-pub trait BankId: crate::typelevel::Sealed {}
+pub trait BankId: Sealed {}
 
 /// Type-level `variant` of `BankId`
 pub struct BankBank0;
-impl crate::typelevel::Sealed for BankBank0 {}
+impl Sealed for BankBank0 {}
 impl BankId for BankBank0 {}
 
 /// Type-level `variant` of `BankId`
 pub struct BankQspi;
-impl crate::typelevel::Sealed for BankQspi {}
+impl Sealed for BankQspi {}
 impl BankId for BankQspi {}
 
 /// Type-level `enum` for the pin Id (pin number + bank).
@@ -125,7 +127,7 @@ pub mod qspi {
 }
 
 pub(crate) fn set_function<P: PinId>(pin: &P, function: DynFunction) {
-    use pac::io_bank0::gpio::gpio_ctrl::FUNCSEL_A;
+    use crate::pac::io_bank0::gpio::gpio_ctrl::FUNCSEL_A;
     let funcsel = match function {
         DynFunction::Xip => FUNCSEL_A::JTAG,
         DynFunction::Spi => FUNCSEL_A::SPI,

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -44,14 +44,14 @@
 //! for a complete example
 
 use core::{marker::PhantomData, ops::Deref};
+use fugit::HertzU32;
 
 use crate::{
     gpio::{bank0::*, pin::pin_sealed::TypeLevelPinId, AnyPin, FunctionI2c},
+    pac::{self, i2c0::RegisterBlock as I2CBlock, I2C0, I2C1, RESETS},
     resets::SubsystemReset,
     typelevel::Sealed,
 };
-use fugit::HertzU32;
-use pac::{i2c0::RegisterBlock as I2CBlock, I2C0, I2C1, RESETS};
 
 /// Controller implementaion
 pub mod controller;

--- a/rp2040-hal/src/i2c/controller.rs
+++ b/rp2040-hal/src/i2c/controller.rs
@@ -1,14 +1,15 @@
 use core::{marker::PhantomData, ops::Deref};
-
-use crate::resets::SubsystemReset;
+use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 use fugit::HertzU32;
-use hal::blocking::i2c::{Read, Write, WriteRead};
-use pac::{i2c0::RegisterBlock as Block, RESETS};
 
 #[cfg(feature = "eh1_0_alpha")]
 use eh1_0_alpha::i2c as eh1;
 
 use super::{i2c_reserved_addr, Controller, Error, ValidPinScl, ValidPinSda, I2C};
+use crate::{
+    pac::{i2c0::RegisterBlock as Block, RESETS},
+    resets::SubsystemReset,
+};
 
 impl<T, Sda, Scl> I2C<T, (Sda, Scl), Controller>
 where

--- a/rp2040-hal/src/i2c/peripheral.rs
+++ b/rp2040-hal/src/i2c/peripheral.rs
@@ -1,9 +1,10 @@
 use core::{marker::PhantomData, ops::Deref};
 
-use crate::resets::SubsystemReset;
-use pac::{i2c0::RegisterBlock as I2CBlock, RESETS};
-
 use super::{Peripheral, ValidPinScl, ValidPinSda, I2C};
+use crate::{
+    pac::{i2c0::RegisterBlock as I2CBlock, RESETS},
+    resets::SubsystemReset,
+};
 
 /// I2C bus events
 #[derive(Debug, PartialEq, Eq)]

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -38,13 +38,10 @@
 #![warn(missing_docs)]
 #![no_std]
 
-extern crate cortex_m;
-extern crate embedded_hal as hal;
-extern crate nb;
 pub use paste;
 
 /// Re-export of the PAC
-pub extern crate rp2040_pac as pac;
+pub use rp2040_pac as pac;
 
 #[macro_use]
 mod intrinsics;

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1,16 +1,16 @@
 //! Programmable IO (PIO)
 //! See [Chapter 3 of the datasheet](https://rptl.io/rp2040-datasheet#section_pio) for more details.
 use core::ops::Deref;
+use pio::{Instruction, InstructionOperands, Program, SideSet, Wrap};
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},
     dma::{EndlessReadTarget, EndlessWriteTarget, ReadTarget, WriteTarget},
     gpio::{Function, FunctionPio0, FunctionPio1},
+    pac::{self, dma::ch::ch_ctrl_trig::TREQ_SEL_A, pio0::RegisterBlock, PIO0, PIO1},
     resets::SubsystemReset,
     typelevel::Sealed,
 };
-use pio::{Instruction, InstructionOperands, Program, SideSet, Wrap};
-use rp2040_pac::{dma::ch::ch_ctrl_trig::TREQ_SEL_A, pio0::RegisterBlock, PIO0, PIO1};
 
 const PIO_INSTRUCTION_COUNT: usize = 32;
 
@@ -26,7 +26,7 @@ pub trait PIOExt: Deref<Target = RegisterBlock> + SubsystemReset + Sized + Send 
     #[allow(clippy::type_complexity)] // Required for symmetry with PIO::free().
     fn split(
         self,
-        resets: &mut pac::RESETS,
+        resets: &mut crate::pac::RESETS,
     ) -> (
         PIO<Self>,
         UninitStateMachine<(Self, SM0)>,
@@ -481,7 +481,7 @@ pub enum PinDir {
 #[derive(Debug)]
 pub struct UninitStateMachine<SM: ValidStateMachine> {
     block: *const RegisterBlock,
-    sm: *const rp2040_pac::pio0::SM,
+    sm: *const crate::pac::pio0::SM,
     _phantom: core::marker::PhantomData<SM>,
 }
 
@@ -538,7 +538,7 @@ impl<SM: ValidStateMachine> UninitStateMachine<SM> {
         }
     }
 
-    unsafe fn sm(&self) -> &rp2040_pac::pio0::SM {
+    unsafe fn sm(&self) -> &crate::pac::pio0::SM {
         &*self.sm
     }
 
@@ -1780,7 +1780,7 @@ impl<'a, P: PIOExt, const IRQ: usize> Interrupt<'a, P, IRQ> {
         &*self.block
     }
 
-    unsafe fn irq(&self) -> &rp2040_pac::pio0::SM_IRQ {
+    unsafe fn irq(&self) -> &crate::pac::pio0::SM_IRQ {
         &self.block().sm_irq[IRQ]
     }
 }

--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -10,9 +10,8 @@ use core::{
 use fugit::{HertzU32, RateExtU32};
 
 use nb::Error::WouldBlock;
-use pac::RESETS;
 
-use crate::{clocks::ClocksManager, resets::SubsystemReset, typelevel::Sealed};
+use crate::{clocks::ClocksManager, pac::RESETS, resets::SubsystemReset, typelevel::Sealed};
 
 /// State of the PLL
 pub trait State: Sealed {}
@@ -47,14 +46,14 @@ impl Sealed for Locking {}
 
 /// Trait to handle both underlying devices from the PAC (PLL_SYS & PLL_USB)
 pub trait PhaseLockedLoopDevice:
-    Deref<Target = rp2040_pac::pll_sys::RegisterBlock> + SubsystemReset + Sealed
+    Deref<Target = crate::pac::pll_sys::RegisterBlock> + SubsystemReset + Sealed
 {
 }
 
-impl PhaseLockedLoopDevice for rp2040_pac::PLL_SYS {}
-impl Sealed for rp2040_pac::PLL_SYS {}
-impl PhaseLockedLoopDevice for rp2040_pac::PLL_USB {}
-impl Sealed for rp2040_pac::PLL_USB {}
+impl PhaseLockedLoopDevice for crate::pac::PLL_SYS {}
+impl Sealed for crate::pac::PLL_SYS {}
+impl PhaseLockedLoopDevice for crate::pac::PLL_USB {}
+impl Sealed for crate::pac::PLL_USB {}
 
 /// A PLL.
 pub struct PhaseLockedLoop<S: State, D: PhaseLockedLoopDevice> {
@@ -200,7 +199,7 @@ impl<D: PhaseLockedLoopDevice> PhaseLockedLoop<Disabled, D> {
     }
 
     /// Configures and starts the PLL : it switches to Locking state.
-    pub fn initialize(self, resets: &mut rp2040_pac::RESETS) -> PhaseLockedLoop<Locking, D> {
+    pub fn initialize(self, resets: &mut crate::pac::RESETS) -> PhaseLockedLoop<Locking, D> {
         self.device.reset_bring_up(resets);
 
         // Turn off PLL in case it is already running

--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -78,17 +78,17 @@
 
 use core::marker::PhantomData;
 
+use embedded_dma::Word;
+use embedded_hal::PwmPin;
+
 use crate::{
+    atomic_register_access::{write_bitmask_clear, write_bitmask_set},
     dma::{EndlessWriteTarget, WriteTarget},
     gpio::{bank0::*, AnyPin, FunctionPwm, Pin, ValidFunction},
+    pac::{self, dma::ch::ch_al1_ctrl::TREQ_SEL_A, PWM},
     resets::SubsystemReset,
     typelevel::{Is, Sealed},
 };
-use embedded_dma::Word;
-use embedded_hal::PwmPin;
-use pac::{dma::ch::ch_al1_ctrl::TREQ_SEL_A, PWM};
-
-use crate::atomic_register_access::{write_bitmask_clear, write_bitmask_set};
 
 pub mod dyn_slice;
 pub use dyn_slice::*;
@@ -514,7 +514,7 @@ macro_rules! pwm {
 
             impl Slices {
                 /// Take ownership of the PAC peripheral and split it into discrete [`Slice`]s
-                pub fn new(pwm: $PWMX, reset : &mut pac::RESETS) -> Self {
+                pub fn new(pwm: $PWMX, reset : &mut crate::pac::RESETS) -> Self {
                     pwm.reset_bring_up(reset);
                     unsafe {
                         Self {

--- a/rp2040-hal/src/pwm/reg.rs
+++ b/rp2040-hal/src/pwm/reg.rs
@@ -1,5 +1,7 @@
-use super::dyn_slice::{DynSliceId, DynSliceMode};
-use pac::pwm::CH;
+use crate::{
+    pac::{self, pwm::CH},
+    pwm::dyn_slice::{DynSliceId, DynSliceMode},
+};
 
 /// # Safety
 ///

--- a/rp2040-hal/src/resets.rs
+++ b/rp2040-hal/src/resets.rs
@@ -1,11 +1,9 @@
 //! Subsystem Resets
 // See [Chapter 2 Section 14](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
-use rp2040_pac as pac;
-
 mod private {
     pub trait SubsystemReset {
-        fn reset_bring_up(&self, resets: &mut pac::RESETS);
-        fn reset_bring_down(&self, resets: &mut pac::RESETS);
+        fn reset_bring_up(&self, resets: &mut crate::pac::RESETS);
+        fn reset_bring_down(&self, resets: &mut crate::pac::RESETS);
     }
 }
 
@@ -13,12 +11,12 @@ pub(crate) use private::SubsystemReset;
 
 macro_rules! generate_reset {
     ($MODULE:ident, $module:ident) => {
-        impl SubsystemReset for pac::$MODULE {
-            fn reset_bring_up(&self, resets: &mut pac::RESETS) {
+        impl SubsystemReset for $crate::pac::$MODULE {
+            fn reset_bring_up(&self, resets: &mut $crate::pac::RESETS) {
                 resets.reset.modify(|_, w| w.$module().clear_bit());
                 while resets.reset_done.read().$module().bit_is_clear() {}
             }
-            fn reset_bring_down(&self, resets: &mut pac::RESETS) {
+            fn reset_bring_down(&self, resets: &mut $crate::pac::RESETS) {
                 resets.reset.modify(|_, w| w.$module().set_bit());
             }
         }

--- a/rp2040-hal/src/rosc.rs
+++ b/rp2040-hal/src/rosc.rs
@@ -3,7 +3,7 @@
 
 use fugit::HertzU32;
 
-use crate::typelevel::Sealed;
+use crate::{pac::ROSC, typelevel::Sealed};
 
 /// State of the Ring Oscillator (typestate trait)
 pub trait State: Sealed {}
@@ -28,7 +28,7 @@ impl Sealed for Dormant {}
 
 /// A Ring Oscillator.
 pub struct RingOscillator<S: State> {
-    device: rp2040_pac::ROSC,
+    device: ROSC,
     state: S,
 }
 
@@ -42,14 +42,14 @@ impl<S: State> RingOscillator<S> {
     }
 
     /// Releases the underlying device.
-    pub fn free(self) -> rp2040_pac::ROSC {
+    pub fn free(self) -> ROSC {
         self.device
     }
 }
 
 impl RingOscillator<Disabled> {
     /// Creates a new RingOscillator from the underlying device.
-    pub fn new(dev: rp2040_pac::ROSC) -> Self {
+    pub fn new(dev: ROSC) -> Self {
         RingOscillator {
             device: dev,
             state: Disabled,

--- a/rp2040-hal/src/rtc/datetime_chrono.rs
+++ b/rp2040-hal/src/rtc/datetime_chrono.rs
@@ -1,5 +1,5 @@
+use crate::pac::rtc::{rtc_0, rtc_1, setup_0, setup_1};
 use chrono::{Datelike, Timelike};
-use rp2040_pac::rtc::{rtc_0, rtc_1, setup_0, setup_1};
 
 /// Alias for [`chrono::NaiveDateTime`]
 pub type DateTime = chrono::NaiveDateTime;

--- a/rp2040-hal/src/rtc/datetime_no_deps.rs
+++ b/rp2040-hal/src/rtc/datetime_no_deps.rs
@@ -1,4 +1,4 @@
-use rp2040_pac::rtc::{rtc_0, rtc_1, setup_0, setup_1};
+use crate::pac::rtc::{rtc_0, rtc_1, setup_0, setup_1};
 
 /// Errors regarding the [`DateTime`] and [`DateTimeFilter`] structs.
 ///

--- a/rp2040-hal/src/rtc/filter.rs
+++ b/rp2040-hal/src/rtc/filter.rs
@@ -1,5 +1,5 @@
 use super::DayOfWeek;
-use rp2040_pac::rtc::{irq_setup_0, irq_setup_1};
+use crate::pac::rtc::{irq_setup_0, irq_setup_1};
 
 /// A filter used for [`RealTimeClock::schedule_alarm`].
 ///

--- a/rp2040-hal/src/rtc/mod.rs
+++ b/rp2040-hal/src/rtc/mod.rs
@@ -23,7 +23,7 @@
 
 use crate::clocks::Clock;
 use crate::clocks::RtcClock;
-use rp2040_pac::{RESETS, RTC};
+use crate::pac::{RESETS, RTC};
 
 mod filter;
 

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -19,7 +19,6 @@
 //! let spi = Spi::<_, _, _, 8>::new(peripherals.SPI0, (mosi, sclk)).init(&mut peripherals.RESETS, 125_000_000u32.Hz(), 16_000_000u32.Hz(), MODE_0);
 //! ```
 
-use crate::dma::{EndlessReadTarget, EndlessWriteTarget, ReadTarget, WriteTarget};
 use core::{convert::Infallible, marker::PhantomData, ops::Deref};
 
 #[cfg(feature = "eh1_0_alpha")]
@@ -31,9 +30,13 @@ use embedded_hal::{
     spi::{FullDuplex, Phase, Polarity},
 };
 use fugit::{HertzU32, RateExtU32};
-use pac::{dma::ch::ch_ctrl_trig::TREQ_SEL_A, RESETS};
 
-use crate::{resets::SubsystemReset, typelevel::Sealed};
+use crate::{
+    dma::{EndlessReadTarget, EndlessWriteTarget, ReadTarget, WriteTarget},
+    pac::{self, dma::ch::ch_ctrl_trig::TREQ_SEL_A, RESETS},
+    resets::SubsystemReset,
+    typelevel::Sealed,
+};
 
 mod pins;
 pub use pins::*;

--- a/rp2040-hal/src/spi/pins.rs
+++ b/rp2040-hal/src/spi/pins.rs
@@ -1,11 +1,10 @@
 use core::marker::PhantomData;
 
-use crate::gpio::{pin::pin_sealed::TypeLevelPinId, AnyPin, FunctionSpi};
 use crate::{
-    gpio::bank0::*,
+    gpio::{bank0::*, pin::pin_sealed::TypeLevelPinId, AnyPin, FunctionSpi},
+    pac::{SPI0, SPI1},
     typelevel::{OptionT, OptionTNone, OptionTSome, Sealed},
 };
-use pac::{SPI0, SPI1};
 
 use super::SpiDevice;
 

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -8,14 +8,16 @@
 //!
 //! See [Chapter 4 Section 6](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) of the datasheet for more details.
 
+use core::sync::atomic::{AtomicU8, Ordering};
 use fugit::{MicrosDurationU32, MicrosDurationU64, TimerInstantU64};
 
-use crate::atomic_register_access::{write_bitmask_clear, write_bitmask_set};
-use crate::clocks::ClocksManager;
-use crate::pac::{RESETS, TIMER};
-use crate::resets::SubsystemReset;
-use crate::typelevel::Sealed;
-use core::sync::atomic::{AtomicU8, Ordering};
+use crate::{
+    atomic_register_access::{write_bitmask_clear, write_bitmask_set},
+    clocks::ClocksManager,
+    pac::{self, RESETS, TIMER},
+    resets::SubsystemReset,
+    typelevel::Sealed,
+};
 
 /// Instant type used by the Timer & Alarm methods.
 pub type Instant = TimerInstantU64<1_000_000>;

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -3,22 +3,21 @@
 //! This module brings together `uart::reader` and `uart::writer` to give a
 //! UartPeripheral object that can both read and write.
 
-use super::*;
-use crate::pac::uart0::uartlcr_h::W as UART_LCR_H_Writer;
-use crate::typelevel::OptionT;
-use core::convert::Infallible;
-use core::fmt;
+use core::{convert::Infallible, fmt};
 use embedded_hal::serial::{Read, Write};
 use fugit::HertzU32;
 use nb::Error::{Other, WouldBlock};
-use rp2040_pac::{UART0, UART1};
+
+use crate::{
+    pac::{self, uart0::uartlcr_h::W as UART_LCR_H_Writer, Peripherals, UART0, UART1},
+    typelevel::OptionT,
+    uart::*,
+};
 
 #[cfg(feature = "eh1_0_alpha")]
 use eh1_0_alpha::serial as eh1;
 #[cfg(feature = "eh1_0_alpha")]
 use eh_nb_1_0_alpha::serial as eh1nb;
-
-use pac::Peripherals;
 
 /// An UART Peripheral based on an underlying UART device.
 pub struct UartPeripheral<S: State, D: UartDevice, P: ValidUartPinout<D>> {

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -4,9 +4,9 @@
 
 use super::{FifoWatermark, UartDevice, ValidUartPinout};
 use crate::dma::{EndlessReadTarget, ReadTarget};
+use crate::pac::uart0::RegisterBlock;
 use embedded_hal::serial::Read;
 use nb::Error::*;
-use rp2040_pac::uart0::RegisterBlock;
 
 #[cfg(feature = "eh1_0_alpha")]
 use eh1_0_alpha::serial as eh1;

--- a/rp2040-hal/src/uart/utils.rs
+++ b/rp2040-hal/src/uart/utils.rs
@@ -1,9 +1,9 @@
+use crate::pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;
 use crate::pac::{uart0::RegisterBlock, UART0, UART1};
 use crate::resets::SubsystemReset;
 use crate::typelevel::Sealed;
 use core::ops::Deref;
 use fugit::HertzU32;
-use rp2040_pac::dma::ch::ch_ctrl_trig::TREQ_SEL_A;
 
 /// Error type for UART operations.
 #[derive(Debug)]

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -4,6 +4,7 @@
 
 use super::{FifoWatermark, UartDevice, ValidUartPinout};
 use crate::dma::{EndlessWriteTarget, WriteTarget};
+use crate::pac::uart0::RegisterBlock;
 use core::fmt;
 use core::{convert::Infallible, marker::PhantomData};
 #[cfg(feature = "eh1_0_alpha")]
@@ -12,7 +13,6 @@ use eh1_0_alpha::serial as eh1;
 use eh_nb_1_0_alpha::serial as eh1nb;
 use embedded_hal::serial::Write;
 use nb::Error::*;
-use rp2040_pac::uart0::RegisterBlock;
 
 /// Set tx FIFO watermark
 ///

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -106,19 +106,18 @@
 //! ```
 
 use core::cell::RefCell;
-
-use crate::clocks::UsbClock;
-use crate::pac::RESETS;
-use crate::pac::USBCTRL_DPRAM;
-use crate::pac::USBCTRL_REGS;
-use crate::resets::SubsystemReset;
-
 use critical_section::{self, Mutex};
 
 use usb_device::{
     bus::{PollResult, UsbBus as UsbBusTrait},
     endpoint::{EndpointAddress, EndpointType},
     Result as UsbResult, UsbDirection, UsbError,
+};
+
+use crate::{
+    clocks::UsbClock,
+    pac::{RESETS, USBCTRL_DPRAM, USBCTRL_REGS},
+    resets::SubsystemReset,
 };
 
 #[cfg(feature = "rp2040-e5")]
@@ -281,7 +280,7 @@ impl Inner {
         .enumerate()
         .filter_map(|(i, ep)| ep.as_ref().map(|ep| (i, ep)))
         {
-            use pac::usbctrl_dpram::ep_control::ENDPOINT_TYPE_A;
+            use crate::pac::usbctrl_dpram::ep_control::ENDPOINT_TYPE_A;
             let ep_type = match ep.ep_type {
                 EndpointType::Bulk => ENDPOINT_TYPE_A::BULK,
                 EndpointType::Isochronous => ENDPOINT_TYPE_A::ISOCHRONOUS,

--- a/rp2040-hal/src/usb/errata5.rs
+++ b/rp2040-hal/src/usb/errata5.rs
@@ -7,7 +7,7 @@
 //! logic if it isn't func selected.
 
 use crate::atomic_register_access::{write_bitmask_clear, write_bitmask_set};
-use rp2040_pac::Peripherals;
+use crate::pac::Peripherals;
 
 pub struct ForceLineStateJ {
     prev_pads: u32,

--- a/rp2040-hal/src/vector_table.rs
+++ b/rp2040-hal/src/vector_table.rs
@@ -40,7 +40,7 @@ impl VectorTable {
     }
 
     /// Initialise our vector table by copying the current table on top of it
-    pub fn init(&mut self, ppb: &mut pac::PPB) {
+    pub fn init(&mut self, ppb: &mut crate::pac::PPB) {
         let vector_table = ppb.vtor.read().bits();
         unsafe {
             crate::rom_data::memcpy44(
@@ -77,7 +77,7 @@ impl VectorTable {
     /// # Safety
     /// Until the vector table has valid entries, activating it will cause an unhandled hardfault!
     /// You must call init() first.
-    pub unsafe fn activate(&mut self, ppb: &mut pac::PPB) {
+    pub unsafe fn activate(&mut self, ppb: &mut crate::pac::PPB) {
         ppb.vtor
             .write(|w| w.bits(&mut self.table as *mut _ as *mut u32 as u32));
     }

--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -34,9 +34,10 @@
 //! ```
 //! See [examples/watchdog.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/watchdog.rs) for a more complete example
 
-use crate::pac::WATCHDOG;
 use embedded_hal::watchdog;
 use fugit::MicrosDurationU32;
+
+use crate::pac::{self, WATCHDOG};
 
 /// Watchdog peripheral
 pub struct Watchdog {

--- a/rp2040-hal/src/xosc.rs
+++ b/rp2040-hal/src/xosc.rs
@@ -7,7 +7,7 @@ use core::{convert::Infallible, ops::RangeInclusive};
 use fugit::HertzU32;
 use nb::Error::WouldBlock;
 
-use crate::typelevel::Sealed;
+use crate::{pac::XOSC, typelevel::Sealed};
 
 /// State of the Crystal Oscillator (typestate trait)
 pub trait State: Sealed {}
@@ -50,7 +50,7 @@ pub enum Error {
 
 /// Blocking helper method to setup the XOSC without going through all the steps.
 pub fn setup_xosc_blocking(
-    xosc_dev: rp2040_pac::XOSC,
+    xosc_dev: XOSC,
     frequency: HertzU32,
 ) -> Result<CrystalOscillator<Stable>, Error> {
     let initialized_xosc = CrystalOscillator::new(xosc_dev).initialize(frequency)?;
@@ -62,7 +62,7 @@ pub fn setup_xosc_blocking(
 
 /// A Crystal Oscillator.
 pub struct CrystalOscillator<S: State> {
-    device: rp2040_pac::XOSC,
+    device: XOSC,
     state: S,
 }
 
@@ -76,14 +76,14 @@ impl<S: State> CrystalOscillator<S> {
     }
 
     /// Releases the underlying device.
-    pub fn free(self) -> rp2040_pac::XOSC {
+    pub fn free(self) -> XOSC {
         self.device
     }
 }
 
 impl CrystalOscillator<Disabled> {
     /// Creates a new CrystalOscillator from the underlying device.
-    pub fn new(dev: rp2040_pac::XOSC) -> Self {
+    pub fn new(dev: XOSC) -> Self {
         CrystalOscillator {
             device: dev,
             state: Disabled,


### PR DESCRIPTION
In addition to the fairly trivial migration to edition 2021, this commit provides some sanitation of macro hygiene and brings some consistencies to rp2040_pac references.