### PR TITLE
Fix an import in a doc comment

### DIFF
--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -1222,7 +1222,7 @@ macro_rules! bsp_pins {
             ///
             /// like this:
             ///```no_run
-            /// use rp2040_hal::{pac, gpio::{bank0::Gpio12, Pin, Pins, PushPullOutput}, sio::Sio};
+            /// use rp2040_hal::{pac, gpio::{bank0::Gpio12, Pin, Pins}, sio::Sio};
             ///
             /// let mut peripherals = pac::Peripherals::take().unwrap();
             /// let sio = Sio::new(peripherals.SIO);


### PR DESCRIPTION
This is inside a macro, so it's only tested when this macro is used. Therefore, it only failed when testing rp-hal-boards: https://github.com/rp-rs/rp-hal-boards/actions/runs/5754010918/job/15598412621