### PR TITLE
implement `embedded_io::ReadReady` and `WriteReady` traits for uart peripheral

### DIFF
--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -490,6 +490,15 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Read for UartPeripheral<
         }
     }
 }
+
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ReadReady
+    for UartPeripheral<Enabled, D, P>
+{
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.uart_is_readable())
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Write for UartPeripheral<Enabled, D, P> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.write_full_blocking(buf);
@@ -498,5 +507,13 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Write for UartPeripheral
     fn flush(&mut self) -> Result<(), Self::Error> {
         nb::block!(super::writer::transmit_flushed(&self.device)).unwrap(); // Infallible
         Ok(())
+    }
+}
+
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::WriteReady
+    for UartPeripheral<Enabled, D, P>
+{
+    fn write_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.uart_is_writable())
     }
 }

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -244,6 +244,12 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Read for Reader<D, P> {
     }
 }
 
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ReadReady for Reader<D, P> {
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(is_readable(&self.device))
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> Read02<u8> for Reader<D, P> {
     type Error = ReadErrorType;
 

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -223,6 +223,12 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Write for Writer<D, P> {
     }
 }
 
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::WriteReady for Writer<D, P> {
+    fn write_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(uart_is_writable(&self.device))
+    }
+}
+
 impl<D: UartDevice, P: ValidUartPinout<D>> Write02<u8> for Writer<D, P> {
     type Error = Infallible;
 


### PR DESCRIPTION
Implements  `embedded_io::ReadReady` and `WriteReady` traits for split and unsplit uart peripheral in terms of the already existing functions for checking if the uart is ready to read or write :rocket: 

Solves #836