### PR TITLE
Add SM as an associated type of ValidStateMachine in pio

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -425,6 +425,8 @@ impl Sealed for SM3 {}
 pub trait ValidStateMachine: Sealed {
     /// The PIO block to which this state machine belongs.
     type PIO: PIOExt;
+    /// The index type of this state machine
+    type SM: StateMachineIndex;
 
     /// The index of this state machine (between 0 and 3).
     fn id() -> usize;
@@ -453,6 +455,7 @@ pub type PIO1SM3 = (PIO1, SM3);
 
 impl<P: PIOExt, SM: StateMachineIndex> ValidStateMachine for (P, SM) {
     type PIO = P;
+    type SM = SM;
     fn id() -> usize {
         SM::id()
     }


### PR DESCRIPTION
Since some functions in the `pio` module expect a `ValidStateMachine` and some require `(PIOExt, StateMachineIndex)` it's difficult to write generic code without access to `ValidStateMachine::SM`. This PR fixes this.