### PR TITLE
Prepare a 0.0.1 release of the rp235x crates

### DIFF
--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "rp235x-hal-examples"
 repository = "https://github.com/rp-rs/rp-hal"
 rust-version = "1.77"
-version = "0.1.0"
+version = "0.0.1"
 
 [dependencies]
 cortex-m = "0.7.2"
@@ -32,7 +32,7 @@ nb = "1.0"
 panic-halt = "0.2.0"
 pio = "0.2.0"
 pio-proc = "0.2.0"
-rp235x-hal = {path = "../rp235x-hal", version = "0.2.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
+rp235x-hal = {path = "../rp235x-hal", version = "0.0.1", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
 usb-device = "0.3.2"
 usbd-serial = "0.2.2"
 static_cell = "2.1.0"

--- a/rp235x-hal-macros/Cargo.toml
+++ b/rp235x-hal-macros/Cargo.toml
@@ -3,7 +3,7 @@ description = "Macros used by rp235x-hal"
 license = "MIT OR Apache-2.0"
 name = "rp235x-hal-macros"
 readme = "README.md"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 repository = "https://github.com/rp-rs/rp-hal"
 

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "rp235x-hal"
 repository = "https://github.com/rp-rs/rp-hal"
 rust-version = "1.77"
-version = "0.2.0"
+version = "0.0.1"
 
 [package.metadata.docs.rs]
 features = ["rt", "defmt", "rtic-monotonic"]
@@ -37,7 +37,7 @@ pio = "0.2.0"
 rand_core = "0.6.3"
 rp-binary-info = {version = "0.1.0", path = "../rp-binary-info"}
 rp-hal-common = {version = "0.1.0", path = "../rp-hal-common"}
-rp235x-hal-macros = {version = "0.1.0", path = "../rp235x-hal-macros"}
+rp235x-hal-macros = {version = "0.0.1", path = "../rp235x-hal-macros"}
 rp235x-pac = {version = "0.1.0", features = ["critical-section", "rt"]}
 sha2-const-stable = "0.1"
 usb-device = "0.3.2"


### PR DESCRIPTION
I'm not sure if the crates are well-tested enough for a "real" release, but starting with a 0.0.1 for now wouldn't hurt IMHO.