### PR TITLE
Add uart_is_busy() method for UART devices

### DIFF
--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -161,6 +161,11 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Enabled, D, P> {
         super::writer::uart_is_writable(&self.device)
     }
 
+    /// Is the UART still busy transmitting data?
+    pub fn uart_is_busy(&self) -> bool {
+        super::writer::uart_is_busy(&self.device)
+    }
+
     /// Is there data in the UART RX FIFO ready to be read?
     pub fn uart_is_readable(&self) -> bool {
         super::reader::is_readable(&self.device)

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -41,6 +41,12 @@ pub(crate) fn uart_is_writable(rb: &RegisterBlock) -> bool {
     rb.uartfr.read().txff().bit_is_clear()
 }
 
+/// Returns `true` if the UART is busy transmitting data, `false` after all
+/// bits (including stop bits) have been transmitted.
+pub(crate) fn uart_is_busy(rb: &RegisterBlock) -> bool {
+    rb.uartfr.read().busy().bit_is_set()
+}
+
 /// Writes bytes to the UART.
 ///
 /// This function writes as long as it can. As soon that the FIFO is full,


### PR DESCRIPTION
The `uart_is_busy()` method returns `true` as long as the UART is busy transmitting data.  It will return `false` once all bits (including stop bits) have been transmitted.