### PR TITLE
Fix set_low() and set_high() implementation for OutputPin

### DIFF
--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -1465,8 +1465,8 @@ mod eh1 {
     use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
 
     use super::{
-        func, AnyPin, AsInputPin, Error, FunctionSio, InOutPin, Pin, PinId, PullType, SioConfig,
-        SioInput, SioOutput,
+        func, AnyPin, AsInputPin, Error, FunctionSio, InOutPin, OutputEnableOverride, Pin, PinId,
+        PullType, SioConfig, SioInput, SioOutput,
     };
 
     impl<I, P, S> ErrorType for Pin<I, FunctionSio<S>, P>
@@ -1558,12 +1558,17 @@ mod eh1 {
         I: AnyPin,
     {
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            self.inner._set_low();
+            // The pin is already set to output low but this is inhibited by the override.
+            self.inner
+                .set_output_enable_override(OutputEnableOverride::Enable);
             Ok(())
         }
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            self.inner._set_high();
+            // To set the open-drain pin to high, just disable the output driver by configuring the
+            // output override. That way, the DHT11 can still pull the data line down to send its response.
+            self.inner
+                .set_output_enable_override(OutputEnableOverride::Disable);
             Ok(())
         }
     }


### PR DESCRIPTION
There is a bug in the implementation of  `set_low()` and `set_high()` functions in `OutputPin` for embedded-hal 1.0. The call to `set_low()` doesn't have any effect because `set_output_enable_override(OutputEnableOverride::Disable)` was set inside `new`

The fix aligns the implementation to be the same as used for embedded-hal 0.2 traits