### PR TITLE
spi: move set_format to all states

### DIFF
--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -278,7 +278,7 @@ impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
     ///
     /// Valid pin sets are in the form of `(Tx, Sck)` or `(Tx, Rx, Sck)`
     ///
-    /// If you pins are dynamically identified (`Pin<DynPinId, _, _>`) they will first need to pass
+    /// If your pins are dynamically identified (`Pin<DynPinId, _, _>`) they will first need to pass
     /// validation using their corresponding [`ValidatedPinXX`](ValidatedPinTx).
     pub fn new(device: D, pins: P) -> Spi<Disabled, D, P, DS> {
         Spi {

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -247,26 +247,9 @@ impl<S: State, D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<S, D, P, DS
         // Return the frequency we were able to achieve
         (freq_in / (prescale as u32 * (1 + postdiv as u32))).Hz()
     }
-}
-
-impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
-    /// Create new not initialized Spi bus. Initialize it with [`.init`][Self::init]
-    /// or [`.init_slave`][Self::init_slave].
-    ///
-    /// Valid pin sets are in the form of `(Tx, Sck)` or `(Tx, Rx, Sck)`
-    ///
-    /// If you pins are dynamically identified (`Pin<DynPinId, _, _>`) they will first need to pass
-    /// validation using their corresponding [`ValidatedPinXX`](ValidatedPinTx).
-    pub fn new(device: D, pins: P) -> Spi<Disabled, D, P, DS> {
-        Spi {
-            device,
-            pins,
-            state: PhantomData,
-        }
-    }
 
     /// Set format and datasize
-    fn set_format(&mut self, data_bits: u8, frame_format: FrameFormat) {
+    pub fn set_format(&mut self, data_bits: u8, frame_format: FrameFormat) {
         self.device.sspcr0().modify(|_, w| unsafe {
             w.dss().bits(data_bits - 1).frf().bits(match &frame_format {
                 FrameFormat::MotorolaSpi(_) => 0x00,
@@ -286,6 +269,23 @@ impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
             }
             w
         });
+    }
+}
+
+impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
+    /// Create new not initialized Spi bus. Initialize it with [`.init`][Self::init]
+    /// or [`.init_slave`][Self::init_slave].
+    ///
+    /// Valid pin sets are in the form of `(Tx, Sck)` or `(Tx, Rx, Sck)`
+    ///
+    /// If you pins are dynamically identified (`Pin<DynPinId, _, _>`) they will first need to pass
+    /// validation using their corresponding [`ValidatedPinXX`](ValidatedPinTx).
+    pub fn new(device: D, pins: P) -> Spi<Disabled, D, P, DS> {
+        Spi {
+            device,
+            pins,
+            state: PhantomData,
+        }
     }
 
     /// Set master/slave


### PR DESCRIPTION
There are other drivers in the wild (uboot, zephyr) that set the format without disabling the peripheral, so we’ll assume it is fine to do so.