### PR TITLE
Use as_ptr() to retrieve pointer to register

### DIFF
--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -694,7 +694,7 @@ impl<'a, Word> AdcFifo<'a, Word> {
     /// The [`DmaReadTarget`] returned by this function can be used to initiate DMA transfers
     /// reading from the ADC.
     pub fn dma_read_target(&self) -> DmaReadTarget<Word> {
-        DmaReadTarget(self.adc.device.fifo() as *const _ as u32, PhantomData)
+        DmaReadTarget(self.adc.device.fifo().as_ptr() as u32, PhantomData)
     }
 }
 

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1432,7 +1432,7 @@ unsafe impl<SM: ValidStateMachine> ReadTarget for Rx<SM> {
 
     fn rx_address_count(&self) -> (u32, u32) {
         (
-            unsafe { &*self.block }.rxf(SM::id()) as *const _ as u32,
+            unsafe { &*self.block }.rxf(SM::id()).as_ptr() as u32,
             u32::MAX,
         )
     }
@@ -1626,7 +1626,7 @@ unsafe impl<SM: ValidStateMachine> WriteTarget for Tx<SM> {
 
     fn tx_address_count(&mut self) -> (u32, u32) {
         (
-            unsafe { &*self.block }.txf(SM::id()) as *const _ as u32,
+            unsafe { &*self.block }.txf(SM::id()).as_ptr() as u32,
             u32::MAX,
         )
     }

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -518,7 +518,7 @@ macro_rules! impl_write {
 
             fn rx_address_count(&self) -> (u32, u32) {
                 (
-                    self.device.sspdr() as *const _ as u32,
+                    self.device.sspdr().as_ptr() as u32,
                     u32::MAX,
                 )
             }
@@ -541,7 +541,7 @@ macro_rules! impl_write {
 
             fn tx_address_count(&mut self) -> (u32, u32) {
                 (
-                    self.device.sspdr() as *const _ as u32,
+                    self.device.sspdr().as_ptr() as u32,
                     u32::MAX,
                 )
             }

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -244,7 +244,7 @@ unsafe impl<D: UartDevice, P: ValidUartPinout<D>> ReadTarget for Reader<D, P> {
     }
 
     fn rx_address_count(&self) -> (u32, u32) {
-        (self.device.uartdr() as *const _ as u32, u32::MAX)
+        (self.device.uartdr().as_ptr() as u32, u32::MAX)
     }
 
     fn rx_increment(&self) -> bool {

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -200,7 +200,7 @@ unsafe impl<D: UartDevice, P: ValidUartPinout<D>> WriteTarget for Writer<D, P> {
     }
 
     fn tx_address_count(&mut self) -> (u32, u32) {
-        (self.device.uartdr() as *const _ as u32, u32::MAX)
+        (self.device.uartdr().as_ptr() as u32, u32::MAX)
     }
 
     fn tx_increment(&self) -> bool {


### PR DESCRIPTION
This is slightly less error prone than `as *const _`.