### PR TITLE
Draft: Clean up the I2C impls.

### DIFF
--- a/rp2040-hal/examples/i2c.rs
+++ b/rp2040-hal/examples/i2c.rs
@@ -17,7 +17,6 @@ use panic_halt as _;
 use rp2040_hal as hal;
 
 // Some traits we need
-use embedded_hal_0_2::blocking::i2c::Write;
 use hal::fugit::RateExtU32;
 
 // A shorter alias for the Peripheral Access Crate, which provides low-level
@@ -81,7 +80,7 @@ fn main() -> ! {
     let scl_pin: Pin<_, FunctionI2C, _> = pins.gpio19.reconfigure();
     // let not_an_scl_pin: Pin<_, FunctionI2C, PullUp> = pins.gpio20.reconfigure();
 
-    // Create the I²C drive, using the two pre-configured pins. This will fail
+    // Create the I²C driver, using the two pre-configured pins. This will fail
     // at compile time if the pins are in the wrong mode, or if this I²C
     // peripheral isn't available on these pins!
     let mut i2c = hal::I2C::i2c1(

--- a/rp2040-hal/examples/i2c_async.rs
+++ b/rp2040-hal/examples/i2c_async.rs
@@ -109,7 +109,7 @@ async fn demo() {
     }
 
     // Asynchronously write three bytes to the I²C device with 7-bit address 0x2C
-    i2c.write(0x76u8, &[1, 2, 3]).await.unwrap();
+    I2c::write(&mut i2c, 0x76u8, &[1, 2, 3]).await.unwrap();
 
     // Demo finish - just loop until reset
     core::future::pending().await

--- a/rp2040-hal/examples/i2c_async_cancelled.rs
+++ b/rp2040-hal/examples/i2c_async_cancelled.rs
@@ -128,12 +128,12 @@ async fn demo() {
 
     // Asynchronously write three bytes to the I²C device with 7-bit address 0x2C
     futures::select_biased! {
-        r = i2c.write(0x76u8, &v).fuse() => r.unwrap(),
+        r = I2c::write(&mut i2c, 0x76u8, &v).fuse() => r.unwrap(),
         _ = timeout.fuse() => {
             defmt::info!("Timed out.");
         }
     }
-    i2c.write(0x76u8, &v).await.unwrap();
+    I2c::write(&mut i2c, 0x76u8, &v).await.unwrap();
 
     // Demo finish - just loop until reset
     core::future::pending().await


### PR DESCRIPTION
Also we have inherent methods, so you can ignore the Embedded HAL traits if you want (makes the examples simpler too).

Whilst doing this I found out we only support 7-bit I2C addresses. I'll come back and fix that later.
