### PR TITLE
Fix warning with rust 1.82.0

### DIFF
--- a/rp-binary-info/src/lib.rs
+++ b/rp-binary-info/src/lib.rs
@@ -106,6 +106,7 @@ extern "C" {
 #[link_section = ".boot_info"]
 #[cfg(feature = "binary-info")]
 #[used]
+#[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static PICOTOOL_HEADER: Header = unsafe {
     Header::new(
         core::ptr::addr_of!(__bi_entries_start),

--- a/rp235x-hal-examples/src/bin/block_loop.rs
+++ b/rp235x-hal-examples/src/bin/block_loop.rs
@@ -37,12 +37,14 @@ extern "C" {
 /// Tell the Boot ROM about our application
 #[link_section = ".start_block"]
 #[used]
+#[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static START_IMAGE_DEF: hal::block::ImageDef =
     hal::block::ImageDef::secure_exe().with_offset(unsafe { core::ptr::addr_of!(start_to_end) });
 
 /// A second Block, and the end of the program in flash
 #[link_section = ".end_block"]
 #[used]
+#[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static END_IMAGE_DEF: hal::block::Block<1> =
     // Put a placeholder item in the block.
     hal::block::Block::new([hal::block::item_ignored()])


### PR DESCRIPTION
Since rust 1.82.0, addr_of is no longer unsafe:
https://github.com/rust-lang/rust/pull/125834

Just removing the unsafe statement would break builds with older versions of rust. Instead, allow the unused_unsafe lint.