### PR TITLE
Interrupts on RISC-V

### DIFF
--- a/rp235x-hal-examples/riscv_examples.txt
+++ b/rp235x-hal-examples/riscv_examples.txt
@@ -9,7 +9,10 @@ block_loop
 dht11
 gpio_dyn_pin_array
 gpio_in_out
+gpio_irq_example
 i2c
+i2c_async
+i2c_async_cancelled
 lcd_display
 mem_to_mem_dma
 pio_blink
@@ -20,6 +23,7 @@ pio_synchronized
 powman_test
 pwm_blink
 pwm_blink_embedded_hal_1
+pwm_irq_input
 rom_funcs
 rosc_as_system_clock
 spi

--- a/rp235x-hal-examples/riscv_examples.txt
+++ b/rp235x-hal-examples/riscv_examples.txt
@@ -17,6 +17,7 @@ pio_dma
 pio_proc_blink
 pio_side_set
 pio_synchronized
+powman_test
 pwm_blink
 pwm_blink_embedded_hal_1
 rom_funcs

--- a/rp235x-hal-examples/rp235x_riscv.x
+++ b/rp235x-hal-examples/rp235x_riscv.x
@@ -80,6 +80,51 @@ PROVIDE(__pre_init = default_pre_init);
 /* A PAC/HAL defined routine that should initialize custom interrupt controller if needed. */
 PROVIDE(_setup_interrupts = default_setup_interrupts);
 
+PROVIDE(TIMER0_IRQ_0 = DefaultIrqHandler);
+PROVIDE(TIMER0_IRQ_1 = DefaultIrqHandler);
+PROVIDE(TIMER0_IRQ_2 = DefaultIrqHandler);
+PROVIDE(TIMER0_IRQ_3 = DefaultIrqHandler);
+PROVIDE(TIMER1_IRQ_0 = DefaultIrqHandler);
+PROVIDE(TIMER1_IRQ_1 = DefaultIrqHandler);
+PROVIDE(TIMER1_IRQ_2 = DefaultIrqHandler);
+PROVIDE(TIMER1_IRQ_3 = DefaultIrqHandler);
+PROVIDE(PWM_IRQ_WRAP_0 = DefaultIrqHandler);
+PROVIDE(PWM_IRQ_WRAP_1 = DefaultIrqHandler);
+PROVIDE(DMA_IRQ_0 = DefaultIrqHandler);
+PROVIDE(DMA_IRQ_1 = DefaultIrqHandler);
+PROVIDE(DMA_IRQ_2 = DefaultIrqHandler);
+PROVIDE(DMA_IRQ_3 = DefaultIrqHandler);
+PROVIDE(USBCTRL_IRQ = DefaultIrqHandler);
+PROVIDE(PIO0_IRQ_0 = DefaultIrqHandler);
+PROVIDE(PIO0_IRQ_1 = DefaultIrqHandler);
+PROVIDE(PIO1_IRQ_0 = DefaultIrqHandler);
+PROVIDE(PIO1_IRQ_1 = DefaultIrqHandler);
+PROVIDE(PIO2_IRQ_0 = DefaultIrqHandler);
+PROVIDE(PIO2_IRQ_1 = DefaultIrqHandler);
+PROVIDE(IO_IRQ_BANK0 = DefaultIrqHandler);
+PROVIDE(IO_IRQ_BANK0_NS = DefaultIrqHandler);
+PROVIDE(IO_IRQ_QSPI = DefaultIrqHandler);
+PROVIDE(IO_IRQ_QSPI_NS = DefaultIrqHandler);
+PROVIDE(SIO_IRQ_FIFO = DefaultIrqHandler);
+PROVIDE(SIO_IRQ_BELL = DefaultIrqHandler);
+PROVIDE(SIO_IRQ_FIFO_NS = DefaultIrqHandler);
+PROVIDE(SIO_IRQ_BELL_NS = DefaultIrqHandler);
+PROVIDE(SIO_IRQ_MTIMECMP = DefaultIrqHandler);
+PROVIDE(CLOCKS_IRQ = DefaultIrqHandler);
+PROVIDE(SPI0_IRQ = DefaultIrqHandler);
+PROVIDE(SPI1_IRQ = DefaultIrqHandler);
+PROVIDE(UART0_IRQ = DefaultIrqHandler);
+PROVIDE(UART1_IRQ = DefaultIrqHandler);
+PROVIDE(ADC_IRQ_FIFO = DefaultIrqHandler);
+PROVIDE(I2C0_IRQ = DefaultIrqHandler);
+PROVIDE(I2C1_IRQ = DefaultIrqHandler);
+PROVIDE(OTP_IRQ = DefaultIrqHandler);
+PROVIDE(TRNG_IRQ = DefaultIrqHandler);
+PROVIDE(PLL_SYS_IRQ = DefaultIrqHandler);
+PROVIDE(PLL_USB_IRQ = DefaultIrqHandler);
+PROVIDE(POWMAN_IRQ_POW = DefaultIrqHandler);
+PROVIDE(POWMAN_IRQ_TIMER = DefaultIrqHandler);
+
 /* # Multi-processing hook function
    fn _mp_hook() -> bool;
 

--- a/rp235x-hal-examples/src/bin/powman_test.rs
+++ b/rp235x-hal-examples/src/bin/powman_test.rs
@@ -124,8 +124,15 @@ fn main() -> ! {
     print_aot_status(&mut powman);
     _ = writeln!(&GLOBAL_UART, "AOT time: 0x{:016x}", powman.aot_get_time());
 
+    // Unmask the IRQ for POWMAN's Timer. We do this after the driver init so
+    // that the interrupt can't go off while it is in the middle of being
+    // configured
     unsafe {
-        hal::arch::interrupt_unmask(pac::Interrupt::POWMAN_IRQ_TIMER);
+        hal::arch::interrupt_unmask(hal::pac::Interrupt::POWMAN_IRQ_TIMER);
+    }
+
+    // Enable interrupts on this core
+    unsafe {
         hal::arch::interrupt_enable();
     }
 

--- a/rp235x-hal-examples/src/bin/powman_test.rs
+++ b/rp235x-hal-examples/src/bin/powman_test.rs
@@ -13,9 +13,6 @@ use rp235x_hal::{
     uart::{DataBits, StopBits, UartConfig, UartPeripheral},
 };
 
-use cortex_m_rt::exception;
-use pac::interrupt;
-
 // Some traits we need
 use core::fmt::Write;
 use hal::fugit::RateExtU32;
@@ -67,7 +64,7 @@ impl GlobalUart {
 
 /// Entry point to our bare-metal application.
 ///
-/// The `#[hal::entry]` macro ensures the Cortex-M start-up code calls this function
+/// The `#[hal::entry]` macro ensures the start-up code calls this function
 /// as soon as all global variables and the spinlock are initialised.
 ///
 /// The function configures the rp235x peripherals, then writes to the UART in
@@ -76,11 +73,6 @@ impl GlobalUart {
 fn main() -> ! {
     // Grab our singleton objects
     let mut pac = pac::Peripherals::take().unwrap();
-    let mut cp = cortex_m::Peripherals::take().unwrap();
-
-    // Enable the cycle counter
-    cp.DCB.enable_trace();
-    cp.DWT.enable_cycle_counter();
 
     // Set up the watchdog driver - needed by the clock setup code
     let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
@@ -99,6 +91,8 @@ fn main() -> ! {
 
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);
+    let mut mtimer = sio.machine_timer;
+    mtimer.set_enabled(true);
 
     // Set the pins to their default state
     let pins = gpio::Pins::new(
@@ -131,29 +125,30 @@ fn main() -> ! {
     _ = writeln!(&GLOBAL_UART, "AOT time: 0x{:016x}", powman.aot_get_time());
 
     unsafe {
-        cortex_m::peripheral::NVIC::unmask(pac::Interrupt::POWMAN_IRQ_TIMER);
+        hal::arch::interrupt_unmask(pac::Interrupt::POWMAN_IRQ_TIMER);
+        hal::arch::interrupt_enable();
     }
 
     _ = writeln!(&GLOBAL_UART, "Starting AOT...");
     powman.aot_start();
     // we don't know what oscillator we're on, so give it time to start whatever it is
-    cortex_m::asm::delay(150_000);
+    hal::arch::delay(150_000);
     print_aot_status(&mut powman);
     rollover_test(&mut powman);
-    loop_test(&mut powman);
+    loop_test(&mut powman, &mtimer);
     alarm_test(&mut powman);
 
     let source = AotClockSource::Xosc(FractionalFrequency::from_hz(12_000_000));
     _ = writeln!(&GLOBAL_UART, "Switching AOT to {}", source);
     powman.aot_set_clock(source).expect("selecting XOSC");
     print_aot_status(&mut powman);
-    loop_test(&mut powman);
+    loop_test(&mut powman, &mtimer);
 
     let source = AotClockSource::Lposc(FractionalFrequency::from_hz(32768));
     _ = writeln!(&GLOBAL_UART, "Switching AOT to {}", source);
     powman.aot_set_clock(source).expect("selecting LPOSC");
     print_aot_status(&mut powman);
-    loop_test(&mut powman);
+    loop_test(&mut powman, &mtimer);
 
     _ = writeln!(&GLOBAL_UART, "Rebooting now");
 
@@ -202,7 +197,7 @@ fn rollover_test(powman: &mut Powman) {
 }
 
 /// In this function, we see how long it takes to pass a certain number of ticks.
-fn loop_test(powman: &mut Powman) {
+fn loop_test(powman: &mut Powman, mtimer: &hal::sio::MachineTimer) {
     let start_loop = 0;
     let end_loop = 2_000; // 2 seconds
     _ = writeln!(
@@ -214,24 +209,24 @@ fn loop_test(powman: &mut Powman) {
     powman.aot_set_time(start_loop);
     powman.aot_start();
 
-    let start_clocks = cortex_m::peripheral::DWT::cycle_count();
+    let start_clocks = mtimer.read();
     loop {
         let now = powman.aot_get_time();
         if now == end_loop {
             break;
         }
     }
-    let end_clocks = cortex_m::peripheral::DWT::cycle_count();
-    // Compare our AOT against our CPU clock speed
-    let delta_clocks = end_clocks.wrapping_sub(start_clocks) as u64;
+    let end_clocks = mtimer.read();
+    // Compare our AOT against our Machine Timer
+    let delta_clocks = end_clocks.wrapping_sub(start_clocks);
     let delta_ticks = end_loop - start_loop;
     let cycles_per_tick = delta_clocks / delta_ticks;
-    // Assume we're running at 150 MHz
-    let ms_per_tick = (cycles_per_tick as f32 * 1000.0) / 150_000_000.0;
+    // Assume we're running at 1 MHz MTimer
+    let ms_per_tick = (cycles_per_tick as f32 * 1000.0) / 1_000_000.0;
     let percent = ((ms_per_tick - 1.0) / 1.0) * 100.0;
     _ = writeln!(
         &GLOBAL_UART,
-        "Loop complete ... {delta_ticks} ticks in {delta_clocks} CPU clock cycles = {cycles_per_tick} cycles/tick ~= {ms_per_tick} ms/tick ({percent:.3}%)",
+        "Loop complete ... {delta_ticks} ticks in {delta_clocks} MTimer cycles = {cycles_per_tick} cycles/tick ~= {ms_per_tick} ms/tick ({percent:.3}%)",
     )
     ;
 }
@@ -258,8 +253,9 @@ fn alarm_test(powman: &mut Powman) {
         &GLOBAL_UART,
         "Sleeping until alarm (* = wakeup, ! = POWMAN interrupt)...",
     );
+
     while !powman.aot_alarm_ringing() {
-        cortex_m::asm::wfe();
+        hal::arch::wfe();
         _ = write!(&GLOBAL_UART, "*",);
     }
 
@@ -278,25 +274,12 @@ fn alarm_test(powman: &mut Powman) {
     _ = writeln!(&GLOBAL_UART, "Alarm cleared OK");
 }
 
-#[interrupt]
+#[no_mangle]
 #[allow(non_snake_case)]
 fn POWMAN_IRQ_TIMER() {
     Powman::static_aot_alarm_interrupt_disable();
     _ = write!(&GLOBAL_UART, "!");
-    cortex_m::asm::sev();
-}
-
-#[exception]
-unsafe fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
-    let _ = writeln!(&GLOBAL_UART, "HARD FAULT:\n{:#?}", ef);
-
-    hal::reboot::reboot(
-        hal::reboot::RebootKind::BootSel {
-            msd_disabled: false,
-            picoboot_disabled: false,
-        },
-        hal::reboot::RebootArch::Normal,
-    );
+    hal::arch::sev();
 }
 
 #[panic_handler]

--- a/rp235x-hal/src/arch.rs
+++ b/rp235x-hal/src/arch.rs
@@ -473,16 +473,15 @@ mod inner {
 
     /// Our default IRQ handler.
     ///
-    /// Just panics.
-    ///
-    /// # Safety
-    ///
-    /// Do not call this function - it is called automatically when our
-    /// `MachineExternal` interrupt handler can't find anything better to call.
+    /// Just spins.
     #[no_mangle]
     #[allow(non_snake_case)]
-    unsafe fn DefaultIrqHandler() {
-        panic!();
+    fn DefaultIrqHandler() {
+        // Spin, so you can attach a debugger if you get stuck here.
+        // This is the also the default functionality used in cortex-m-rt.
+        loop {
+            crate::arch::nop();
+        }
     }
 }
 

--- a/rp235x-hal/src/arch.rs
+++ b/rp235x-hal/src/arch.rs
@@ -4,41 +4,77 @@
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 mod inner {
+    #[doc(inline)]
     pub use cortex_m::asm::{delay, dsb, nop, sev, wfe, wfi};
+
+    #[doc(inline)]
     pub use cortex_m::interrupt::{disable as interrupt_disable, enable as interrupt_enable};
 
-    /// Are interrupts current enabled?
+    /// Are interrupts currently enabled?
     pub fn interrupts_enabled() -> bool {
         cortex_m::register::primask::read().is_active()
     }
 
-    /// Run the closure without interrupts
+    /// Check if an IRQ is pending
+    pub fn interrrupt_is_pending(irq: rp235x_pac::Interrupt) -> bool {
+        cortex_m::peripheral::NVIC::is_pending(irq)
+    }
+
+    /// Enable an RP235x IRQ
     ///
-    /// No critical-section token because we haven't blocked the second core
-    pub fn interrupt_free<T, F>(f: F) -> T
-    where
-        F: FnOnce() -> T,
-    {
-        let active = interrupts_enabled();
-        if active {
-            interrupt_disable();
-        }
-        let t = f();
-        if active {
-            unsafe {
-                interrupt_enable();
-            }
-        }
-        t
+    /// # Safety
+    ///
+    /// This function is unsafe because it can break mask-based critical
+    /// sections. Do not call inside a critical section.
+    pub unsafe fn interrupt_unmask(irq: rp235x_pac::Interrupt) {
+        unsafe { cortex_m::peripheral::NVIC::unmask(irq) }
+    }
+
+    /// Disable an RP235x IRQ
+    pub fn interrupt_mask(irq: rp235x_pac::Interrupt) {
+        cortex_m::peripheral::NVIC::mask(irq)
+    }
+
+    /// Check if an RP235x IRQ is enabled
+    pub fn interrupt_is_enabled(irq: rp235x_pac::Interrupt) -> bool {
+        cortex_m::peripheral::NVIC::is_enabled(irq)
+    }
+
+    /// Mark an RP235x IRQ as pending
+    pub fn interrupt_pend(irq: rp235x_pac::Interrupt) {
+        cortex_m::peripheral::NVIC::pend(irq)
     }
 }
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
 mod inner {
+    #[doc(inline)]
     pub use riscv::asm::{delay, nop, wfi};
-    pub use riscv::interrupt::machine::{
-        disable as interrupt_disable, enable as interrupt_enable, free as interrupt_free,
+
+    #[doc(inline)]
+    pub use riscv::interrupt::machine::disable as interrupt_disable;
+
+    #[doc(inline)]
+    pub use crate::xh3irq::{
+        is_enabled as interrupt_is_enabled, is_pending as interrrupt_is_pending,
+        mask as interrupt_mask, pend as interrupt_pend, unmask as interrupt_unmask,
     };
+
+    /// Enable interrupts
+    ///
+    /// Enable the Machine External interrupt as well as the global interrupt
+    /// flag.
+    ///
+    /// # Safety
+    ///
+    /// Do not call from inside a critical section.
+    #[inline(always)]
+    pub unsafe fn interrupt_enable() {
+        unsafe {
+            riscv::register::mie::set_mext();
+            riscv::interrupt::machine::enable();
+        }
+    }
 
     /// Send Event
     #[inline(always)]
@@ -50,18 +86,10 @@ mod inner {
     }
 
     /// Wait for Event
-    ///
-    /// This is the interrupt-safe version of WFI.
     pub fn wfe() {
-        let active = interrupts_enabled();
-        if active {
-            interrupt_disable();
-        }
-        wfi();
-        if active {
-            unsafe {
-                interrupt_enable();
-            }
+        unsafe {
+            // This is how h3.block is encoded.
+            core::arch::asm!("slt x0, x0, x0");
         }
     }
 
@@ -73,10 +101,388 @@ mod inner {
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
     }
 
-    /// Are interrupts current enabled?
+    /// Are interrupts currently enabled?
     #[inline(always)]
     pub fn interrupts_enabled() -> bool {
         riscv::register::mstatus::read().mie()
+    }
+
+    #[no_mangle]
+    #[allow(non_snake_case)]
+    fn MachineExternal() {
+        loop {
+            let Some(irq) = crate::xh3irq::get_next_interrupt() else {
+                return;
+            };
+            match irq {
+                rp235x_pac::Interrupt::TIMER0_IRQ_0 => {
+                    extern "Rust" {
+                        fn TIMER0_IRQ_0();
+                    }
+                    unsafe {
+                        TIMER0_IRQ_0();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER0_IRQ_1 => {
+                    extern "Rust" {
+                        fn TIMER0_IRQ_1();
+                    }
+                    unsafe {
+                        TIMER0_IRQ_1();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER0_IRQ_2 => {
+                    extern "Rust" {
+                        fn TIMER0_IRQ_2();
+                    }
+                    unsafe {
+                        TIMER0_IRQ_2();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER0_IRQ_3 => {
+                    extern "Rust" {
+                        fn TIMER0_IRQ_3();
+                    }
+                    unsafe {
+                        TIMER0_IRQ_3();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER1_IRQ_0 => {
+                    extern "Rust" {
+                        fn TIMER1_IRQ_0();
+                    }
+                    unsafe {
+                        TIMER1_IRQ_0();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER1_IRQ_1 => {
+                    extern "Rust" {
+                        fn TIMER1_IRQ_1();
+                    }
+                    unsafe {
+                        TIMER1_IRQ_1();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER1_IRQ_2 => {
+                    extern "Rust" {
+                        fn TIMER1_IRQ_2();
+                    }
+                    unsafe {
+                        TIMER1_IRQ_2();
+                    }
+                }
+                rp235x_pac::Interrupt::TIMER1_IRQ_3 => {
+                    extern "Rust" {
+                        fn TIMER1_IRQ_3();
+                    }
+                    unsafe {
+                        TIMER1_IRQ_3();
+                    }
+                }
+                rp235x_pac::Interrupt::PWM_IRQ_WRAP_0 => {
+                    extern "Rust" {
+                        fn PWM_IRQ_WRAP_0();
+                    }
+                    unsafe {
+                        PWM_IRQ_WRAP_0();
+                    }
+                }
+                rp235x_pac::Interrupt::PWM_IRQ_WRAP_1 => {
+                    extern "Rust" {
+                        fn PWM_IRQ_WRAP_1();
+                    }
+                    unsafe {
+                        PWM_IRQ_WRAP_1();
+                    }
+                }
+                rp235x_pac::Interrupt::DMA_IRQ_0 => {
+                    extern "Rust" {
+                        fn DMA_IRQ_0();
+                    }
+                    unsafe {
+                        DMA_IRQ_0();
+                    }
+                }
+                rp235x_pac::Interrupt::DMA_IRQ_1 => {
+                    extern "Rust" {
+                        fn DMA_IRQ_1();
+                    }
+                    unsafe {
+                        DMA_IRQ_1();
+                    }
+                }
+                rp235x_pac::Interrupt::DMA_IRQ_2 => {
+                    extern "Rust" {
+                        fn DMA_IRQ_2();
+                    }
+                    unsafe {
+                        DMA_IRQ_2();
+                    }
+                }
+                rp235x_pac::Interrupt::DMA_IRQ_3 => {
+                    extern "Rust" {
+                        fn DMA_IRQ_3();
+                    }
+                    unsafe {
+                        DMA_IRQ_3();
+                    }
+                }
+                rp235x_pac::Interrupt::USBCTRL_IRQ => {
+                    extern "Rust" {
+                        fn USBCTRL_IRQ();
+                    }
+                    unsafe {
+                        USBCTRL_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::PIO0_IRQ_0 => {
+                    extern "Rust" {
+                        fn PIO0_IRQ_0();
+                    }
+                    unsafe {
+                        PIO0_IRQ_0();
+                    }
+                }
+                rp235x_pac::Interrupt::PIO0_IRQ_1 => {
+                    extern "Rust" {
+                        fn PIO0_IRQ_1();
+                    }
+                    unsafe {
+                        PIO0_IRQ_1();
+                    }
+                }
+                rp235x_pac::Interrupt::PIO1_IRQ_0 => {
+                    extern "Rust" {
+                        fn PIO1_IRQ_0();
+                    }
+                    unsafe {
+                        PIO1_IRQ_0();
+                    }
+                }
+                rp235x_pac::Interrupt::PIO1_IRQ_1 => {
+                    extern "Rust" {
+                        fn PIO1_IRQ_1();
+                    }
+                    unsafe {
+                        PIO1_IRQ_1();
+                    }
+                }
+                rp235x_pac::Interrupt::PIO2_IRQ_0 => {
+                    extern "Rust" {
+                        fn PIO2_IRQ_0();
+                    }
+                    unsafe {
+                        PIO2_IRQ_0();
+                    }
+                }
+                rp235x_pac::Interrupt::PIO2_IRQ_1 => {
+                    extern "Rust" {
+                        fn PIO2_IRQ_1();
+                    }
+                    unsafe {
+                        PIO2_IRQ_1();
+                    }
+                }
+                rp235x_pac::Interrupt::IO_IRQ_BANK0 => {
+                    extern "Rust" {
+                        fn IO_IRQ_BANK0();
+                    }
+                    unsafe {
+                        IO_IRQ_BANK0();
+                    }
+                }
+                rp235x_pac::Interrupt::IO_IRQ_BANK0_NS => {
+                    extern "Rust" {
+                        fn IO_IRQ_BANK0_NS();
+                    }
+                    unsafe {
+                        IO_IRQ_BANK0_NS();
+                    }
+                }
+                rp235x_pac::Interrupt::IO_IRQ_QSPI => {
+                    extern "Rust" {
+                        fn IO_IRQ_QSPI();
+                    }
+                    unsafe {
+                        IO_IRQ_QSPI();
+                    }
+                }
+                rp235x_pac::Interrupt::IO_IRQ_QSPI_NS => {
+                    extern "Rust" {
+                        fn IO_IRQ_QSPI_NS();
+                    }
+                    unsafe {
+                        IO_IRQ_QSPI_NS();
+                    }
+                }
+                rp235x_pac::Interrupt::SIO_IRQ_FIFO => {
+                    extern "Rust" {
+                        fn SIO_IRQ_FIFO();
+                    }
+                    unsafe {
+                        SIO_IRQ_FIFO();
+                    }
+                }
+                rp235x_pac::Interrupt::SIO_IRQ_BELL => {
+                    extern "Rust" {
+                        fn SIO_IRQ_BELL();
+                    }
+                    unsafe {
+                        SIO_IRQ_BELL();
+                    }
+                }
+                rp235x_pac::Interrupt::SIO_IRQ_FIFO_NS => {
+                    extern "Rust" {
+                        fn SIO_IRQ_FIFO_NS();
+                    }
+                    unsafe {
+                        SIO_IRQ_FIFO_NS();
+                    }
+                }
+                rp235x_pac::Interrupt::SIO_IRQ_BELL_NS => {
+                    extern "Rust" {
+                        fn SIO_IRQ_BELL_NS();
+                    }
+                    unsafe {
+                        SIO_IRQ_BELL_NS();
+                    }
+                }
+                rp235x_pac::Interrupt::SIO_IRQ_MTIMECMP => {
+                    extern "Rust" {
+                        fn SIO_IRQ_MTIMECMP();
+                    }
+                    unsafe {
+                        SIO_IRQ_MTIMECMP();
+                    }
+                }
+                rp235x_pac::Interrupt::CLOCKS_IRQ => {
+                    extern "Rust" {
+                        fn CLOCKS_IRQ();
+                    }
+                    unsafe {
+                        CLOCKS_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::SPI0_IRQ => {
+                    extern "Rust" {
+                        fn SPI0_IRQ();
+                    }
+                    unsafe {
+                        SPI0_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::SPI1_IRQ => {
+                    extern "Rust" {
+                        fn SPI1_IRQ();
+                    }
+                    unsafe {
+                        SPI1_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::UART0_IRQ => {
+                    extern "Rust" {
+                        fn UART0_IRQ();
+                    }
+                    unsafe {
+                        UART0_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::UART1_IRQ => {
+                    extern "Rust" {
+                        fn UART1_IRQ();
+                    }
+                    unsafe {
+                        UART1_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::ADC_IRQ_FIFO => {
+                    extern "Rust" {
+                        fn ADC_IRQ_FIFO();
+                    }
+                    unsafe {
+                        ADC_IRQ_FIFO();
+                    }
+                }
+                rp235x_pac::Interrupt::I2C0_IRQ => {
+                    extern "Rust" {
+                        fn I2C0_IRQ();
+                    }
+                    unsafe {
+                        I2C0_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::I2C1_IRQ => {
+                    extern "Rust" {
+                        fn I2C1_IRQ();
+                    }
+                    unsafe {
+                        I2C1_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::OTP_IRQ => {
+                    extern "Rust" {
+                        fn OTP_IRQ();
+                    }
+                    unsafe {
+                        OTP_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::TRNG_IRQ => {
+                    extern "Rust" {
+                        fn TRNG_IRQ();
+                    }
+                    unsafe {
+                        TRNG_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::PLL_SYS_IRQ => {
+                    extern "Rust" {
+                        fn PLL_SYS_IRQ();
+                    }
+                    unsafe {
+                        PLL_SYS_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::PLL_USB_IRQ => {
+                    extern "Rust" {
+                        fn PLL_USB_IRQ();
+                    }
+                    unsafe {
+                        PLL_USB_IRQ();
+                    }
+                }
+                rp235x_pac::Interrupt::POWMAN_IRQ_POW => {
+                    extern "Rust" {
+                        fn POWMAN_IRQ_POW();
+                    }
+                    unsafe {
+                        POWMAN_IRQ_POW();
+                    }
+                }
+                rp235x_pac::Interrupt::POWMAN_IRQ_TIMER => {
+                    extern "Rust" {
+                        fn POWMAN_IRQ_TIMER();
+                    }
+                    unsafe {
+                        POWMAN_IRQ_TIMER();
+                    }
+                }
+            }
+        }
+    }
+
+    /// Our default IRQ handler.
+    ///
+    /// Just panics.
+    ///
+    /// # Safety
+    ///
+    /// Do not call this function - it is called automatically when our
+    /// `MachineExternal` interrupt handler can't find anything better to call.
+    #[no_mangle]
+    #[allow(non_snake_case)]
+    unsafe fn DefaultIrqHandler() {
+        panic!();
     }
 }
 
@@ -84,32 +490,87 @@ mod inner {
 mod inner {
     /// Placeholder function to disable interrupts
     pub fn interrupt_disable() {}
+
     /// Placeholder function to enable interrupts
-    pub fn interrupt_enable() {}
+    ///
+    /// # Safety
+    ///
+    /// Do not call from inside a critical section.
+    pub unsafe fn interrupt_enable() {}
+
     /// Placeholder function to check if interrupts are enabled
     pub fn interrupts_enabled() -> bool {
         false
     }
+
+    /// Placeholder function to wait for an interrupt
+    pub fn wfi() {}
+
     /// Placeholder function to wait for an event
     pub fn wfe() {}
+
     /// Placeholder function to do nothing
     pub fn nop() {}
+
     /// Placeholder function to emit a data synchronisation barrier
     pub fn dsb() {}
-    /// Placeholder function to run a closure with interrupts disabled    
-    pub fn interrupt_free<T, F>(f: F) -> T
-    where
-        F: FnOnce() -> T,
-    {
-        f()
-    }
+
     /// Placeholder function to wait for some clock cycles
     pub fn delay(_: u32) {}
+
     /// Placeholder function to emit an event
     pub fn sev() {}
+
+    /// Placeholder function to check if an IRQ is pending
+    pub fn interrrupt_is_pending(_irq: rp235x_pac::Interrupt) -> bool {
+        false
+    }
+
+    /// Placeholder function to enable an IRQ
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it can break mask-based critical
+    /// sections. Do not call inside a critical section.
+    pub unsafe fn interrupt_unmask(_irq: rp235x_pac::Interrupt) {}
+
+    /// Placeholder function to disable an IRQ
+    pub fn interrupt_mask(_irq: rp235x_pac::Interrupt) {}
+
+    /// Placeholder function to check if an IRQ is enabled
+    pub fn interrupt_is_enabled(_irq: rp235x_pac::Interrupt) -> bool {
+        false
+    }
+
+    /// Placeholder function to mark an IRQ as pending
+    pub fn interrupt_pend(_irq: rp235x_pac::Interrupt) {}
 }
 
-pub use inner::*;
+#[doc(inline)]
+pub use inner::{
+    delay, dsb, interrrupt_is_pending, interrupt_disable, interrupt_enable, interrupt_is_enabled,
+    interrupt_mask, interrupt_pend, interrupt_unmask, interrupts_enabled, nop, sev, wfe, wfi,
+};
+
+/// Run the closure without interrupts
+///
+/// No critical-section token because we haven't blocked the second core
+pub fn interrupt_free<T, F>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let active = interrupts_enabled();
+    if active {
+        interrupt_disable();
+    }
+    let t = f();
+    if active {
+        unsafe {
+            interrupt_enable();
+        }
+    }
+    t
+}
 
 /// Create a static variable which we can grab a mutable reference to exactly once.
 #[macro_export]

--- a/rp235x-hal/src/lib.rs
+++ b/rp235x-hal/src/lib.rs
@@ -70,6 +70,7 @@ pub mod uart;
 pub mod usb;
 pub mod vector_table;
 pub mod watchdog;
+pub mod xh3irq;
 pub mod xosc;
 
 // Provide access to common datastructures to avoid repeating ourselves

--- a/rp235x-hal/src/xh3irq.rs
+++ b/rp235x-hal/src/xh3irq.rs
@@ -222,17 +222,20 @@ mod test {
 
     #[test]
     fn test_interrupt_to_mask() {
-        let (index, bitmask) = interrupt_to_mask(rp235x_pac::Interrupt::UART1_IRQ);
-        // 34 -> window 2, bit 3
+        let (index, bitmask) = interrupt_to_mask(rp235x_pac::Interrupt::ADC_IRQ_FIFO);
+        assert_eq!(rp235x_pac::Interrupt::ADC_IRQ_FIFO as u16, 35);
+        // ADC_IRQ_FIFO is IRQ 35, so that's index 2, bit 3
         assert_eq!(index, 2);
-        assert_eq!(bitmask, 0b0000_0000_0000_0100);
+        assert_eq!(bitmask, 1 << 3);
     }
 
     #[test]
     fn test_interrupt_to_mask_index() {
-        let mask = interrupt_to_mask_index(rp235x_pac::Interrupt::UART1_IRQ);
-        // 34 -> bit 3 | window 2
-        assert_eq!(mask, 0x0004_0002);
+        let mask = interrupt_to_mask_index(rp235x_pac::Interrupt::ADC_IRQ_FIFO);
+        assert_eq!(rp235x_pac::Interrupt::ADC_IRQ_FIFO as u16, 35);
+        // ADC_IRQ_FIFO is IRQ 35, so that's index 2, bit 3
+        // This value is in (bitmask | index) format, and 1 << 3 is 0x0008
+        assert_eq!(mask, 0x0008_0002);
     }
 }
 

--- a/rp235x-hal/src/xh3irq.rs
+++ b/rp235x-hal/src/xh3irq.rs
@@ -1,0 +1,239 @@
+//! Hazard3 Interrupt Controller (Xh3irq) Driver
+//!
+//! > Xh3irq controls up to 512 external interrupts, with up to 16 levels of
+//! > pre-emption. It is architected as a layer on top of the standard mip.meip
+//! > external interrupt line, and all standard RISC-V interrupt behaviour still
+//! > applies.
+//!
+//! See [Section 3.8.6.1](https://rptl.io/rp2350-datasheet#extension-xh3irq-section) for more details
+
+/// The Machine External Interrupt Enable Array
+///
+/// The array contains a read-write bit for each external interrupt request: a
+/// `1` bit indicates that interrupt is currently enabled. At reset, all
+/// external interrupts are disabled.
+///
+/// If enabled, an external interrupt can cause assertion of the standard RISC-V
+/// machine external interrupt pending flag (`mip.meip`), and therefore cause
+/// the processor to enter the external interrupt vector. See `meipa`.
+///
+/// There are up to 512 external interrupts. The upper half of this register
+/// contains a 16-bit window into the full 512-bit vector. The window is indexed
+/// by the 5 LSBs of the write data.
+pub const RVCSR_MEIEA_OFFSET: u32 = 0xbe0;
+
+/// Machine External Interrupt Pending Array
+///
+/// Contains a read-only bit for each external interrupt request. Similarly to
+/// `meiea`, this register is a window into an array of up to 512 external
+/// interrupt flags. The status appears in the upper 16 bits of the value read
+/// from `meipa`, and the lower 5 bits of the value _written_ by the same CSR
+/// instruction (or 0 if no write takes place) select a 16-bit window of the
+/// full interrupt pending array.
+///
+/// A `1` bit indicates that interrupt is currently asserted. IRQs are assumed
+/// to be level-sensitive, and the relevant `meipa` bit is cleared by servicing
+/// the requestor so that it deasserts its interrupt request.
+///
+/// When any interrupt of sufficient priority is both set in `meipa` and enabled
+/// in `meiea`, the standard RISC-V external interrupt pending bit `mip.meip` is
+/// asserted. In other words, `meipa` is filtered by `meiea` to generate the
+/// standard `mip.meip` flag.
+pub const RVCSR_MEIPA_OFFSET: u32 = 0xbe1;
+
+/// Machine External Interrupt Force Array
+//
+/// Contains a read-write bit for every interrupt request. Writing a 1 to a bit
+/// in the interrupt force array causes the corresponding bit to become pending
+/// in `meipa`. Software can use this feature to manually trigger a particular
+/// interrupt.
+///
+/// There are no restrictions on using `meifa` inside of an interrupt. The more
+/// useful case here is to schedule some lower- priority handler from within a
+/// high-priority interrupt, so that it will execute before the core returns to
+/// the foreground code. Implementers may wish to reserve some external IRQs
+/// with their external inputs tied to 0 for this purpose.
+///
+/// Bits can be cleared by software, and are cleared automatically by hardware
+/// upon a read of `meinext` which returns the corresponding IRQ number in
+/// `meinext.irq` with `mienext.noirq` clear (no matter whether `meinext.update`
+/// is written).
+///
+/// `meifa` implements the same array window indexing scheme as `meiea` and
+/// `meipa`.
+pub const RVCSR_MEIFA_OFFSET: u32 = 0xbe2;
+
+/// Machine External Interrupt Priority Array
+///
+/// Each interrupt has an (up to) 4-bit priority value associated with it, and
+/// each access to this register reads and/or writes a 16-bit window containing
+/// four such priority values. When less than 16 priority levels are available,
+/// the LSBs of the priority fields are hardwired to 0.
+///
+/// When an interrupt's priority is lower than the current preemption priority
+/// `meicontext.preempt`, it is treated as not being pending for the purposes of
+/// `mip.meip`. The pending bit in `meipa` will still assert, but the machine
+/// external interrupt pending bit `mip.meip` will not, so the processor will
+/// ignore this interrupt. See `meicontext`.
+pub const RVCSR_MEIPRA_OFFSET: u32 = 0xbe3;
+
+/// Machine External Get Next Interrupt
+///
+/// Contains the index of the highest-priority external interrupt which is both
+/// asserted in `meipa` and enabled in `meiea`, left- shifted by 2 so that it
+/// can be used to index an array of 32-bit function pointers. If there is no
+/// such interrupt, the MSB is set.
+///
+/// When multiple interrupts of the same priority are both pending and enabled,
+/// the lowest-numbered wins. Interrupts with priority less than
+/// `meicontext.ppreempt` -- the _previous_ preemption priority -- are treated
+/// as though they are not pending. This is to ensure that a preempting
+/// interrupt frame does not service interrupts which may be in progress in the
+/// frame that was preempted.
+pub const RVCSR_MEINEXT_OFFSET: u32 = 0xbe4;
+
+/// Check if a given interrupt is pending
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+pub fn is_pending(irq: rp235x_pac::Interrupt) -> bool {
+    let (index, bits) = interrupt_to_mask(irq);
+    let index = index as u32;
+    let mut csr_rdata: u32;
+    // Do a CSR Read-Set on RVCSR_MEIPA_OFFSET
+    unsafe {
+        core::arch::asm!(
+            "csrrs {0}, 0xbe1, {1}",
+            out(reg) csr_rdata,
+            in(reg) index
+        );
+    }
+    let bitmask = (bits as u32) << 16;
+    (csr_rdata & bitmask) != 0
+}
+
+/// Enable an interrupt
+///
+/// # Safety
+///
+/// This function is unsafe because it can break mask-based critical
+/// sections. Do not call inside a critical section.
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+pub unsafe fn unmask(irq: rp235x_pac::Interrupt) {
+    let mask_index = interrupt_to_mask_index(irq);
+    // Do a RISC-V CSR Set on RVCSR_MEIEA_OFFSET
+    unsafe {
+        core::arch::asm!(
+            "csrs 0xbe0, {0}",
+            in(reg) mask_index
+        );
+    }
+}
+
+/// Disable an interrupt
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+pub fn mask(irq: rp235x_pac::Interrupt) {
+    let mask_index = interrupt_to_mask_index(irq);
+    // Do a RISC-V CSR Clear on RVCSR_MEIEA_OFFSET
+    unsafe {
+        core::arch::asm!(
+            "csrc 0xbe0, {0}",
+            in(reg) mask_index
+        );
+    }
+}
+
+/// Check if an interrupt is enabled
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+pub fn is_enabled(irq: rp235x_pac::Interrupt) -> bool {
+    let (index, bits) = interrupt_to_mask(irq);
+    let index = index as u32;
+    let mut csr_rdata: u32;
+    // Do a CSR Read-Set on RVCSR_MEIEA_OFFSET
+    unsafe {
+        core::arch::asm!(
+            "csrrs {0}, 0xbe0, {1}",
+            out(reg) csr_rdata,
+            in(reg) index
+        );
+    }
+    let bitmask = (bits as u32) << 16;
+    (csr_rdata & bitmask) != 0
+}
+
+/// Set an interrupt as pending, even if it isn't.
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+pub fn pend(irq: rp235x_pac::Interrupt) {
+    let mask_index = interrupt_to_mask_index(irq);
+    // Do a RISC-V CSR Set on RVCSR_MEIFA_OFFSET
+    unsafe {
+        core::arch::asm!(
+            "csrs 0xbe2, {0}",
+            in(reg) mask_index
+        );
+    }
+}
+
+/// Check which interrupt should be handled next
+///
+/// Also updates the state so next time you call this you'll get a different
+/// answer.
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
+pub fn get_next_interrupt() -> Option<rp235x_pac::Interrupt> {
+    const NOIRQ: u32 = 0x8000_0000;
+
+    let mut csr_rdata: u32;
+    // Do a CSR Read-Set-Immediate on MEINEXT to set the UPDATE bit
+    unsafe {
+        core::arch::asm!(
+            "csrrsi {0}, 0xbe4, 0x01",
+            out(reg) csr_rdata,
+        );
+    }
+
+    if (csr_rdata & NOIRQ) != 0 {
+        return None;
+    }
+
+    let irq_no = (csr_rdata >> 2) as u8;
+    let irq = rp235x_pac::Interrupt::try_from(irq_no).unwrap();
+    Some(irq)
+}
+
+/// Convert an IRQ into a window selection value and separate a bitmask for that
+/// window.
+pub const fn interrupt_to_mask(irq: rp235x_pac::Interrupt) -> (u16, u16) {
+    let irq = irq as u16;
+    // Select a bank of 16 interrupts out of the 512 total
+    let index = irq / 16;
+    // Which interrupt out of the 16 we've selected
+    let bitmask = 1 << (irq % 16);
+    (index, bitmask)
+}
+
+/// Convert an IRQ into a 32-bit value that selects a window and a bit within
+/// that window.
+pub const fn interrupt_to_mask_index(irq: rp235x_pac::Interrupt) -> u32 {
+    let (index, bits) = interrupt_to_mask(irq);
+    (bits as u32) << 16 | index as u32
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_interrupt_to_mask() {
+        let (index, bitmask) = interrupt_to_mask(rp235x_pac::Interrupt::UART1_IRQ);
+        // 34 -> window 2, bit 3
+        assert_eq!(index, 2);
+        assert_eq!(bitmask, 0b0000_0000_0000_0100);
+    }
+
+    #[test]
+    fn test_interrupt_to_mask_index() {
+        let mask = interrupt_to_mask_index(rp235x_pac::Interrupt::UART1_IRQ);
+        // 34 -> bit 3 | window 2
+        assert_eq!(mask, 0x0004_0002);
+    }
+}
+
+// End of file


### PR DESCRIPTION
) Adds an Xh3irq controller driver
) Adds a default `MachineExternal` handler which uses the Xh3irq to run whichever interrupts are pending
) Adds a bunch of interrupt control stuff to `hal::arch`
) Fixes the `powman_test` example to use the new interrupt APIs - it now works on RISC-V and Arm.

Tested `powman_test` on a Pico 2 in both `riscv32imac-unknown-none-elf` and `thumbv8m.main-none-eabihf`.
