### PR TITLE
Slightly improve deprecation note on from_program

### DIFF
--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1997,7 +1997,9 @@ impl<P: PIOExt> PIOBuilder<P> {
     /// defaults to `ShiftDirection::Left`, which is different from the
     /// rp2040 reset value. The alternative [`Self::from_installed_program`],
     /// fixes this.
-    #[deprecated(note = "please use `from_installed_program` instead")]
+    #[deprecated(
+        note = "please use `from_installed_program` instead and update shift direction if necessary"
+    )]
     pub fn from_program(p: InstalledProgram<P>) -> Self {
         PIOBuilder {
             clock_divisor: (1, 0),


### PR DESCRIPTION
As noticed in https://github.com/rp-rs/rp-hal/pull/791, the existing deprecation note doesn't mention that `from_installed_program` isn't an identical replacement for `from_program`. That can misguide people to just replace the function call without noticing the changed shift direction.