### PR TITLE
Add missing binary info to 2350 linker scripts.

### DIFF
--- a/rp235x-hal-examples/memory.x
+++ b/rp235x-hal-examples/memory.x
@@ -31,6 +31,7 @@ SECTIONS {
     {
         __start_block_addr = .;
         KEEP(*(.start_block));
+        KEEP(*(.boot_info));
     } > FLASH
 
 } INSERT AFTER .vector_table;

--- a/rp235x-hal-examples/rp235x_riscv.x
+++ b/rp235x-hal-examples/rp235x_riscv.x
@@ -112,6 +112,7 @@ SECTIONS
     . = ALIGN(4);
     __start_block_addr = .;
     KEEP(*(.start_block));
+    KEEP(*(.boot_info));
     . = ALIGN(4);
     *(.trap);
     *(.trap.rust);


### PR DESCRIPTION
The `.boot_info` section was missing from the RP2350 linker scripts (both Arm and RISC-V).

This adds it back, tucking it next to where the start block lives, as the BI must be in the first 4K of flash.

Closes #853