### PR TITLE
Ensure that i2c pins have PullUp activated

### DIFF
--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -23,7 +23,7 @@ use hal::fugit::RateExtU32;
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access and a gpio related types.
 use hal::{
-    gpio::{FunctionI2C, Pin, PullUp},
+    gpio::{FunctionI2C, Pin},
     pac,
 };
 
@@ -78,8 +78,8 @@ fn main() -> ! {
     );
 
     // Configure two pins as being I²C, not GPIO
-    let sda_pin: Pin<_, FunctionI2C, PullUp> = pins.gpio18.reconfigure();
-    let scl_pin: Pin<_, FunctionI2C, PullUp> = pins.gpio19.reconfigure();
+    let sda_pin: Pin<_, FunctionI2C, _> = pins.gpio18.reconfigure();
+    let scl_pin: Pin<_, FunctionI2C, _> = pins.gpio19.reconfigure();
     // let not_an_scl_pin: Pin<_, FunctionI2C, PullUp> = pins.gpio20.reconfigure();
 
     // Create the I²C drive, using the two pre-configured pins. This will fail

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -340,8 +340,10 @@ macro_rules! hal {
 
                 $crate::paste::paste! {
                     /// Configures the I2C peripheral to work in master mode
-                    /// This function can be called without the pull-ups on the I2C pins.
-                    pub fn [<$i2cX _unchecked>]<F, SystemF>(
+                    ///
+                    /// This function can be called without activating internal pull-ups on the I2C pins.
+                    /// It should only be used if external pull-ups are provided.
+                    pub fn [<$i2cX _with_external_pull_up>]<F, SystemF>(
                         i2c: $I2CX,
                         sda_pin: Sda,
                         scl_pin: Scl,

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -12,8 +12,8 @@
 //!
 //! let mut i2c = I2C::i2c1(
 //!     peripherals.I2C1,
-//!     pins.gpio18.into_pull_up_input().into_function(), // sda
-//!     pins.gpio19.into_pull_up_input().into_function(), // scl
+//!     pins.gpio18.reconfigure(), // sda
+//!     pins.gpio19.reconfigure(), // scl
 //!     400.kHz(),
 //!     &mut peripherals.RESETS,
 //!     125_000_000.Hz(),


### PR DESCRIPTION
It is possible to skip this check by using `hal::I2C::i2c0_unchecked(...)` or `hal::I2C::i2c1_unchecked(...)`, but the default constructor functions now only accept pins with activated PullUp.

Fixes #690.