### PR TITLE
Make i2c::controller pub again

### DIFF
--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -53,7 +53,11 @@ use crate::{
     typelevel::Sealed,
 };
 
-mod controller;
+/// Controller implementaion
+///
+/// This is only pub for historical reasons, to stay semver compatible with v0.9.0.
+/// It should be made private before releasing v0.10.0.
+pub mod controller;
 pub mod peripheral;
 
 /// Pac I2C device


### PR DESCRIPTION
According to cargo semver-checks, that's necessary to stay semver compatible with v0.9.0