### PR TITLE
Extend tests in `gpio::check_pin_groups()`

### DIFF
--- a/on-target-tests/tests/gpio.rs
+++ b/on-target-tests/tests/gpio.rs
@@ -46,8 +46,8 @@ mod tests {
             &mut pac.RESETS,
             &mut watchdog,
         )
-            .ok()
-            .unwrap();
+        .ok()
+        .unwrap();
 
         let sio = hal::Sio::new(pac.SIO);
 


### PR DESCRIPTION
I was scrolling through the code and I thought I could fix this while I was at it. I just extended the tests in `gpio.rs` a _tiny_ bit.

# Changes

Replaced the uses of `assert!(x == y)` with `assert_eq!()`, so it was more clear which pin was wrong when tests failed.

Also added checks for `group.set(...)`, `group.set_u32(...)`, on top of the existing `group.toggle()`

Switch hex numbers to binary to make it easier to read the bits.