### PR TITLE
Let UART write return some bytes were written

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -16,6 +16,10 @@ The Minimum-Supported Rust Version (MSRV) for the next release is 1.77
 - Support for *binary info*, which is metadata that `picotool` can read from your binary.
 - Bump MSRV to 1.77, because *binary info* examples need C-Strings.
 
+### Fixed
+
+- Let UART embedded\_io::Write::write return some bytes were written.
+
 ## [0.10.0] - 2024-03-10
 
 ### Added

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -214,8 +214,8 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType for Writer<D, 
 
 impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::Write for Writer<D, P> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.write_full_blocking(buf);
-        Ok(buf.len())
+        let remaining = nb::block!(write_raw(&self.device, buf)).unwrap(); // Infallible
+        Ok(buf.len() - remaining.len())
     }
     fn flush(&mut self) -> Result<(), Self::Error> {
         nb::block!(transmit_flushed(&self.device)).unwrap(); // Infallible


### PR DESCRIPTION
embedded_io::Write::write(buf) should not block until the full buffer was written. Instead, it should only block until at least one byte was written.

(See https://github.com/rp-rs/rp-hal/pull/837#issuecomment-2305371353)