### PR TITLE
Implement InputPin and OutputPin for Pin<I, DynFunction, P>

### DIFF
--- a/rp2040-hal/src/gpio/func.rs
+++ b/rp2040-hal/src/gpio/func.rs
@@ -145,6 +145,7 @@ impl SioConfig for SioOutput {
 //==============================================================================
 
 /// Error type for invalid function conversion.
+#[derive(Debug)]
 pub struct InvalidFunction;
 
 /// Marker of valid pin -> function combination.


### PR DESCRIPTION
Operations on this are fallible: They return Err(DynPinError::IncompatibleFunction) if the pin is not configured to an incompatible function.
