### PR TITLE
feat: add `DynI2c`

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -120,6 +120,10 @@ name = "dht11"
 required-features = ["critical-section-impl"]
 
 [[example]]
+name = "dyn-i2c"
+required-features = ["critical-section-impl"]
+
+[[example]]
 name = "gpio_in_out"
 required-features = ["critical-section-impl"]
 

--- a/rp2040-hal/examples/dyn-i2c.rs
+++ b/rp2040-hal/examples/dyn-i2c.rs
@@ -74,20 +74,24 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    // Create the I²C drive. The pins are acquired without taking
-    // ownership from `pins` - the developer is in charge of ensuring
-    // that nothing else uses I2C0 and the pins.
+    // Create the I²C drive, using the two pre-configured pins. This will fail
+    // at compile time if the pins are in the wrong mode, or wrong pull type.
+    // It is your responsibility to ensure that the pins aren't being used
+    // elsewhere, and that they match the I²C peripheral! The pins will be
+    // automatically configured to have the correct schmitt mode and slew rate.
     let mut i2c = hal::I2C::new_controller(
         unsafe { pac::Peripherals::steal().I2C0 },
         unsafe {
             new_pin(pins.gpio18.id())
                 .try_into_function()
                 .unwrap_or_else(|_| panic!("gpio18 couldn't be allocated"))
+                .into_pull_type()
         },
         unsafe {
             new_pin(pins.gpio19.id())
                 .try_into_function()
                 .unwrap_or_else(|_| panic!("gpio19 couldn't be allocated"))
+                .into_pull_type()
         },
         400.kHz().into(),
         &mut pac.RESETS,

--- a/rp2040-hal/examples/dyn-i2c.rs
+++ b/rp2040-hal/examples/dyn-i2c.rs
@@ -1,0 +1,107 @@
+//! # I²C Example
+//!
+//! This application demonstrates how to talk to I²C devices with an RP2040.
+//!
+//! It may need to be adapted to your particular board layout and/or pin assignment.
+//!
+//! See the `Cargo.toml` file for Copyright and license details.
+
+#![no_std]
+#![no_main]
+
+// Ensure we halt the program on panic (if we don't mention this crate it won't
+// be linked)
+use panic_halt as _;
+
+// Some traits we need
+use embedded_hal::blocking::i2c::Write;
+use fugit::RateExtU32;
+
+// Alias for our HAL crate
+use rp2040_hal as hal;
+
+// A shorter alias for the Peripheral Access Crate, which provides low-level
+// register access
+use hal::{gpio::new_pin, pac};
+
+/// The linker will place this boot block at the start of our program image. We
+/// need this to help the ROM bootloader get our code up and running.
+/// Note: This boot block is not necessary when using a rp-hal based BSP
+/// as the BSPs already perform this step.
+#[link_section = ".boot2"]
+#[used]
+pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
+
+/// External high-speed crystal on the Raspberry Pi Pico board is 12 MHz. Adjust
+/// if your board has a different frequency
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+/// Entry point to our bare-metal application.
+///
+/// The `#[rp2040_hal::entry]` macro ensures the Cortex-M start-up code calls this function
+/// as soon as all global variables and the spinlock are initialised.
+///
+/// The function configures the RP2040 peripherals, then performs a single I²C
+/// write to a fixed address.
+#[rp2040_hal::entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+
+    // Set up the watchdog driver - needed by the clock setup code
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+
+    // Configure the clocks
+    let clocks = hal::clocks::init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(pac.SIO);
+
+    // Set the pins to their default state
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // Create the I²C drive. The pins are acquired without taking
+    // ownership from `pins` - the developer is in charge of ensuring
+    // that nothing else uses I2C0 and the pins.
+    let mut i2c = hal::I2C::new_controller(
+        unsafe { pac::Peripherals::steal().I2C0 },
+        unsafe {
+            new_pin(pins.gpio18.id())
+                .try_into_function()
+                .unwrap_or_else(|_| panic!("gpio18 couldn't be allocated"))
+        },
+        unsafe {
+            new_pin(pins.gpio19.id())
+                .try_into_function()
+                .unwrap_or_else(|_| panic!("gpio19 couldn't be allocated"))
+        },
+        400.kHz().into(),
+        &mut pac.RESETS,
+        (&clocks.system_clock).into(),
+    );
+
+    // Write three bytes to the I²C device with 7-bit address 0x2C
+    i2c.write(0x2c, &[1, 2, 3]).unwrap();
+
+    // Demo finish - just loop until reset
+
+    loop {
+        cortex_m::asm::wfi();
+    }
+}
+
+// End of file

--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -74,14 +74,22 @@ fn main() -> ! {
         &mut pac.RESETS,
     );
 
-    // Configure two pins as being I²C, not GPIO
-    let sda_pin = pins.gpio18.into_function::<hal::gpio::FunctionI2C>();
-    let scl_pin = pins.gpio19.into_function::<hal::gpio::FunctionI2C>();
+    // Configure two pins as being I²C and pull-up (per the datasheet), not
+    // GPIO
+    let sda_pin = pins
+        .gpio18
+        .into_function::<hal::gpio::FunctionI2C>()
+        .into_pull_type::<hal::gpio::PullUp>();
+    let scl_pin = pins
+        .gpio19
+        .into_function::<hal::gpio::FunctionI2C>()
+        .into_pull_type::<hal::gpio::PullUp>();
     // let not_an_scl_pin = pins.gpio20.into_function::<hal::gpio::FunctionI2C>();
 
     // Create the I²C drive, using the two pre-configured pins. This will fail
-    // at compile time if the pins are in the wrong mode, or if this I²C
-    // peripheral isn't available on these pins!
+    // at compile time if the pins are in the wrong mode, wrong pull type, or
+    // if this I²C peripheral isn't available on these pins! The pins will be
+    // automatically configured to have the correct schmitt mode and slew rate.
     let mut i2c = hal::I2C::i2c1(
         pac.I2C1,
         sda_pin,

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -65,7 +65,7 @@ pub mod peripheral;
 
 /// Pac I2C device with an ID known at compile time
 pub trait ConstI2cDevice: I2cDevice {
-    /// Index of the peripheral. Will be `usize::MAX` for `DynI2c`.
+    /// Index of the peripheral
     const ID: usize;
 }
 /// Pac I2C device

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -78,7 +78,7 @@ pub mod xosc;
 // Provide access to common datastructures to avoid repeating ourselves
 pub use adc::Adc;
 pub use clocks::Clock;
-pub use i2c::I2C;
+pub use i2c::{DynI2c, I2C};
 /// Attribute to declare the entry point of the program
 ///
 /// This is based on and can be used like the [entry attribute from


### PR DESCRIPTION
Adds `DynI2c`, which allows selecting the I2C peripheral at runtime. This is required for much the same reason that `DynPinId` exists. Also makes `DynPinId` work with everything I2c.

# Fixes

Page 441 of the spec sheet also indicates the following:

> Each controller must connect its clock SCL and data SDA to one pair of GPIOs. The I2C standard requires that drivers drive a signal low, or when not driven the signal will be pulled high. This applies to SCL and SDA. The GPIO pads should be configured for:
> * pull-up enabled
> * slew rate limited
> * schmitt trigger enabled 

The current examples have the exact opposite of all of the above. The I2C interface now enforces `PullUp` in addition to the existing `FunctionI2c`. The slew rate and schmitt trigger are also configured by both the controller and peripheral.

With these changes I can communicate (KB2040) with two rust-based peripherals (PI Pico) on the same I2C bus (the entire bus collapses if the pins are not configured correctly and a second device is connected).