### PR TITLE
Make `Spi::free` also free up the pins

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -193,9 +193,9 @@ impl<S: State, D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<S, D, P, DS
         }
     }
 
-    /// Releases the underlying device.
-    pub fn free(self) -> D {
-        self.device
+    /// Releases the underlying device and pins.
+    pub fn free(self) -> (D, P) {
+        (self.device, self.pins)
     }
 
     /// Set device pre-scale and post-div properties to match the given baudrate as


### PR DESCRIPTION
In the case where the pins are shared with some other function, one should be able to free them up from the Spi instance. Also useful if the SPI0 will be switched between two configurations, therefore calling `Spi::new` and `Spi::free` back and forth.

Example use case is Pololu's 3Pi+ Robot which reuses SPI0 configured with different pins.
Reference C support: https://github.com/pololu/pololu-3pi-2040-robot/tree/master/c/pololu_3pi_2040_robot
WIP Rust support in `rp-hal-boards`: https://github.com/SCingolani/rp-hal-boards/tree/pololu-threepi-plus-2040