### PR TITLE
Disable clippy lint needless_pass_by_ref_mut

### DIFF
--- a/rp2040-hal/src/rtc/mod.rs
+++ b/rp2040-hal/src/rtc/mod.rs
@@ -51,6 +51,8 @@ impl RealTimeClock {
     ///
     /// [`ClocksManager`]: ../clocks/struct.ClocksManager.html
     /// [`clocks`]: ../clocks/index.html
+    #[allow(unknown_lints)]
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn new(
         rtc: RTC,
         clock: RtcClock,

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -272,6 +272,8 @@ fn calculate_baudrate_dividers(
 }
 
 /// Baudrate configuration. Code loosely inspired from the C SDK.
+#[allow(unknown_lints)]
+#[allow(clippy::needless_pass_by_ref_mut)]
 fn configure_baudrate<U: UartDevice>(
     device: &mut U,
     wanted_baudrate: HertzU32,

--- a/rp2040-hal/src/vector_table.rs
+++ b/rp2040-hal/src/vector_table.rs
@@ -40,6 +40,8 @@ impl VectorTable {
     }
 
     /// Initialise our vector table by copying the current table on top of it
+    #[allow(unknown_lints)]
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn init(&mut self, ppb: &mut crate::pac::PPB) {
         let vector_table = ppb.vtor.read().bits();
         unsafe {
@@ -77,6 +79,8 @@ impl VectorTable {
     /// # Safety
     /// Until the vector table has valid entries, activating it will cause an unhandled hardfault!
     /// You must call init() first.
+    #[allow(unknown_lints)]
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub unsafe fn activate(&mut self, ppb: &mut crate::pac::PPB) {
         ppb.vtor
             .write(|w| w.bits(&mut self.table as *mut _ as *mut u32 as u32));


### PR DESCRIPTION
We sometimes use &mut to guarantee exclusive access to some ressource, where the compiler can't see that such a guarantee is needed for soundness. Therefore, warnings about needles &mut references should not be generated.

Without this change, starting from rust 1.73 (currently in beta), the following clippy warnings will be generated:
```
warning: this argument is a mutable reference, but not used mutably 
  --> rp2040-hal/src/rtc/mod.rs:57:17 
   | 
57 |         resets: &mut RESETS, 
   |                 ^^^^^^^^^^^ help: consider changing to: `&RESETS` 
   | 
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut 
   = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default 
 
warning: this argument is a mutable reference, but not used mutably 
   --> rp2040-hal/src/uart/peripheral.rs:278:13 
    | 
278 |     device: &mut U, 
    |             ^^^^^^ help: consider changing to: `&U` 
    | 
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut 
 
warning: this argument is a mutable reference, but not used mutably 
  --> rp2040-hal/src/vector_table.rs:43:33 
   | 
43 |     pub fn init(&mut self, ppb: &mut crate::pac::PPB) { 
   |                                 ^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&crate::pac::PPB` 
   | 
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut 
 
warning: this argument is a mutable reference, but not used mutably 
  --> rp2040-hal/src/vector_table.rs:80:44 
   | 
80 |     pub unsafe fn activate(&mut self, ppb: &mut crate::pac::PPB) { 
   |                                            ^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&crate::pac::PPB` 
   | 
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut 
 
warning: `rp2040-hal` (lib) generated 4 warnings
```