### PR TITLE
Fix several clippy and cargo doc warnings

### DIFF
--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -532,7 +532,7 @@ impl<'a, Word> AdcFifoBuilder<'a, Word> {
         self
     }
 
-    /// Enable the FIFO interrupt ([`ADC_IRQ_FIFO`](pac::Interrupt::ADC_IRQ_FIFO))
+    /// Enable the FIFO interrupt ([`ADC_IRQ_FIFO`](crate::pac::Interrupt::ADC_IRQ_FIFO))
     ///
     /// It will be triggered whenever there are at least `threshold` samples waiting in the FIFO.
     pub fn enable_interrupt(self, threshold: u8) -> Self {
@@ -606,7 +606,7 @@ impl<'a, Word> AdcFifoBuilder<'a, Word> {
         }
     }
 
-    /// Alias for [`start_paused`].
+    /// Alias for [`AdcFifoBuilder::start_paused`].
     #[deprecated(note = "Use `start_paused()` instead.", since = "0.10.0")]
     pub fn prepare(self) -> AdcFifo<'a, Word> {
         self.start_paused()
@@ -796,14 +796,14 @@ impl<'a, Word> AdcFifo<'a, Word> {
 
     /// Trigger a single conversion
     ///
-    /// Ignored unless in [`AdcFifoBuilder::manual_trigger`] mode.
+    /// Ignored when in [`Adc::free_running`] mode.
     pub fn trigger(&mut self) {
         self.adc.device.cs().modify(|_, w| w.start_once().set_bit());
     }
 
     /// Check if ADC is ready for the next conversion trigger
     ///
-    /// Only useful in [`AdcFifoBuilder::manual_trigger`] mode.
+    /// Not useful when in [`Adc::free_running`] mode.
     pub fn is_ready(&self) -> bool {
         self.adc.device.cs().read().ready().bit_is_set()
     }

--- a/rp2040-hal/src/dma/single_channel.rs
+++ b/rp2040-hal/src/dma/single_channel.rs
@@ -106,18 +106,6 @@ pub trait SingleChannel: Sealed {
     }
 }
 
-/// Trait which implements low-level functionality for transfers requiring two DMA channels.
-///
-/// Anything that requires more than a single buffer exactly once requires two channels to be
-/// combined.
-pub trait ChannelPair: SingleChannel + Sealed {
-    /// Returns the registers associated with the second DMA channel associated with this channel
-    /// pair.
-    fn ch2(&self) -> &crate::pac::dma::CH;
-    /// Returns the index of the second DMA channel.
-    fn id2(&self) -> u8;
-}
-
 impl<CH: ChannelIndex> SingleChannel for Channel<CH> {
     fn ch(&self) -> &crate::pac::dma::CH {
         self.regs()

--- a/rp2040-hal/src/float/mod.rs
+++ b/rp2040-hal/src/float/mod.rs
@@ -92,6 +92,7 @@ pub trait Float:
     }
 
     /// Returns true if `self` is infinity
+    #[allow(unused)]
     fn is_infinity(self) -> bool {
         (self.repr() & (Self::EXPONENT_MASK | Self::SIGNIFICAND_MASK)) == Self::EXPONENT_MASK
     }

--- a/rp2040-hal/src/gpio/func.rs
+++ b/rp2040-hal/src/gpio/func.rs
@@ -11,7 +11,6 @@ pub(crate) mod func_sealed {
         fn from(f: DynFunction) -> Self;
         fn as_dyn(&self) -> DynFunction;
     }
-    pub trait TypeLevelFunction {}
 }
 
 /// Type-level `enum` for pin function.
@@ -83,7 +82,6 @@ macro_rules! pin_func {
             /// Type-level `variant` for pin [`Function`].
             pub struct [<Function $fn>](pub(super) ());
             impl Function for [<Function $fn>] {}
-            impl func_sealed::TypeLevelFunction for [<Function $fn>] {}
             impl func_sealed::Function for [<Function $fn>] {
                 #[inline]
                 fn from(_f: DynFunction) -> Self {
@@ -110,7 +108,6 @@ pin_func!(Xip, Spi, Uart, I2c as I2C, Pwm, Pio0, Pio1, Clock, Usb, Null);
 /// Type-level `variant` for pin [`Function`].
 pub struct FunctionSio<C>(PhantomData<C>);
 impl<C: SioConfig> Function for FunctionSio<C> {}
-impl<C: SioConfig> func_sealed::TypeLevelFunction for FunctionSio<C> {}
 impl<C: SioConfig> func_sealed::Function for FunctionSio<C> {
     fn from(_f: DynFunction) -> Self {
         FunctionSio(PhantomData)

--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -100,7 +100,7 @@ use reg::RegisterInterface;
 
 /// Used to pin traits to a specific channel (A or B)
 pub trait ChannelId: Sealed {
-    /// Corresponding [`DynChannelId`](dyn_slice::DynChannelId)
+    /// Corresponding [`DynChannelId`]
     const DYN: DynChannelId;
 }
 
@@ -140,7 +140,7 @@ pub trait ValidSliceInputMode<I: SliceId>: Sealed + ValidSliceMode<I> {}
 
 /// Mode for slice
 pub trait SliceMode: Sealed + Sized {
-    /// Corresponding [`DynSliceMode`](dyn_slice::DynSliceMode)
+    /// Corresponding [`DynSliceMode`]
     const DYN: DynSliceMode;
 }
 
@@ -175,7 +175,7 @@ impl<I: SliceId> ValidSliceInputMode<I> for CountFallingEdge {}
 
 /// Type-level `enum` for slice IDs
 pub trait SliceId: Sealed {
-    /// Corresponding [`DynSliceId`](dyn_slice::DynSliceId)
+    /// Corresponding [`DynSliceId`]
     const DYN: DynSliceId;
     /// [`SliceMode`] at reset
     type Reset;

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -188,7 +188,7 @@ impl embedded_hal::delay::DelayNs for Timer {
     }
 }
 
-/// Implementation of the [`embedded_hal_0_2::timer`] traits using [`rp2040_hal::timer`] counter.
+/// Implementation of the [`embedded_hal_0_2::timer`] traits using [`rp2040_hal::timer`](crate::timer) counter.
 ///
 /// There is no Embedded HAL 1.0 equivalent at this time.
 ///

--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -175,7 +175,7 @@ impl Watchdog {
     }
 
     /// Start the watchdog. This enables a timer which will reboot the
-    /// rp2040 if [`feed()`] doesnot get called for the configured period.
+    /// rp2040 if [`Watchdog::feed()`] does not get called for the configured period.
     pub fn start<T: Into<MicrosDurationU32>>(&mut self, period: T) {
         const MAX_PERIOD: u32 = 0xFFFFFF;
 


### PR DESCRIPTION
Fix several warnings reported by clippy (in nightly) and cargo doc (in stable) about unused code, dangling links etc.