### PR TITLE
Use same USB_PLL default setting as the C SDK

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+
+- Fixed USB PLL's VCO frequency according to updated datasheet - #688 @ithinuel, @jannic
+
 ## [0.9.0]
 
 ### MSRV

--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -127,10 +127,10 @@ pub mod common_configs {
 
     /// Default, nominal configuration for PLL_USB.
     pub const PLL_USB_48MHZ: PLLConfig = PLLConfig {
-        vco_freq: HertzU32::MHz(480),
+        vco_freq: HertzU32::MHz(1200),
         refdiv: 1,
         post_div1: 5,
-        post_div2: 2,
+        post_div2: 5,
     };
 }
 


### PR DESCRIPTION
The previously used settings used a VCO clock of 480MHz, which is outside the valid range (750MHz - 1600MHz) given by the datasheet since revision 1.8.

There are several valid VCO values, and there is a tradeoff between lower jitter and lower power consumption. So it's not obvious which value would be the best default.

Instead of doing our own guesswork, use the same value as the C SDK: https://github.com/raspberrypi/pico-sdk/pull/869/files

This patch only changes the default value, but doesn't update the input validation. So it's still possible to manually specify a VCO frequency outside the updated range, as long as it's in the more lenient range specified by older datasheet revisions, 400MHz - 1600MHz.