### PR TITLE
Add support for aborting DMA transfers

### DIFF
--- a/rp2040-hal/src/dma/single_channel.rs
+++ b/rp2040-hal/src/dma/single_channel.rs
@@ -31,6 +31,11 @@ pub trait SingleChannel: Sealed {
         }
     }
 
+    /// Check if the DMA_IRQ_0 signal for this channel is enabled.
+    fn is_enabled_irq0(&mut self) -> bool {
+        unsafe { ((*DMA::ptr()).inte0().read().bits() & (1 << self.id())) != 0 }
+    }
+
     #[deprecated(note = "Renamed to disable_irq0")]
     /// Disables the DMA_IRQ_0 signal for this channel.
     fn unlisten_irq0(&mut self) {
@@ -73,6 +78,11 @@ pub trait SingleChannel: Sealed {
         unsafe {
             write_bitmask_set((*DMA::ptr()).inte1().as_ptr(), 1 << self.id());
         }
+    }
+
+    /// Check if the DMA_IRQ_1 signal for this channel is enabled.
+    fn is_enabled_irq1(&mut self) -> bool {
+        unsafe { ((*DMA::ptr()).inte1().read().bits() & (1 << self.id())) != 0 }
     }
 
     #[deprecated(note = "Renamed to disable_irq1")]


### PR DESCRIPTION
This MR implements support for aborting DMA transfers, following 2.5.5.3 of the datasheet and #722.

This should close #722.