### PR TITLE
Fix some more nightly clippy warnings

### DIFF
--- a/rp2040-hal/src/async_utils.rs
+++ b/rp2040-hal/src/async_utils.rs
@@ -21,6 +21,13 @@ pub(crate) mod sealed {
     pub struct IrqWaker {
         waker: Mutex<Cell<Option<Waker>>>,
     }
+
+    impl Default for IrqWaker {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl IrqWaker {
         pub const fn new() -> Self {
             Self {

--- a/rp2040-hal/src/clocks/clock_sources.rs
+++ b/rp2040-hal/src/clocks/clock_sources.rs
@@ -6,12 +6,8 @@ use crate::{
         bank0::{Gpio20, Gpio22},
         FunctionClock, Pin, PullNone, PullType,
     },
-    pll::{Locked, PhaseLockedLoop},
     rosc::{Enabled, RingOscillator},
-    typelevel::Sealed,
-    xosc::{CrystalOscillator, Stable},
 };
-use pac::{PLL_SYS, PLL_USB};
 
 pub(crate) type PllSys = PhaseLockedLoop<Locked, PLL_SYS>;
 impl Sealed for PllSys {}

--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -96,6 +96,12 @@ pub struct Stack<const SIZE: usize> {
     pub mem: [usize; SIZE],
 }
 
+impl<const SIZE: usize> Default for Stack<SIZE> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const SIZE: usize> Stack<SIZE> {
     /// Construct a stack of length SIZE, initialized to 0
     pub const fn new() -> Stack<SIZE> {

--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -2,7 +2,7 @@
 // See [Chapter 2 Section 18](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
 
 use core::{
-    convert::{Infallible, TryInto},
+    convert::Infallible,
     marker::PhantomData,
     ops::{Deref, Range, RangeInclusive},
 };

--- a/rp2040-hal/src/rtc/datetime.rs
+++ b/rp2040-hal/src/rtc/datetime.rs
@@ -34,7 +34,7 @@ pub struct DateTime {
     pub month: u8,
     /// 1..28,29,30,31 depending on month
     pub day: u8,
-    ///
+    /// The day of week
     pub day_of_week: DayOfWeek,
     /// 0..23
     pub hour: u8,

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -626,6 +626,12 @@ pub struct LaneCtrl {
     pub shift: u8,
 }
 
+impl Default for LaneCtrl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LaneCtrl {
     /// Default configuration. Normal operation, unsigned, mask keeps all bits, no shift.
     pub const fn new() -> Self {

--- a/rp2040-hal/src/usb.rs
+++ b/rp2040-hal/src/usb.rs
@@ -106,7 +106,7 @@
 //! ```
 
 use core::cell::RefCell;
-use critical_section::{self, Mutex};
+use critical_section::Mutex;
 
 use usb_device::{
     bus::{PollResult, UsbBus as UsbBusTrait},

--- a/rp2040-hal/src/vector_table.rs
+++ b/rp2040-hal/src/vector_table.rs
@@ -30,6 +30,12 @@ pub struct VectorTable {
     table: [Vector; 48],
 }
 
+impl Default for VectorTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VectorTable {
     /// Create a new vector table. All entries will point to 0 - you must call init()
     /// on this to copy the current vector table before setting it as active

--- a/rp2040-hal/src/xosc.rs
+++ b/rp2040-hal/src/xosc.rs
@@ -1,7 +1,6 @@
 //! Crystal Oscillator (XOSC)
 // See [Chapter 2 Section 16](https://datasheets.raspberrypi.org/rp2040/rp2040_datasheet.pdf) for more details
 
-use core::convert::TryInto;
 use core::{convert::Infallible, ops::RangeInclusive};
 
 use fugit::HertzU32;


### PR DESCRIPTION
I'm not sure how useful these `Default` implementations are in practice. But I like the pattern "if there is a non-argument new() constructor, `Default` should be implemented as well".
https://rust-lang.github.io/rust-clippy/master/index.html#/new_without_default