### PR TITLE
Remove -Cinline-threshold=5 option from config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,14 +23,12 @@ target = "thumbv6m-none-eabi"
 #   script. This is usually provided by the cortex-m-rt crate, and by default
 #   the version in that crate will include a file called `memory.x` which
 #   describes the particular memory layout for your specific chip. 
-# * inline-threshold=5 makes the compiler more aggressive and inlining functions
 # * no-vectorize-loops turns off the loop vectorizer (seeing as the M0+ doesn't
 #   have SIMD)
 rustflags = [
     "-C", "link-arg=--nmagic",
     "-C", "link-arg=-Tlink.x",
     "-C", "link-arg=-Tdefmt.x",
-    "-C", "inline-threshold=5",
     "-C", "no-vectorize-loops",
 ]
 


### PR DESCRIPTION
It doesn't work anyway, see https://github.com/rust-lang/rust/pull/124712