### PR TITLE
Preparations for release 0.10.1

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2024-04-28
+
+### Added
+
+- Implement send_break support - #700 @ithinuel
+- Implement embedded_io traits for Reader/Writer - #781 @jannic
+
+### Changed
+
+- Fix debugging after halt() - #785 @jannic
+- Slightly improve deprecation note on from_program - #792 @jannic
+- Fix float_to_fix64 return value & f32 trig function doc corrections - #787 @Text-Input
+- Simplify ceiling division in delay calculation - #783 @jannic
+
 ## [0.10.0] - 2024-03-10
 
 ### Added
@@ -391,7 +405,8 @@ The Minimum-Supported Rust Version (MSRV) for this release is 1.54.
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/rp-rs/rp-hal/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/rp-rs/rp-hal/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/rp-rs/rp-hal/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/rp-rs/rp-hal/compare/v0.8.1...v0.9.0

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-hal"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The rp-rs Developers"]
 edition = "2021"
 homepage = "https://github.com/rp-rs/rp-hal"

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -1979,7 +1979,9 @@ impl<P: PIOExt> PIOBuilder<P> {
     /// defaults to `ShiftDirection::Left`, which is different from the
     /// rp2040 reset value. The alternative [`Self::from_installed_program`],
     /// fixes this.
-    #[deprecated(note = "please use `from_installed_program` instead")]
+    #[deprecated(
+        note = "please use `from_installed_program` instead and update shift direction if necessary"
+    )]
     pub fn from_program(p: InstalledProgram<P>) -> Self {
         PIOBuilder {
             clock_divisor: (1, 0),

--- a/rp2040-hal/src/rom_data.rs
+++ b/rp2040-hal/src/rom_data.rs
@@ -478,13 +478,13 @@ pub mod float_funcs {
         /// nearest(v/(2^n))`
         0x38 ufix_to_float(v: u32, n: i32) -> f32;
         /// Calculates the cosine of `angle`. The value
-        /// of `angle` is in radians, and must be in the range `-1024` to `1024`
+        /// of `angle` is in radians, and must be in the range `-128` to `128`
         0x3c fcos(angle: f32) -> f32;
         /// Calculates the sine of `angle`. The value of
-        /// `angle` is in radians, and must be in the range `-1024` to `1024`
+        /// `angle` is in radians, and must be in the range `-128` to `128`
         0x40 fsin(angle: f32) -> f32;
         /// Calculates the tangent of `angle`. The value
-        /// of `angle` is in radians, and must be in the range `-1024` to `1024`
+        /// of `angle` is in radians, and must be in the range `-128` to `128`
         0x44 ftan(angle: f32) -> f32;
 
         // 0x48 is deprecated
@@ -566,7 +566,7 @@ pub mod float_funcs {
         /// 16) == 0x8000`. This method rounds towards -Infinity, and clamps the
         /// resulting integer to lie within the range `-0x8000000000000000` to
         /// `0x7FFFFFFFFFFFFFFF`
-        0x70 float_to_fix64(v: f32, n: i32) -> f32;
+        0x70 float_to_fix64(v: f32, n: i32) -> i64;
         /// Converts an f32 to an unsigned 64-bit
         /// integer, rounding towards -Infinity, and clamping the result to lie
         /// within the range `0x0000000000000000` to `0xFFFFFFFFFFFFFFFF`

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -218,6 +218,16 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Reader<D, P> {
     }
 }
 
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType for Reader<D, P> {
+    type Error = ReadErrorType;
+}
+
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Read for Reader<D, P> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        nb::block!(self.read_raw(buf)).map_err(|e| e.err_type)
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> Read02<u8> for Reader<D, P> {
     type Error = ReadErrorType;
 

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -172,6 +172,40 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Writer<D, P> {
     pub fn disable_tx_interrupt(&mut self) {
         disable_tx_interrupt(&self.device)
     }
+
+    /// Initiates a break
+    ///
+    /// If transmitting, this takes effect immediately after the current byte has completed.  
+    /// For proper execution of the break command, this must be held for at least 2 complete frames
+    /// worth of time.
+    ///
+    /// <div class="warning">The device won’t be able to send anything while breaking.</div>
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use rp2040_hal::uart::{Pins, ValidUartPinout, Enabled, UartPeripheral};
+    /// # use rp2040_hal::pac::UART0;
+    /// # use rp2040_hal::typelevel::OptionTNone;
+    /// # use embedded_hal_0_2::blocking::delay::DelayUs;
+    /// # type PINS = Pins<OptionTNone, OptionTNone, OptionTNone, OptionTNone>;
+    /// # let mut serial: UartPeripheral<Enabled, UART0, PINS> = unsafe { core::mem::zeroed() };
+    /// # let mut timer: rp2040_hal::Timer = unsafe { core::mem::zeroed() };
+    /// serial.lowlevel_break_start();
+    /// // at 115_200Bps on 8N1 configuration, 20bits takes (20*10⁶)/115200 = 173.611…μs.
+    /// timer.delay_us(175);
+    /// serial.lowlevel_break_stop();
+    /// ```
+    pub fn lowlevel_break_start(&mut self) {
+        self.device.uartlcr_h().modify(|_, w| w.brk().set_bit());
+    }
+
+    /// Terminates a break condition.
+    ///
+    /// See `lowlevel_break_start` for more details.
+    pub fn lowlevel_break_stop(&mut self) {
+        self.device.uartlcr_h().modify(|_, w| w.brk().clear_bit());
+    }
 }
 
 impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType for Writer<D, P> {

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -174,6 +174,21 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Writer<D, P> {
     }
 }
 
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType for Writer<D, P> {
+    type Error = Infallible;
+}
+
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Write for Writer<D, P> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.write_full_blocking(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        nb::block!(transmit_flushed(&self.device)).unwrap(); // Infallible
+        Ok(())
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> Write02<u8> for Writer<D, P> {
     type Error = Infallible;
 


### PR DESCRIPTION
Update CHANGELOG.md 
Set version to 0.10.1 in preparation for the release

This is a rebase of changes from main on top of 0.10.0, excluding PIO DMA changes:

Here is the selection of commits used via rebase -i
```text
pick 4a677a6 Simplify ceiling division in delay calculation
pick caa0ea0 Fix float_to_fix64 return value & docs for f32 trig functions
drop 9947302 Enable transfer size of PIO DMA to be specified
drop 6ce5672 Add some more type params
drop caaef72 Remove type params on `build` to avoid inference failures
drop 36a05f2 Fix Tx::transfer_size
drop efe574a Move TransferSize to `dma` module
pick 48dbfcc Slightly improve deprecation note on from_program
pick effcc46 Fix debugging after halt()
pick 0d819d3 Implement embedded_io traits for Reader/Writer
pick 8e15127 Implement `send_break` support
```

Leaving this as a draft PR so it doesn't get merged. Will tag the final commit hash as v0.10.1 and close this PR when reviewed.