### PR TITLE
Configure ADC free running mode, separate from FIFO

### DIFF
--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -539,7 +539,7 @@ impl<'a, Word> AdcFreeRunning<'a, Word> {
     /// their defaults.
     ///
     /// Returns the underlying [`Adc`], to be reused.
-    pub fn stop(mut self) -> &'a mut Adc {
+    pub fn stop(self) -> &'a mut Adc {
         // stop capture and clear channel selection
         self.adc
             .device


### PR DESCRIPTION
I make a proof-of-concept, of how it could be if we could configure _ADC free running mode_ separate from the FIFO.

The `AdcFreeRunning` struct only has the methods from `AdcFifo` that is related to _free running mode_, but not the methods related to FIFO.

It is yet a Draft, because it only adds duplicate code. It would be best if a FIFO configuration could be "hooked up" into this, but I am not sure how.

related to #731 