### PR TITLE
This adds a test-case covering the fix from PR #799

### DIFF
--- a/on-target-tests/tests/gpio.rs
+++ b/on-target-tests/tests/gpio.rs
@@ -149,4 +149,15 @@ mod tests {
         cortex_m::asm::delay(10);
         assert_eq!(group.read(), 0b1010);
     }
+
+    #[test]
+    fn read_adc() {
+        use embedded_hal_0_2::adc::OneShot;
+
+        // Safety: Test cases do not run in parallel
+        let mut pac = unsafe { pac::Peripherals::steal() };
+        let mut adc = hal::Adc::new(pac.ADC, &mut pac.RESETS);
+        let mut temp_sensor = hal::adc::Adc::take_temp_sensor(&mut adc).unwrap();
+        let _temperature: u16 = adc.read(&mut temp_sensor).unwrap();
+    }
 }


### PR DESCRIPTION
This test just hangs without the fix from #799. Is there an easy way to set a timeout in defmt-tests? Of course the test case could configure the watchdog, but that would quite some boilerplate to an otherwise simple test case.

Still better than no test at all.