### PR TITLE
Implement embedded_io traits for Reader/Writer

### DIFF
--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -218,6 +218,16 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Reader<D, P> {
     }
 }
 
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType for Reader<D, P> {
+    type Error = ReadErrorType;
+}
+
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Read for Reader<D, P> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        nb::block!(self.read_raw(buf)).map_err(|e| e.err_type)
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> Read02<u8> for Reader<D, P> {
     type Error = ReadErrorType;
 

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -174,6 +174,21 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Writer<D, P> {
     }
 }
 
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType for Writer<D, P> {
+    type Error = Infallible;
+}
+
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Write for Writer<D, P> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.write_full_blocking(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        nb::block!(transmit_flushed(&self.device)).unwrap(); // Infallible
+        Ok(())
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> Write02<u8> for Writer<D, P> {
     type Error = Infallible;
 


### PR DESCRIPTION
The embedde_io traits were already implemented for the unsplit peripheral, https://github.com/rp-rs/rp-hal/blob/main/rp2040-hal/src/uart/peripheral.rs#L421-L445.

This adds implementations for the Reader and Writer types.