### PR TITLE
Fix version of cargo-hack to 0.5.28

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,6 +13,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
+          version: "=0.5.28"
       - name: Build rp2040-hal's workspace (without the examples)
         run: cargo hack build --optional-deps --each-feature
   examples-builds:
@@ -27,6 +28,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
+          version: "=0.5.28"
       - name: Build workspace
         run: cargo hack build --examples --optional-deps --each-feature
   tests:
@@ -41,6 +43,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
+          version: "=0.5.28"
       - name: Test
         run: cargo hack test -p rp2040-hal --tests --target x86_64-unknown-linux-gnu  --optional-deps --each-feature --features critical-section-impl
       - name: Test docs
@@ -64,6 +67,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
+          version: "=0.5.28"
       - name: Install cargo-udeps
         uses: baptiste0928/cargo-install@v2
         with:
@@ -84,6 +88,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-hack
+          version: "=0.5.28"
       - name: Verifiy MSRV
         run: cargo hack build --examples --optional-deps --each-feature
   on-target-build:


### PR DESCRIPTION
The latest version of cargo-hack does no longer compile with our MSRV, see https://github.com/rp-rs/rp-hal/actions/runs/5776719346/job/15656129384?pr=660

Version 0.5.28 did work:
https://github.com/rp-rs/rp-hal/actions/runs/5767856400/job/15640265924o

Therefore, lock the version we install in our workflow to that version.