### PR TITLE
Replace probe-run by probe-rs

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -39,4 +39,4 @@ runner = "elf2uf2-rs -d"
 
 # This runner will find a supported SWD debug probe and flash your RP2040 over
 # SWD:
-# runner = "probe-run --chip RP2040"
+# runner = "probe-rs run --chip RP2040"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -89,6 +89,8 @@ jobs:
         with:
           crate: cargo-hack
           version: "=0.5.28"
+      - name: Use older version of regex
+        run: cargo update -p regex --precise 1.9.3
       - name: Verifiy MSRV
         run: cargo hack build --examples --optional-deps --each-feature
   on-target-build:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You may also want to install these helpful tools:
 # Useful to creating UF2 images for the RP2040 USB Bootloader
 cargo install elf2uf2-rs --locked
 # Useful for flashing over the SWD pins using a supported JTAG probe
-cargo install probe-run
+cargo install probe-rs --features cli --locked
 ```
 
 ## Packages
@@ -171,26 +171,23 @@ file and copy it to your RP2040.
 $ cargo run --release --example pwm_blink
 ```
 
-### Loading with probe-run
-
-The Knurling project has a tool called
-[probe-run](https://github.com/knurling-rs/probe-run). This is a command-line
-tool which can flash a wide variety of microcontrollers using a wide variety of
-debug/JTAG probes. It is based on a library called
-[probe-rs](https://github.com/probe-rs/probe-rs). Unlike using, say, OpenOCD,
+### Loading with probe-rs
+[probe-rs](https://github.com/probe-rs/probe-rs) is a library and a
+command-line tool which can flash a wide variety of microcontrollers
+using a wide variety of debug/JTAG probes. Unlike using, say, OpenOCD,
 probe-rs can autodetect your debug probe, which can make it easier to use.
 
-*Step 1* - Install `probe-run`:
+*Step 1* - Install `probe-rs`:
 
 ```console
-$ cargo install probe-run
+$ cargo install probe-rs --features cli --locked
 ```
 
 *Step 2* - Make sure your .cargo/config contains the following:
 
 ```toml
 [target.thumbv6m-none-eabi]
-runner = "probe-run --chip RP2040"
+runner = "probe-rs run --chip RP2040"
 ```
 
 *Step 3* - Connect your USB JTAG/debug probe (such as a Raspberry Pi Pico
@@ -199,8 +196,8 @@ programming pins on your RP2040 board. Check the probe has been found by
 running:
 
 ```console
-$ probe-run --list-probes
-The following devices were found:
+$ probe-rs list
+The following debug probes were found:
 [0]: J-Link (J-Link) (VID: 1366, PID: 0101, Serial: 000099999999, JLink)
 ```
 
@@ -208,7 +205,7 @@ There is a SEGGER J-Link connected in the example above - the message you see
 will reflect the probe you have connected.
 
 *Step 4* - Use `cargo run`, which will compile the code and start the specified
-'runner'. As the 'runner' is the `probe-run` tool, it will connect to the
+'runner'. As the 'runner' is the `probe-rs` tool, it will connect to the
 RP2040 via the first probe it finds, and install your firmware into the Flash
 connected to the RP2040.
 

--- a/on-target-tests/.cargo/config.toml
+++ b/on-target-tests/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # we need probe-run to run target tests
 # note: this will be overridden by the top-level config.toml
-runner = "probe-run --chip RP2040"
+runner = "probe-rs run --chip RP2040"
 
 rustflags = [
   "-C", "link-arg=-Tdefmt.x",

--- a/on-target-tests/Cargo.toml
+++ b/on-target-tests/Cargo.toml
@@ -35,7 +35,7 @@ embedded-hal = { version = "0.2.5", features = ["unproven"] }
 
 defmt = "0.3"
 defmt-rtt = "0.4"
-defmt-test = "0.3"
+defmt-test = "0.3.1"
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
 rp2040-hal = { path = "../rp2040-hal", features = [

--- a/on-target-tests/README.md
+++ b/on-target-tests/README.md
@@ -7,7 +7,7 @@ Adding a test:
 - Add a new [[test]] to the Cargo.toml
 
 Running all tests:  
-Linux (and any other Unix-likes where probe-run are supported):
+Linux (and any other Unix-likes where probe-rs are supported):
 ```system
 ./run_tests.sh
 ```
@@ -19,7 +19,7 @@ run_tests.bat
 To run a specific test (to make developing tests faster)
 
 ```system
-CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER=probe-run cargo test --test my_new_test -- --chip rp2040
+CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run" cargo test --test my_new_test -- --chip rp2040
 ```
 
 ## Prerequisites

--- a/on-target-tests/run_tests.bat
+++ b/on-target-tests/run_tests.bat
@@ -1,6 +1,6 @@
 @rem Keep running tests even if one of them fails
 @rem We need to specify environment variables here to control build since we aren't able to override them in Cargo.toml
 
-@SET CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER=probe-run
+@SET "CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER=probe-rs run"
 
 cargo test --no-fail-fast -- --chip rp2040

--- a/on-target-tests/run_tests.sh
+++ b/on-target-tests/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 # Keep running tests even if one of them fails
-# We need to specify probe-run as our runner via environment variables here 
+# We need to specify probe-rs as our runner via environment variables here
 # to control build since we aren't able to override them in config.toml
-CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER=probe-run cargo test --no-fail-fast -- --chip rp2040
+CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run" cargo test --no-fail-fast -- --chip rp2040


### PR DESCRIPTION
Probe-run is deprecated in favour of probe-rs: https://ferrous-systems.com/blog/probe-run-deprecation/

~The on-target tests still use probe-run, they fail with probe-rs:~ on-target tests migrated to probe-rs, as well. See 3rd commit for details.

```
$ CARGO_TARGET_THUMBV6M_NONE_EABI_RUNNER="probe-rs run" cargo test --test dma_m2m_u8 -- --chip rp2040
    Finished test [optimized + debuginfo] target(s) in 0.03s
     Running tests/dma_m2m_u8.rs (target/thumbv6m-none-eabi/debug/deps/dma_m2m_u8-ebcd141c1ecc1d99)
     Erasing sectors ✔ [00:00:00] [###############################################################################################################################################################] 12.00 KiB/12.00 KiB @ 45.03 KiB/s (eta 0s )
 Programming pages   ✔ [00:00:00] [###############################################################################################################################################################] 12.00 KiB/12.00 KiB @ 21.81 KiB/s (eta 0s )    Finished in 0.867s
(1/1) running `dma_mem2mem_u8`...
all tests passed!
Frame 0: __bkpt @ 0x10001a3c inline
       ./asm/lib.rs:48:1
Frame 1: __bkpt @ 0x0000000010001a3c
       ./asm/lib.rs:51:17
Frame 2: exit @ 0x10001700
       .cargo/registry/src/index.crates.io-6f17d22bba15001f/defmt-test-0.3.0/src/export.rs:8:9
Frame 3: __defmt_test_entry @ 0x10000668
       rp-hal/on-target-tests/tests/dma_m2m_u8.rs:42:1
Frame 4: <unknown function @ 0x100001ee> @ 0x100001ee
       /home/jonas/dev/cortex-m-rt/asm.S:106:1
Error: CPU halted unexpectedly.
error: test failed, to rerun pass `--test dma_m2m_u8`

Caused by:
  process didn't exit successfully: `probe-rs run rp-hal/on-target-tests/target/thumbv6m-none-eabi/debug/deps/dma_m2m_u8-ebcd141c1ecc1d99 --chip rp2040` (exit status: 1)
```

Maybe just a different exit code returned from the cli binary?