### PR TITLE
Update critical-section dependency to version 1.2.0

### DIFF
--- a/on-target-tests/Cargo.toml
+++ b/on-target-tests/Cargo.toml
@@ -48,7 +48,7 @@ name = "gpio"
 [dependencies]
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
-critical-section = "1.0.0"
+critical-section = "1.2.0"
 defmt = "0.3"
 defmt-rtt = "0.4"
 defmt-test = "0.3.1"

--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.0"
 cortex-m = "0.7.2"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.1.4"
-critical-section = {version = "1.0.0"}
+critical-section = {version = "1.2.0"}
 defmt = "0.3"
 defmt-rtt = "0.4.0"
 dht-sensor = "0.2.1"

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -21,7 +21,7 @@ targets = ["thumbv6m-none-eabi"]
 # Non-optional dependencies. Keep these sorted by name.
 bitfield = {version = "0.14.0"}
 cortex-m = "0.7.2"
-critical-section = {version = "1.0.0"}
+critical-section = {version = "1.2.0"}
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.1.0"
 cortex-m = "0.7.2"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.1.4"
-critical-section = {version = "1.0.0"}
+critical-section = {version = "1.2.0"}
 defmt = "0.3"
 defmt-rtt = "0.4.0"
 dht-sensor = "0.2.1"

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -20,7 +20,7 @@ targets = ["thumbv8m.main-none-eabihf"]
 [dependencies]
 # Non-optional dependencies. Keep these sorted by name.
 bitfield = "0.14.0"
-critical-section = "1.0.0"
+critical-section = "1.2.0"
 embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"


### PR DESCRIPTION
Older versions contain a soundness bug.