### PR TITLE
Use embassy-executor instead of nostd_async

### DIFF
--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -41,4 +41,4 @@ rp2040-hal = {path = "../rp2040-hal", version = "0.10.0", features = ["binary-in
 static_cell = "2.1.0"
 
 [target.'cfg( target_arch = "arm" )'.dependencies]
-embassy-executor = {version = "0.6", features = ["arch-cortex-m", "executor-thread"]}
+embassy-executor = {version = "0.5", features = ["arch-cortex-m", "executor-thread"]}

--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -29,7 +29,6 @@ fugit = "0.3.6"
 futures = {version = "0.3.30", default-features = false, features = ["async-await"]}
 hd44780-driver = "0.4.0"
 nb = "1.0"
-nostd_async = {version = "0.6.1", features = ["cortex_m"]}
 panic-halt = "0.2.0"
 panic-probe = {version = "0.3.1", features = ["print-defmt"]}
 pio = "0.2.0"
@@ -39,3 +38,7 @@ pio-proc = "0.2.0"
 portable-atomic = {version = "1.7.0", features = ["critical-section"]}
 rp2040-boot2 = "0.3.0"
 rp2040-hal = {path = "../rp2040-hal", version = "0.10.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
+static_cell = "2.1.0"
+
+[target.'cfg( target_arch = "arm" )'.dependencies]
+embassy-executor = {version = "0.6", features = ["arch-cortex-m", "executor-thread"]}

--- a/rp2040-hal-examples/src/bin/i2c_async.rs
+++ b/rp2040-hal-examples/src/bin/i2c_async.rs
@@ -10,7 +10,6 @@
 #![no_std]
 #![no_main]
 
-use embassy_executor::Executor;
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)
 use panic_halt as _;
@@ -27,6 +26,7 @@ use hal::{
 };
 
 // Import required types & traits.
+use embassy_executor::Executor;
 use embedded_hal_async::i2c::I2c;
 use hal::{
     gpio::{FunctionI2C, Pin, PullUp},

--- a/rp2040-hal-examples/src/bin/i2c_async_cancelled.rs
+++ b/rp2040-hal-examples/src/bin/i2c_async_cancelled.rs
@@ -16,6 +16,7 @@ use core::task::Poll;
 // be linked)
 //use panic_halt as _;
 
+use embassy_executor::Executor;
 use embedded_hal_async::i2c::I2c;
 use futures::FutureExt;
 
@@ -39,6 +40,7 @@ use hal::{
 
 use defmt_rtt as _;
 use panic_probe as _;
+use static_cell::StaticCell;
 
 /// The linker will place this boot block at the start of our program image. We
 /// need this to help the ROM bootloader get our code up and running.
@@ -60,6 +62,7 @@ unsafe fn I2C0_IRQ() {
 
 /// The function configures the RP2040 peripherals, then performs a single I²C
 /// write to a fixed address.
+#[embassy_executor::task]
 async fn demo() {
     let mut pac = pac::Peripherals::take().unwrap();
 
@@ -142,9 +145,7 @@ async fn demo() {
 /// Entry point to our bare-metal application.
 #[rp2040_hal::entry]
 fn main() -> ! {
-    let runtime = nostd_async::Runtime::new();
-    let mut task = nostd_async::Task::new(demo());
-    let handle = task.spawn(&runtime);
-    handle.join();
-    unreachable!()
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| spawner.spawn(demo()).unwrap());
 }

--- a/rp2040-hal-examples/src/bin/i2c_async_cancelled.rs
+++ b/rp2040-hal-examples/src/bin/i2c_async_cancelled.rs
@@ -16,7 +16,6 @@ use core::task::Poll;
 // be linked)
 //use panic_halt as _;
 
-use embassy_executor::Executor;
 use embedded_hal_async::i2c::I2c;
 use futures::FutureExt;
 
@@ -39,6 +38,7 @@ use hal::{
 };
 
 use defmt_rtt as _;
+use embassy_executor::Executor;
 use panic_probe as _;
 use static_cell::StaticCell;
 

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -29,10 +29,16 @@ futures = {version = "0.3.30", default-features = false, features = ["async-awai
 hd44780-driver = "0.4.0"
 heapless = "0.8.0"
 nb = "1.0"
-nostd_async = {version = "0.6.1", features = ["cortex_m"]}
 panic-halt = "0.2.0"
 pio = "0.2.0"
 pio-proc = "0.2.0"
 rp235x-hal = {path = "../rp235x-hal", version = "0.2.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
 usb-device = "0.3.2"
 usbd-serial = "0.2.2"
+static_cell = "2.1.0"
+
+[target.'cfg( target_arch = "arm" )'.dependencies]
+embassy-executor = {version = "0.6", features = ["arch-cortex-m", "executor-thread"]}
+
+[target.'cfg( target_arch = "riscv32" )'.dependencies]
+embassy-executor = {version = "0.6", features = ["arch-riscv32", "executor-thread"]}

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -38,7 +38,7 @@ usbd-serial = "0.2.2"
 static_cell = "2.1.0"
 
 [target.'cfg( target_arch = "arm" )'.dependencies]
-embassy-executor = {version = "0.6", features = ["arch-cortex-m", "executor-thread"]}
+embassy-executor = {version = "0.5", features = ["arch-cortex-m", "executor-thread"]}
 
 [target.'cfg( target_arch = "riscv32" )'.dependencies]
-embassy-executor = {version = "0.6", features = ["arch-riscv32", "executor-thread"]}
+embassy-executor = {version = "0.5", features = ["arch-riscv32", "executor-thread"]}

--- a/rp235x-hal-examples/src/bin/i2c_async.rs
+++ b/rp235x-hal-examples/src/bin/i2c_async.rs
@@ -10,7 +10,6 @@
 #![no_std]
 #![no_main]
 
-use embassy_executor::Executor;
 // Ensure we halt the program on panic (if we don't mention this crate it won't
 // be linked)
 use panic_halt as _;
@@ -29,6 +28,7 @@ use hal::{
 };
 
 // Import required types & traits.
+use embassy_executor::Executor;
 use embedded_hal_async::i2c::I2c;
 use static_cell::StaticCell;
 

--- a/rp235x-hal-examples/src/bin/i2c_async_cancelled.rs
+++ b/rp235x-hal-examples/src/bin/i2c_async_cancelled.rs
@@ -15,6 +15,7 @@
 use panic_halt as _;
 
 use core::task::Poll;
+use embassy_executor::Executor;
 use embedded_hal_async::i2c::I2c;
 use futures::FutureExt;
 
@@ -32,6 +33,7 @@ use hal::{
 };
 
 use defmt_rtt as _;
+use static_cell::StaticCell;
 
 /// Tell the Boot ROM about our application
 #[link_section = ".start_block"]
@@ -50,6 +52,7 @@ unsafe fn I2C0_IRQ() {
 
 /// The function configures the RP235x peripherals, then performs a single I²C
 /// write to a fixed address.
+#[embassy_executor::task]
 async fn demo() {
     let mut pac = hal::pac::Peripherals::take().unwrap();
 
@@ -132,11 +135,9 @@ async fn demo() {
 /// Entry point to our bare-metal application.
 #[hal::entry]
 fn main() -> ! {
-    let runtime = nostd_async::Runtime::new();
-    let mut task = nostd_async::Task::new(demo());
-    let handle = task.spawn(&runtime);
-    handle.join();
-    unreachable!()
+    static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+    let executor = EXECUTOR.init(Executor::new());
+    executor.run(|spawner| spawner.spawn(demo()).unwrap());
 }
 
 /// Program metadata for `picotool info`

--- a/rp235x-hal-examples/src/bin/i2c_async_cancelled.rs
+++ b/rp235x-hal-examples/src/bin/i2c_async_cancelled.rs
@@ -15,7 +15,6 @@
 use panic_halt as _;
 
 use core::task::Poll;
-use embassy_executor::Executor;
 use embedded_hal_async::i2c::I2c;
 use futures::FutureExt;
 
@@ -33,6 +32,7 @@ use hal::{
 };
 
 use defmt_rtt as _;
+use embassy_executor::Executor;
 use static_cell::StaticCell;
 
 /// Tell the Boot ROM about our application


### PR DESCRIPTION
For the needs of our examples, a much simpler executor would suffice. But it doesn't hurt to use a full-blown executor, the code doesn't become more complicated that way.