### PR TITLE
Properly report break conditions

### DIFF
--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -146,7 +146,7 @@ pub(crate) fn read_raw<'b, D: UartDevice>(
             }
 
             // A break condition is also a framing error.
-            // As it is the more specifc code, return
+            // As it is the more specific code, return
             // the break error.
             if read.be().bit_is_set() {
                 error = Some(ReadErrorType::Break);

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -137,16 +137,19 @@ pub(crate) fn read_raw<'b, D: UartDevice>(
                 error = Some(ReadErrorType::Overrun);
             }
 
-            if read.be().bit_is_set() {
-                error = Some(ReadErrorType::Break);
-            }
-
             if read.pe().bit_is_set() {
                 error = Some(ReadErrorType::Parity);
             }
 
             if read.fe().bit_is_set() {
                 error = Some(ReadErrorType::Framing);
+            }
+
+            // A break condition is also a framing error.
+            // As it is the more specifc code, return
+            // the break error.
+            if read.be().bit_is_set() {
+                error = Some(ReadErrorType::Break);
             }
 
             if let Some(err_type) = error {


### PR DESCRIPTION
A break condition is also a framing error. As it is the more specific code, return the break error.