### PR TITLE
Use namespaced (`dep:`) features for optional dependencies

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -82,6 +82,15 @@ critical-section-impl = ["critical-section/restore-state-u8"]
 # Support alpha release of embedded-hal
 eh1_0_alpha = ["dep:eh1_0_alpha", "dep:eh_nb_1_0_alpha"]
 
+# Add conversion functions between chrono types and the rp2040-hal specific DateTime type
+chrono = ["dep:chrono"]
+
+# Implement `defmt::Format` for several types.
+defmt = ["dep:defmt"]
+
+# Implement `rtic_monotonic::Monotonic` based on the RP2040 timer peripheral
+rtic-monotonic = ["dep:rtic-monotonic"]
+
 [[example]]
 # irq example uses cortex-m-rt::interrupt, need rt feature for that
 name = "gpio_irq_example"

--- a/rp2040-hal/src/lib.rs
+++ b/rp2040-hal/src/lib.rs
@@ -8,8 +8,7 @@
 //! # Crate features
 //!
 //! * **chrono** -
-//!   Modifies some RTC access functions to use chrono types instead of a rp2040-hal specific
-//!   DateTime type
+//!   Add conversion functions between chrono types and the rp2040-hal specific DateTime type
 //! * **critical-section-impl** -
 //!   critical section that is safe for multicore use
 //! * **defmt** -


### PR DESCRIPTION
This is supported since rust 1.60, and makes available features more visible.