### PR TITLE
Removed second division by `refdiv`

### DIFF
--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -183,8 +183,8 @@ impl<D: PhaseLockedLoopDevice> PhaseLockedLoop<Disabled, D> {
         let refdiv = config.refdiv;
         let post_div1 = config.post_div1;
         let post_div2 = config.post_div2;
-        let frequency: HertzU32 = (ref_freq_hz * u32::from(fbdiv))
-            / (u32::from(post_div1) * u32::from(post_div2));
+        let frequency: HertzU32 =
+            (ref_freq_hz * u32::from(fbdiv)) / (u32::from(post_div1) * u32::from(post_div2));
 
         Ok(PhaseLockedLoop {
             state: Disabled {

--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -183,7 +183,7 @@ impl<D: PhaseLockedLoopDevice> PhaseLockedLoop<Disabled, D> {
         let refdiv = config.refdiv;
         let post_div1 = config.post_div1;
         let post_div2 = config.post_div2;
-        let frequency: HertzU32 = ((ref_freq_hz / u32::from(refdiv)) * u32::from(fbdiv))
+        let frequency: HertzU32 = (ref_freq_hz * u32::from(fbdiv))
             / (u32::from(post_div1) * u32::from(post_div2));
 
         Ok(PhaseLockedLoop {


### PR DESCRIPTION
While setting up a custom clock with `refdiv = 2`, I noticed it's post division frequency was half it's expected value; it seems that when making a new `PhaseLockedLoopDevice`, division of the reference frequency by `refdiv` occurs twice, which I assume is unintentional.