### PR TITLE
Sync pio_side_set examples

### DIFF
--- a/rp2040-hal-examples/src/bin/pio_side_set.rs
+++ b/rp2040-hal-examples/src/bin/pio_side_set.rs
@@ -6,12 +6,15 @@
 #![no_std]
 #![no_main]
 
+use rp2040_hal as hal;
+
 use hal::gpio::{FunctionPio0, Pin};
-use hal::pac;
 use hal::pio::PIOExt;
 use hal::Sio;
+
+// Ensure we halt the program on panic (if we don't mention this crate it won't
+// be linked)
 use panic_halt as _;
-use rp2040_hal as hal;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -23,11 +26,11 @@ pub static BOOT2: [u8; 256] = rp2040_boot2::BOOT_LOADER_GENERIC_03H;
 
 /// Entry point to our bare-metal application.
 ///
-/// The `#[rp2040_hal::entry]` macro ensures the Cortex-M start-up code calls this function
+/// The `#[hal::entry]` macro ensures the Cortex-M start-up code calls this function
 /// as soon as all global variables and the spinlock are initialised.
-#[rp2040_hal::entry]
+#[hal::entry]
 fn main() -> ! {
-    let mut pac = pac::Peripherals::take().unwrap();
+    let mut pac = hal::pac::Peripherals::take().unwrap();
 
     let sio = Sio::new(pac.SIO);
     let pins = hal::gpio::Pins::new(
@@ -44,10 +47,10 @@ fn main() -> ! {
 
     // Define some simple PIO program.
     let program = pio_proc::pio_asm!(
-        ".side_set 1", // each instruction may set 1 bit
+        ".side_set 1", // each instruction must set 1 bit
         ".wrap_target",
-        "    nop side 1",
-        "    nop side 0",
+        "    nop side 1 [15]",
+        "    nop side 0 [15]",
         ".wrap",
     );
 
@@ -55,7 +58,7 @@ fn main() -> ! {
     let (mut pio, sm0, _, _, _) = pac.PIO0.split(&mut pac.RESETS);
     let installed = pio.install(&program.program).unwrap();
     let (int, frac) = (0, 0); // as slow as possible (0 is interpreted as 65536)
-    let (mut sm, _, _) = rp2040_hal::pio::PIOBuilder::from_installed_program(installed)
+    let (mut sm, _, _) = hal::pio::PIOBuilder::from_installed_program(installed)
         .side_set_pin_base(led_pin_id)
         .clock_divisor_fixed_point(int, frac)
         .build(sm0);
@@ -68,3 +71,16 @@ fn main() -> ! {
         cortex_m::asm::wfi();
     }
 }
+
+/// Program metadata for `picotool info`
+#[link_section = ".bi_entries"]
+#[used]
+pub static PICOTOOL_ENTRIES: [hal::binary_info::EntryAddr; 5] = [
+    hal::binary_info::rp_cargo_bin_name!(),
+    hal::binary_info::rp_cargo_version!(),
+    hal::binary_info::rp_program_description!(c"PIO Side-set Example"),
+    hal::binary_info::rp_cargo_homepage_url!(),
+    hal::binary_info::rp_program_build_attribute!(),
+];
+
+// End of file

--- a/rp235x-hal-examples/src/bin/pio_side_set.rs
+++ b/rp235x-hal-examples/src/bin/pio_side_set.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
 
     // Define some simple PIO program.
     let program = pio_proc::pio_asm!(
-        ".side_set 1", // each instruction may set 1 bit
+        ".side_set 1", // each instruction must set 1 bit
         ".wrap_target",
         "    nop side 1 [15]",
         "    nop side 0 [15]",


### PR DESCRIPTION
The rp2040 and rp235x example of pio_side_set have diverged a bit. Port the changes made to the rp235x back to rp2040, where applicable.

Also update a comment, as suggested in https://github.com/rp-rs/pio-rs/issues/62