### PR TITLE
Rename private function Adc::read to Adc::inner_read

### DIFF
--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -299,7 +299,7 @@ impl Adc {
         }
     }
 
-    fn read(&mut self, chan: u8) -> u16 {
+    fn inner_read(&mut self, chan: u8) -> u16 {
         while !self.device.cs.read().ready().bit_is_set() {
             cortex_m::asm::nop();
         }
@@ -327,7 +327,7 @@ where
     fn read(&mut self, _pin: &mut SRC) -> nb::Result<WORD, Self::Error> {
         let chan = SRC::channel();
 
-        Ok(self.read(chan).into())
+        Ok(self.inner_read(chan).into())
     }
 }
 
@@ -351,7 +351,7 @@ where
             return Err(nb::Error::Other(InvalidPinError));
         };
 
-        Ok(self.read(chan).into())
+        Ok(self.inner_read(chan).into())
     }
 }
 


### PR DESCRIPTION
The name conflicts with the public trait method OneShot::read. This isn't an issue with correct programs, as rustc just uses the visible function when called from other crates.

But if you forget importing OneShot, you get a confusing error message:

```
error[E0624]: method `read` is private
   --> rp2040-hal/examples/adc.rs:116:45
    |
116 |         let temp_sens_adc_counts: u16 = adc.read(&mut temperature_sensor).unwrap();
    |                                             ^^^^ private method
    |
   ::: /home/jan/rp2040/rp-rs/rp-hal/rp2040-hal/src/adc.rs:302:5
    |
302 |     fn read(&mut self, chan: u8) -> u16 {
    |     ----------------------------------- private method defined here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
15  + use cortex_m::prelude::_embedded_hal_adc_OneShot;
    |
```

Note that the referenced method in line 302 is not the one that should be called, and also has different parameters.

(This was noticed in https://github.com/rp-rs/rp-hal-boards/issues/42)