### PR TITLE
Add startup_delay_multiplier parameter to xosc initialization

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - bump MSRV to 1.65
+- Set startup\_delay\_multiplier of XOSC to 64, and make it configurable.
+  This should increase compatibility with boards where the oscillator starts up
+  more slowly than on the Raspberry Pico.
 
 ## [0.9.1]
 


### PR DESCRIPTION
This works the same way as PICO_XOSC_STARTUP_DELAY_MULTIPLIER in the Pico SDK

Closes #745