### PR TITLE
Improve Spi device/peripheral docs

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -19,10 +19,10 @@
 //! let sclk = pins.gpio2.into_function::<FunctionSpi>();
 //! let mosi = pins.gpio3.into_function::<FunctionSpi>();
 //!
-//! let spi_pin_layout = (mosi, sclk);
 //! let spi_device = peripherals.SPI0;
+//! let spi_pin_layout = (mosi, sclk);
 //!
-//! let spi = Spi::new(spi_pin_layout, spi_device)
+//! let spi = Spi::new(spi_device, spi_pin_layout)
 //!     .init(&mut peripherals.RESETS, 125_000_000u32.Hz(), 16_000_000u32.Hz(), MODE_0);
 //! ```
 

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -22,7 +22,7 @@
 //! let spi_device = peripherals.SPI0;
 //! let spi_pin_layout = (mosi, sclk);
 //!
-//! let spi = Spi::new(spi_device, spi_pin_layout)
+//! let spi = Spi::<_, _, _, 8>::new(spi_device, spi_pin_layout)
 //!     .init(&mut peripherals.RESETS, 125_000_000u32.Hz(), 16_000_000u32.Hz(), MODE_0);
 //! ```
 

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -154,7 +154,10 @@ impl DataSize for u16 {}
 impl Sealed for u8 {}
 impl Sealed for u16 {}
 
-/// Configured Spi device.
+/// Configured Spi bus.
+///
+/// This struct implements the `embedded-hal` Spi-related traits. It represents unique ownership
+/// of the entire Spi bus of a single configured RP2040 Spi peripheral.
 ///
 /// `Spi` has four generic parameters:
 /// - `S`: a typestate for whether the bus is [`Enabled`] or [`Disabled`]. Upon initial creation,


### PR DESCRIPTION
Documents the types of the `Spi` struct and brushes up a few other docs.