### PR TITLE
Revert "Make i2c::controller pub again"

### DIFF
--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -53,11 +53,7 @@ use crate::{
     typelevel::Sealed,
 };
 
-/// Controller implementaion
-///
-/// This is only pub for historical reasons, to stay semver compatible with v0.9.0.
-/// It should be made private before releasing v0.10.0.
-pub mod controller;
+mod controller;
 pub mod peripheral;
 
 /// Pac I2C device


### PR DESCRIPTION
This reverts commit 0e0506ce94a5347c9972c72714953885108cea4b.

To be applied before the next minor release (0.10.0). (Or after creating a 0.9.x release branch, if we want to do so)