### PR TITLE
Allow free-running ADC mode without FIFO

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Allow to use ADC free-running mode without FIFO.
+
 ### Changed
 
 - bump MSRV to 1.65
 - Set startup\_delay\_multiplier of XOSC to 64, and make it configurable.
   This should increase compatibility with boards where the oscillator starts up
   more slowly than on the Raspberry Pico.
+- Some reorganization of ADC code, making sure that AdcPin can only
+  be created for pins that can actually be used as ADC channels.
 
 ## [0.9.1]
 

--- a/rp2040-hal/examples/adc.rs
+++ b/rp2040-hal/examples/adc.rs
@@ -110,7 +110,7 @@ fn main() -> ! {
     let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26);
+    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26).unwrap();
     loop {
         // Read the raw ADC counts from the temperature sensor channel.
         let temp_sens_adc_counts: u16 = adc.read(&mut temperature_sensor).unwrap();

--- a/rp2040-hal/examples/adc_fifo_dma.rs
+++ b/rp2040-hal/examples/adc_fifo_dma.rs
@@ -27,10 +27,6 @@ use rp2040_hal::Clock;
 // UART related types
 use hal::uart::{DataBits, StopBits, UartConfig};
 
-// ADC related types
-use hal::adc::AdcPin;
-use hal::Adc;
-
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access
 use hal::pac;
@@ -111,13 +107,13 @@ fn main() -> ! {
     let dma = pac.DMA.split(&mut pac.RESETS);
 
     // Enable ADC
-    let mut adc = Adc::new(pac.ADC, &mut pac.RESETS);
+    let mut adc = hal::Adc::new(pac.ADC, &mut pac.RESETS);
 
     // Enable the temperature sense channel
     let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let adc_pin_0 = AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
+    let adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
 
     // we'll capture 1000 samples in total (500 per channel)
     // NOTE: when calling `shift_8bit` below, the type here must be changed from `u16` to `u8`

--- a/rp2040-hal/examples/adc_fifo_dma.rs
+++ b/rp2040-hal/examples/adc_fifo_dma.rs
@@ -27,6 +27,10 @@ use rp2040_hal::Clock;
 // UART related types
 use hal::uart::{DataBits, StopBits, UartConfig};
 
+// ADC related types
+use hal::adc::AdcPin;
+use hal::Adc;
+
 // A shorter alias for the Peripheral Access Crate, which provides low-level
 // register access
 use hal::pac;
@@ -107,13 +111,13 @@ fn main() -> ! {
     let dma = pac.DMA.split(&mut pac.RESETS);
 
     // Enable ADC
-    let mut adc = hal::Adc::new(pac.ADC, &mut pac.RESETS);
+    let mut adc = Adc::new(pac.ADC, &mut pac.RESETS);
 
     // Enable the temperature sense channel
     let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
+    let adc_pin_0 = AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
 
     // we'll capture 1000 samples in total (500 per channel)
     // NOTE: when calling `shift_8bit` below, the type here must be changed from `u16` to `u8`
@@ -129,7 +133,7 @@ fn main() -> ! {
         // sample the temperature sensor first
         .set_channel(&mut temperature_sensor)
         // then alternate between GPIO26 and the temperature sensor
-        .round_robin((&mut adc_pin_0, &mut temperature_sensor))
+        .round_robin((&adc_pin_0, &temperature_sensor))
         // Uncomment this line to produce 8-bit samples, instead of 12 bit (lower bits are discarded)
         //.shift_8bit()
         // Enable DMA transfers for the FIFO

--- a/rp2040-hal/examples/adc_fifo_dma.rs
+++ b/rp2040-hal/examples/adc_fifo_dma.rs
@@ -113,7 +113,7 @@ fn main() -> ! {
     let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input());
+    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
 
     // we'll capture 1000 samples in total (500 per channel)
     // NOTE: when calling `shift_8bit` below, the type here must be changed from `u16` to `u8`
@@ -135,7 +135,7 @@ fn main() -> ! {
         // Enable DMA transfers for the FIFO
         .enable_dma()
         // Create the FIFO, but don't start it just yet
-        .prepare();
+        .start_paused();
 
     // Start a DMA transfer (must happen before resuming the ADC FIFO)
     let dma_transfer =

--- a/rp2040-hal/examples/adc_fifo_irq.rs
+++ b/rp2040-hal/examples/adc_fifo_irq.rs
@@ -112,7 +112,7 @@ mod app {
         *c.local.adc = Some(hal::Adc::new(c.device.ADC, &mut resets));
         let adc = c.local.adc.as_mut().unwrap();
 
-        let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input());
+        let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
 
         uart.write_full_blocking(b"ADC FIFO interrupt example\r\n");
 

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -108,7 +108,7 @@ fn main() -> ! {
     let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
+    let adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
 
     // Configure free-running mode:
     let mut adc_fifo = adc
@@ -120,7 +120,7 @@ fn main() -> ! {
         // sample the temperature sensor first
         .set_channel(&mut temperature_sensor)
         // then alternate between GPIO26 and the temperature sensor
-        .round_robin((&mut adc_pin_0, &mut temperature_sensor))
+        .round_robin((&adc_pin_0, &temperature_sensor))
         // Uncomment this line to produce 8-bit samples, instead of 12 bit (lower bits are discarded)
         //.shift_8bit()
         // start sampling

--- a/rp2040-hal/examples/adc_fifo_poll.rs
+++ b/rp2040-hal/examples/adc_fifo_poll.rs
@@ -108,7 +108,7 @@ fn main() -> ! {
     let mut temperature_sensor = adc.take_temp_sensor().unwrap();
 
     // Configure GPIO26 as an ADC input
-    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input());
+    let mut adc_pin_0 = hal::adc::AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
 
     // Configure free-running mode:
     let mut adc_fifo = adc

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -141,10 +141,8 @@
 //! let mut adc = Adc::new(peripherals.ADC, &mut peripherals.RESETS);
 //! // Configure one of the pins as an ADC input
 //! let mut adc_pin_0 = AdcPin::new(pins.gpio26.into_floating_input()).unwrap();
-//! // Read at least once to configure ADC channel and trigger first conversion
-//! let _: u16 = adc.read(&mut adc_pin_0).unwrap();
 //! // Enable free-running mode
-//! adc.free_running(true);
+//! adc.free_running(&adc_pin_0);
 //! // Read the ADC counts from the ADC channel whenever necessary
 //! loop {
 //!    let pin_adc_counts: u16 = adc.read_single();
@@ -379,7 +377,7 @@ impl Adc {
     }
 
     /// Enable free-running mode by setting the start_many flag.
-    pub fn free_running<T: AnyPin>(&mut self, pin: &mut AdcPin<T>) {
+    pub fn free_running<T: AnyPin>(&mut self, pin: &AdcPin<T>) {
         self.device
             .cs()
             .modify(|_, w| w.ainsel().variant(pin.channel()).start_many().set_bit());

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -860,66 +860,60 @@ impl<Word> dma::EndlessReadTarget for DmaReadTarget<Word> {}
 /// See [`AdcFifoBuilder::round_robin`], for usage example.
 pub struct RoundRobin(u8);
 
-impl<PIN: AdcChannel> From<PIN> for RoundRobin {
-    fn from(pin: PIN) -> Self {
+impl<PIN: AdcChannel> From<&PIN> for RoundRobin {
+    fn from(pin: &PIN) -> Self {
         Self(1 << pin.channel())
     }
 }
 
-// impl<PIN: Channel<Adc, ID = u8>> From<PIN> for RoundRobin {
-//     fn from(_: PIN) -> Self {
-//         Self(1 << PIN::channel())
-//     }
-// }
-
-impl<A, B> From<(&mut A, &mut B)> for RoundRobin
+impl<A, B> From<(&A, &B)> for RoundRobin
 where
-    A: Channel<Adc, ID = u8>,
-    B: Channel<Adc, ID = u8>,
+    A: AdcChannel,
+    B: AdcChannel,
 {
-    fn from(_: (&mut A, &mut B)) -> Self {
-        Self(1 << A::channel() | 1 << B::channel())
+    fn from(pins: (&A, &B)) -> Self {
+        Self(1 << pins.0.channel() | 1 << pins.1.channel())
     }
 }
 
-impl<A, B, C> From<(&mut A, &mut B, &mut C)> for RoundRobin
+impl<A, B, C> From<(&A, &B, &C)> for RoundRobin
 where
-    A: Channel<Adc, ID = u8>,
-    B: Channel<Adc, ID = u8>,
-    C: Channel<Adc, ID = u8>,
+    A: AdcChannel,
+    B: AdcChannel,
+    C: AdcChannel,
 {
-    fn from(_: (&mut A, &mut B, &mut C)) -> Self {
-        Self(1 << A::channel() | 1 << B::channel() | 1 << C::channel())
+    fn from(pins: (&A, &B, &C)) -> Self {
+        Self(1 << pins.0.channel() | 1 << pins.1.channel() | 1 << pins.2.channel())
     }
 }
 
-impl<A, B, C, D> From<(&mut A, &mut B, &mut C, &mut D)> for RoundRobin
+impl<A, B, C, D> From<(&A, &B, &C, &D)> for RoundRobin
 where
-    A: Channel<Adc, ID = u8>,
-    B: Channel<Adc, ID = u8>,
-    C: Channel<Adc, ID = u8>,
-    D: Channel<Adc, ID = u8>,
+    A: AdcChannel,
+    B: AdcChannel,
+    C: AdcChannel,
+    D: AdcChannel,
 {
-    fn from(_: (&mut A, &mut B, &mut C, &mut D)) -> Self {
-        Self(1 << A::channel() | 1 << B::channel() | 1 << C::channel() | 1 << D::channel())
+    fn from(pins: (&A, &B, &C, &D)) -> Self {
+        Self(1 << pins.0.channel() | 1 << pins.1.channel() | 1 << pins.2.channel() | 1 << pins.3.channel())
     }
 }
 
-impl<A, B, C, D, E> From<(&mut A, &mut B, &mut C, &mut D, &mut E)> for RoundRobin
+impl<A, B, C, D, E> From<(&A, &B, &C, &D, &E)> for RoundRobin
 where
-    A: Channel<Adc, ID = u8>,
-    B: Channel<Adc, ID = u8>,
-    C: Channel<Adc, ID = u8>,
-    D: Channel<Adc, ID = u8>,
-    E: Channel<Adc, ID = u8>,
+    A: AdcChannel,
+    B: AdcChannel,
+    C: AdcChannel,
+    D: AdcChannel,
+    E: AdcChannel,
 {
-    fn from(_: (&mut A, &mut B, &mut C, &mut D, &mut E)) -> Self {
+    fn from(pins: (&A, &B, &C, &D, &E)) -> Self {
         Self(
-            1 << A::channel()
-                | 1 << B::channel()
-                | 1 << C::channel()
-                | 1 << D::channel()
-                | 1 << E::channel(),
+            1 << pins.0.channel()
+                | 1 << pins.1.channel()
+                | 1 << pins.2.channel()
+                | 1 << pins.3.channel()
+                | 1 << pins.4.channel(),
         )
     }
 }

--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -377,7 +377,7 @@ impl Adc {
     }
 
     /// Enable free-running mode by setting the start_many flag.
-    pub fn free_running<T: AnyPin>(&mut self, pin: &AdcPin<T>) {
+    pub fn free_running(&mut self, pin: &dyn AdcChannel) {
         self.device
             .cs()
             .modify(|_, w| w.ainsel().variant(pin.channel()).start_many().set_bit());


### PR DESCRIPTION
- Renamed `AdcFifoBuilder::prepare(self)` to `AdcFifoBuilder::start_paused(self)` as it more clearly describes what it does.
- Added new trait `AdcChannel`, implemented by `AdcPin` and `TempSense`. Main difference to embedded hal's `Channel` type: `AdcChannel::channel(&self)` has the `&self` parameter, so it can be sanely implemented for `DynPin`.
- Added `Adc::free_running(&mut self, pin: &dyn AdcChannel)` to configure free-running mode on an ADC
- Added `Adc::wait_ready(&self)` and `Adc::is_ready(&self)` mainly for completeness (not sure if they are useful?)
- Added `AdcFifo::trigger(&mut self)` to be able to use `AdcFifo` without free-running mode
- Added `AdcFifo::is_ready(&self)`
- Added more doc comments
