### PR TITLE
Fix `float_to_fix64` return value & f32 trig function doc corrections

### DIFF
--- a/rp2040-hal/src/rom_data.rs
+++ b/rp2040-hal/src/rom_data.rs
@@ -478,13 +478,13 @@ pub mod float_funcs {
         /// nearest(v/(2^n))`
         0x38 ufix_to_float(v: u32, n: i32) -> f32;
         /// Calculates the cosine of `angle`. The value
-        /// of `angle` is in radians, and must be in the range `-1024` to `1024`
+        /// of `angle` is in radians, and must be in the range `-128` to `128`
         0x3c fcos(angle: f32) -> f32;
         /// Calculates the sine of `angle`. The value of
-        /// `angle` is in radians, and must be in the range `-1024` to `1024`
+        /// `angle` is in radians, and must be in the range `-128` to `128`
         0x40 fsin(angle: f32) -> f32;
         /// Calculates the tangent of `angle`. The value
-        /// of `angle` is in radians, and must be in the range `-1024` to `1024`
+        /// of `angle` is in radians, and must be in the range `-128` to `128`
         0x44 ftan(angle: f32) -> f32;
 
         // 0x48 is deprecated
@@ -566,7 +566,7 @@ pub mod float_funcs {
         /// 16) == 0x8000`. This method rounds towards -Infinity, and clamps the
         /// resulting integer to lie within the range `-0x8000000000000000` to
         /// `0x7FFFFFFFFFFFFFFF`
-        0x70 float_to_fix64(v: f32, n: i32) -> f32;
+        0x70 float_to_fix64(v: f32, n: i32) -> i64;
         /// Converts an f32 to an unsigned 64-bit
         /// integer, rounding towards -Infinity, and clamping the result to lie
         /// within the range `0x0000000000000000` to `0xFFFFFFFFFFFFFFFF`


### PR DESCRIPTION
The current return argument for `float_to_fix64()` is `f32`, which doesn't make sense and is at odds with the definition in the pico SDK. This PR replaces it with the correct type.

The function as exposed by the SDK is here:
https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_float/include/pico/float.h#L44
It returns an `int64`, so I've updated rom_data.rs to match. I tested this on my pico by converting a small set of `f32`s to fix64 with the change in this PR, then back through `fix64_to_float()` and the values match up.

This is a breaking change, though given that the return argument was both the wrong type and the wrong size, I'm not sure if anyone could really have used this function as it currently stands.

Additionally, the function descriptions for fcos, fsin, and ftan state a valid range of -1024 to 1024, but the datasheet gives a range of -128 to 128 on page 140. Note that the valid range for doubles is specified as -1024 to 1024 on page 143. 
