### PR TITLE
Add debug derive for the GPIO structures

### DIFF
--- a/on-target-tests/Cargo.toml
+++ b/on-target-tests/Cargo.toml
@@ -48,7 +48,7 @@ name = "gpio"
 [dependencies]
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
-critical-section = "1.0.0"
+critical-section = "1.2.0"
 defmt = "0.3"
 defmt-rtt = "0.4"
 defmt-test = "0.3.1"

--- a/rp-binary-info/src/lib.rs
+++ b/rp-binary-info/src/lib.rs
@@ -106,6 +106,7 @@ extern "C" {
 #[link_section = ".boot_info"]
 #[cfg(feature = "binary-info")]
 #[used]
+#[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static PICOTOOL_HEADER: Header = unsafe {
     Header::new(
         core::ptr::addr_of!(__bi_entries_start),

--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.0"
 cortex-m = "0.7.2"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.1.4"
-critical-section = {version = "1.0.0"}
+critical-section = {version = "1.2.0"}
 defmt = "0.3"
 defmt-rtt = "0.4.0"
 dht-sensor = "0.2.1"

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -21,7 +21,7 @@ targets = ["thumbv6m-none-eabi"]
 # Non-optional dependencies. Keep these sorted by name.
 bitfield = {version = "0.14.0"}
 cortex-m = "0.7.2"
-critical-section = {version = "1.0.0"}
+critical-section = {version = "1.2.0"}
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"

--- a/rp2040-hal/src/gpio/func.rs
+++ b/rp2040-hal/src/gpio/func.rs
@@ -80,6 +80,7 @@ macro_rules! pin_func {
     ($($fn:ident $(as $alias:ident)?),*) => {
         $(paste! {
             /// Type-level `variant` for pin [`Function`].
+            #[derive(Debug)]
             pub struct [<Function $fn>](pub(super) ());
             impl Function for [<Function $fn>] {}
             impl func_sealed::Function for [<Function $fn>] {
@@ -106,6 +107,7 @@ pin_func!(Xip, Spi, Uart, I2c as I2C, Pwm, Pio0, Pio1, Clock, Usb, Null);
 //==============================================================================
 
 /// Type-level `variant` for pin [`Function`].
+#[derive(Debug)]
 pub struct FunctionSio<C>(PhantomData<C>);
 impl<C: SioConfig> Function for FunctionSio<C> {}
 impl<C: SioConfig> func_sealed::Function for FunctionSio<C> {
@@ -128,12 +130,14 @@ pub trait SioConfig {
 }
 
 /// Type-level `variant` for SIO configuration.
+#[derive(Debug)]
 pub enum SioInput {}
 impl SioConfig for SioInput {
     #[allow(missing_docs)]
     const DYN: DynSioConfig = DynSioConfig::Input;
 }
 /// Type-level `variant` for SIO configuration.
+#[derive(Debug)]
 pub enum SioOutput {}
 impl SioConfig for SioOutput {
     #[allow(missing_docs)]

--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -158,6 +158,7 @@ pub enum OutputOverride {
 
 /// Represents a pin, with a given ID (e.g. Gpio3), a given function (e.g. FunctionUart) and a given pull type
 /// (e.g. pull-down).
+#[derive(Debug)]
 pub struct Pin<I: PinId, F: func::Function, P: PullType> {
     id: I,
     function: F,
@@ -1081,6 +1082,7 @@ macro_rules! gpio {
     (struct: $bank:ident $prefix:ident $($PXi:ident, $id:expr, $func:ident, $pull_type:ident),*) => {
         paste::paste!{
                 /// Collection of all the individual [`Pin`]s
+                #[derive(Debug)]
                 pub struct Pins {
                     _io: [<IO_ $bank:upper>],
                     _pads: [<PADS_ $bank:upper>],

--- a/rp2040-hal/src/gpio/pin.rs
+++ b/rp2040-hal/src/gpio/pin.rs
@@ -88,6 +88,7 @@ macro_rules! pin_ids {
         paste::paste!{
             $(
                 #[doc = "Type level variant for the pin `" $name "` in bank `" $prefix "`."]
+                #[derive(Debug)]
                 pub struct [<$prefix $name>] (pub(crate) ());
                 impl crate::typelevel::Sealed for [<$prefix $name>] {}
                 impl PinId for [<$prefix $name>] {

--- a/rp2040-hal/src/gpio/pull.rs
+++ b/rp2040-hal/src/gpio/pull.rs
@@ -47,6 +47,7 @@ macro_rules! pin_pull_type {
     ($($pull_type:ident),*) => {
         $(paste! {
             /// Type-level `variant` of [`PullType`].
+            #[derive(Debug)]
             pub struct [<Pull $pull_type>](pub(super) ());
             impl PullType for [<Pull $pull_type>] {}
             impl pull_sealed::PullType for [<Pull $pull_type>] {

--- a/rp2040-hal/src/sio.rs
+++ b/rp2040-hal/src/sio.rs
@@ -35,26 +35,31 @@ pub enum CoreId {
 }
 
 /// Marker struct for ownership of SIO gpio bank0
+#[derive(Debug)]
 pub struct SioGpioBank0 {
     _private: (),
 }
 
 /// Marker struct for ownership of SIO FIFO
+#[derive(Debug)]
 pub struct SioFifo {
     _private: (),
 }
 
 /// Marker struct for ownership of SIO gpio qspi
+#[derive(Debug)]
 pub struct SioGpioQspi {
     _private: (),
 }
 
 /// Marker struct for ownership of divide/modulo module
+#[derive(Debug)]
 pub struct HwDivider {
     _private: (),
 }
 
 /// Result of divide/modulo operation
+#[derive(Debug)]
 pub struct DivResult<T> {
     /// The quotient of divide/modulo operation
     pub quotient: T,

--- a/rp2040-hal/src/spi.rs
+++ b/rp2040-hal/src/spi.rs
@@ -248,10 +248,10 @@ impl<S: State, D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<S, D, P, DS
         (freq_in / (prescale as u32 * (1 + postdiv as u32))).Hz()
     }
 
-    /// Set format and datasize
-    pub fn set_format(&mut self, data_bits: u8, frame_format: FrameFormat) {
+    /// Set format
+    pub fn set_format(&mut self, frame_format: FrameFormat) {
         self.device.sspcr0().modify(|_, w| unsafe {
-            w.dss().bits(data_bits - 1).frf().bits(match &frame_format {
+            w.dss().bits(DS - 1).frf().bits(match &frame_format {
                 FrameFormat::MotorolaSpi(_) => 0x00,
                 FrameFormat::TexasInstrumentsSynchronousSerial => 0x01,
                 FrameFormat::NationalSemiconductorMicrowire => 0x10,
@@ -309,7 +309,7 @@ impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
         self.device.reset_bring_up(resets);
 
         self.set_baudrate(peri_frequency, baudrate);
-        self.set_format(DS, frame_format);
+        self.set_format(frame_format);
         self.set_slave(slave);
         // Always enable DREQ signals -- harmless if DMA is not listening
         self.device

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.0"
 cortex-m = "0.7.2"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.1.4"
-critical-section = {version = "1.0.0"}
+critical-section = {version = "1.2.0"}
 defmt = "0.3"
 defmt-rtt = "0.4.0"
 dht-sensor = "0.2.1"

--- a/rp235x-hal-examples/src/bin/block_loop.rs
+++ b/rp235x-hal-examples/src/bin/block_loop.rs
@@ -37,12 +37,14 @@ extern "C" {
 /// Tell the Boot ROM about our application
 #[link_section = ".start_block"]
 #[used]
+#[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static START_IMAGE_DEF: hal::block::ImageDef =
     hal::block::ImageDef::secure_exe().with_offset(unsafe { core::ptr::addr_of!(start_to_end) });
 
 /// A second Block, and the end of the program in flash
 #[link_section = ".end_block"]
 #[used]
+#[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static END_IMAGE_DEF: hal::block::Block<1> =
     // Put a placeholder item in the block.
     hal::block::Block::new([hal::block::item_ignored()])

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["thumbv8m.main-none-eabihf"]
 [dependencies]
 # Non-optional dependencies. Keep these sorted by name.
 bitfield = "0.14.0"
-critical-section = "1.0.0"
+critical-section = "1.2.0"
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"

--- a/rp235x-hal/src/spi.rs
+++ b/rp235x-hal/src/spi.rs
@@ -274,10 +274,10 @@ impl<S: State, D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<S, D, P, DS
         (freq_in / (prescale as u32 * (1 + postdiv as u32))).Hz()
     }
 
-    /// Set format and datasize
-    pub fn set_format(&mut self, data_bits: u8, frame_format: FrameFormat) {
+    /// Set format
+    pub fn set_format(&mut self, frame_format: FrameFormat) {
         self.device.sspcr0().modify(|_, w| unsafe {
-            w.dss().bits(data_bits - 1).frf().bits(match &frame_format {
+            w.dss().bits(DS - 1).frf().bits(match &frame_format {
                 FrameFormat::MotorolaSpi(_) => 0x00,
                 FrameFormat::TexasInstrumentsSynchronousSerial => 0x01,
                 FrameFormat::NationalSemiconductorMicrowire => 0x10,
@@ -335,7 +335,7 @@ impl<D: SpiDevice, P: ValidSpiPinout<D>, const DS: u8> Spi<Disabled, D, P, DS> {
         self.device.reset_bring_up(resets);
 
         self.set_baudrate(peri_frequency, baudrate);
-        self.set_format(DS, frame_format);
+        self.set_format(frame_format);
         self.set_slave(slave);
         // Always enable DREQ signals -- harmless if DMA is not listening
         self.device


### PR DESCRIPTION
Is there a general problem adding these derives to more structures? I am trying to use a driver for a LCD display, and I can not unwrap the returned result structure because Debug is not implemented by the pin structures used by the driver. This applies to both the concrete pins and the downgraded pins.

These were only the derives I needed to pass both dyn pins and concrete pins to the driver. There are probably a lot more structures where t his derive could be added.
