### PR TITLE
Preperations for release 0.10.2

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2024-04-28
+
+### Changed
+
+- Move TransferSize to dma module - #790 @jsgf
+- Enable transfer size of PIO DMA to be specified - #788 @jsgf
+
+## [0.10.1] - 2024-04-28
+
+### Added
+
+- Implement send_break support - #700 @ithinuel
+- Implement embedded_io traits for Reader/Writer - #781 @jannic
+
+### Changed
+
+- Fix debugging after halt() - #785 @jannic
+- Slightly improve deprecation note on from_program - #792 @jannic
+- Fix float_to_fix64 return value & f32 trig function doc corrections - #787 @Text-Input
+- Simplify ceiling division in delay calculation - #783 @jannic
+
 ## [0.10.0] - 2024-03-10
 
 ### Added
@@ -391,7 +412,9 @@ The Minimum-Supported Rust Version (MSRV) for this release is 1.54.
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.10.2...HEAD
+[0.10.2]: https://github.com/rp-rs/rp-hal/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/rp-rs/rp-hal/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/rp-rs/rp-hal/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/rp-rs/rp-hal/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/rp-rs/rp-hal/compare/v0.8.1...v0.9.0

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp2040-hal"
-version = "0.10.0"
+version = "0.10.2"
 authors = ["The rp-rs Developers"]
 edition = "2021"
 homepage = "https://github.com/rp-rs/rp-hal"


### PR DESCRIPTION
Update CHANGELOG.md
Set version to 0.10.2 in preparation for the release

This is based on main, not 0.10.x branch.
The only changes from 0.10.1 -> 0.10.2 are the PIO DMA transfer size changes. We *think* these are not breaking changes, so we're doing 0.10.1 and 0.10.2 as a tactical release strategy - will yank 0.10.2 if this release causes people grief.

See #796 for the changes that were cherry-picked from main for that release.