### PR TITLE
Add function to enable multiple PWM slices at the same time

### DIFF
--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -501,17 +501,16 @@ impl Slices {
         self._pwm
     }
 
-    //     /// Enable multiple slices at the same time to make their counters sync up.
-    //     ///
-    //     /// You still need to call `slice` to get an actual slice
-    //     pub fn enable_simultaneous<S: SliceId>(&mut self, bits: u8) {
-    //         // Enable all slices at the same time
-    //         unsafe {
-    //             &(*pac::PWM::ptr())
-    //                 .en
-    //                 .modify(|r, w| w.bits(((r.bits() as u8) | bits) as u32));
-    //         }
-    //     }
+    /// Enable multiple slices at the same time to make their counters sync up.
+    ///
+    /// You still need to call `slice` to get an actual slice
+    pub fn enable_simultaneous(&mut self, bits: u8) {
+        // Enable multiple slices at the same time
+        unsafe {
+            let reg = self._pwm.en.as_ptr();
+            write_bitmask_set(reg, bits as u32);
+        }
+    }
 
     // /// Get pwm slice based on gpio pin
     // pub fn borrow_mut_from_pin<


### PR DESCRIPTION
This is needed to be able to have e.g. 3 PWM slices that are in phase, but may use different duty cycles.

Example usage: `pwm_slices.enable_simultaneous(0b0000_0111);`

Demo
----

Phases between slices before this fix, using
```
    pwm0.enable();
    pwm1.enable();
```

![IMG-6377](https://github.com/rp-rs/rp-hal/assets/1351150/9748b9e0-5717-4d98-8a08-70340be70221)


Phases between slices after this fix, using
```
pwm_slices.enable_simultaneous(0b0000_0111);
```
![IMG-6378](https://github.com/rp-rs/rp-hal/assets/1351150/b6618253-c780-41f2-b07d-93d61f4de1fd)
