### PR TITLE
Base CountDown on Timer instead of &Timer

### DIFF
--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -88,9 +88,9 @@ impl Timer {
     }
 
     /// Initialized a Count Down instance without starting it.
-    pub fn count_down(&self) -> CountDown<'_> {
+    pub fn count_down(&self) -> CountDown {
         CountDown {
-            timer: self,
+            timer: *self,
             period: MicrosDurationU64::nanos(0),
             next_end: None,
         }
@@ -213,13 +213,13 @@ impl embedded_hal::delay::DelayNs for Timer {
 /// // Cancel it immediately
 /// count_down.cancel();
 /// ```
-pub struct CountDown<'timer> {
-    timer: &'timer Timer,
+pub struct CountDown {
+    timer: Timer,
     period: MicrosDurationU64,
     next_end: Option<u64>,
 }
 
-impl embedded_hal_0_2::timer::CountDown for CountDown<'_> {
+impl embedded_hal_0_2::timer::CountDown for CountDown {
     type Time = MicrosDurationU64;
 
     fn start<T>(&mut self, count: T)
@@ -250,9 +250,9 @@ impl embedded_hal_0_2::timer::CountDown for CountDown<'_> {
     }
 }
 
-impl embedded_hal_0_2::timer::Periodic for CountDown<'_> {}
+impl embedded_hal_0_2::timer::Periodic for CountDown {}
 
-impl embedded_hal_0_2::timer::Cancel for CountDown<'_> {
+impl embedded_hal_0_2::timer::Cancel for CountDown {
     type Error = &'static str;
 
     fn cancel(&mut self) -> Result<(), Self::Error> {


### PR DESCRIPTION
This allows to remove the lifetime parameter from CountDown. As Timer is zero-sized, this should also reduce the size of CountDown.

Due to the removal of the lifetime parameter, this is a breaking change.

Closes #216