### PR TITLE
feat: Make it easier to specify target architecture

### DIFF
--- a/rp235x-hal-examples/.cargo/config.toml
+++ b/rp235x-hal-examples/.cargo/config.toml
@@ -5,6 +5,13 @@
 # writing programs for Raspberry Silicon microcontrollers.
 #
 
+# Add aliases for building and running for the ARM and RISC-V targets.
+[alias]
+build-arm = "build --target=thumbv8m.main-none-eabihf"
+run-arm = "run --target=thumbv8m.main-none-eabihf"
+build-riscv = "build --target=riscv32imac-unknown-none-elf"
+run-riscv = "run --target=riscv32imac-unknown-none-elf"
+
 [build]
 # Set the default target to match the Cortex-M33 in the RP2350
 target = "thumbv8m.main-none-eabihf"

--- a/rp235x-hal-examples/.cargo/config.toml
+++ b/rp235x-hal-examples/.cargo/config.toml
@@ -8,28 +8,16 @@
 # Add aliases for building and running for the ARM and RISC-V targets.
 [alias]
 
-# Build arm or riscv using defaults or other options
+# Build arm or riscv
 bld-arm = "build --target=thumbv8m.main-none-eabihf"
 bld-riscv = "build --target=riscv32imac-unknown-none-elf"
 
-# Run arm or riscv using defaults or other options
+# Run arm or riscv
 run-arm = "run --target=thumbv8m.main-none-eabihf"
 run-riscv = "run --target=riscv32imac-unknown-none-elf"
 
-# Build dev and release for arm
-bda = "bld-arm"
-bra = "bld-arm --release"
-
-# Build dev and release for risc-v
-bdr = "bld-riscv"
-brr = "bld-riscv --release"
-
-# Run dev and release for arm
-rda = "run-arm"
+# Run release for arm or riscv, add other cumstom aliases as desired.
 rra = "run-arm --release"
-
-# Run dev and release for risc-v
-rdr = "run-riscv"
 rrr = "run-riscv --release"
 
 [build]

--- a/rp235x-hal-examples/.cargo/config.toml
+++ b/rp235x-hal-examples/.cargo/config.toml
@@ -7,10 +7,30 @@
 
 # Add aliases for building and running for the ARM and RISC-V targets.
 [alias]
-build-arm = "build --target=thumbv8m.main-none-eabihf"
+
+# Build arm or riscv using defaults or other options
+bld-arm = "build --target=thumbv8m.main-none-eabihf"
+bld-riscv = "build --target=riscv32imac-unknown-none-elf"
+
+# Run arm or riscv using defaults or other options
 run-arm = "run --target=thumbv8m.main-none-eabihf"
-build-riscv = "build --target=riscv32imac-unknown-none-elf"
 run-riscv = "run --target=riscv32imac-unknown-none-elf"
+
+# Build dev and release for arm
+bda = "bld-arm"
+bra = "bld-arm --release"
+
+# Build dev and release for risc-v
+bdr = "bld-riscv"
+brr = "bld-riscv --release"
+
+# Run dev and release for arm
+rda = "run-arm"
+rra = "run-arm --release"
+
+# Run dev and release for risc-v
+rdr = "run-riscv"
+rrr = "run-riscv --release"
 
 [build]
 # Set the default target to match the Cortex-M33 in the RP2350

--- a/rp235x-hal-examples/.cargo/config.toml
+++ b/rp235x-hal-examples/.cargo/config.toml
@@ -9,16 +9,16 @@
 [alias]
 
 # Build arm or riscv
-bld-arm = "build --target=thumbv8m.main-none-eabihf"
-bld-riscv = "build --target=riscv32imac-unknown-none-elf"
+build-arm = "build --target=thumbv8m.main-none-eabihf"
+build-riscv = "build --target=riscv32imac-unknown-none-elf"
 
 # Run arm or riscv
 run-arm = "run --target=thumbv8m.main-none-eabihf"
 run-riscv = "run --target=riscv32imac-unknown-none-elf"
 
-# Run release for arm or riscv, add other cumstom aliases as desired.
-rra = "run-arm --release"
-rrr = "run-riscv --release"
+# Add other custom aliases here, `rrr-blinky` which
+# runs in release mode a riscv version of blinky.
+rrr-blinky = "run-riscv --release --bin=blinky"
 
 [build]
 # Set the default target to match the Cortex-M33 in the RP2350

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -124,7 +124,7 @@ You can also specify the Arm mode target directly by using
 `--target thumbv8m.main-none-eabihf` instead of `--target riscv32imac-unknown-none-elf`.
 
 To build, flash and start the application on the RP235x
-you use `cargo run` with one of the following commands:
+you use `cargo run` with one of the following commands. Note: be sure the RP235x is in BOOTSEL mode before using the `run` command because we use `picotool` to flash and run the binary:
 
 ```console
 $ cargo run --target thumbv8m.main-none-eabihf --bin blinky
@@ -168,7 +168,7 @@ haven't ported to work in RISC-V mode yet.
 
 Here is an example using the `blinky` example in RISC-V mode. We'll build and
 run it first using the default dev profile, emulating the development cycle **Note:** be sure
-the pico 2 is in BOOTSEL mode before the `run` command:
+the RP235x is in BOOTSEL mode before using the `run` command because we use `picotool` to flash and run the binary:
 
 ```console
 $ cargo build --bin blinky --target=riscv32imac-unknown-none-elf
@@ -195,7 +195,7 @@ $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 ```
 
 Next we'll build and run it using the release profile for "final" testing,
-again be sure the pico 2 is in BOOTSEL mode:
+again be sure the RP235x is in BOOTSEL mode:
 
 ```console
 $ cargo run --bin blinky --target=riscv32imac-unknown-none-elf --release

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -56,43 +56,156 @@ https://github.com/rp-rs/rp-hal-boards/ for more details.
 <!-- GETTING STARTED -->
 ## Getting Started
 
-To build all the examples, first grab a copy of the source code:
+To build the examples, first grab a copy of the source code:
 
 ```console
 $ git clone https://github.com/rp-rs/rp-hal.git
 ```
 
-Then use `rustup` to grab the Rust Standard Library for the appropriate targets. There are two targets because the RP2350 has both an Arm mode and a RISC-V mode.
+Then use `rustup` to grab the Rust Standard Library for the appropriate targets. the RP2350
+has two possible targets, thumbv8m.main-none-eabihf for the ARM cpu. And riscv32imac-unknown-none-elf
+for the RISC-V cpu.
 
 ```console
 $ rustup target add thumbv8m.main-none-eabihf
 $ rustup target add riscv32imac-unknown-none-elf
 ```
 
-To build all the examples for Arm mode, run:
+**Note: all examples assume the current directory is <repo root>/rp235x-hal-examples.**
+```
+cd rp235x-hal-examples
+```
 
+The most basic method is to use `cargo build` with the `--bin` flag to specify the example you want to
+build. For example, to build the `blinky` example:
 ```console
-$ cargo build --target=thumbv8m.main-none-eabihf
-   Compiling rp235x-hal-examples v0.1.0 (/home/user/rp-hal/rp235x-hal-examples)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.53s
 $ cargo build --bin blinky
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
+   Compiling proc-macro2 v1.0.89
+   Compiling unicode-ident v1.0.13
+   Compiling syn v1.0.109
+...
+   Compiling pio-parser v0.2.2
+   Compiling rp235x-hal v0.2.0 (/home/wink/prgs/rpi-pico/myrepos/rp-hal-clone/rp235x-hal)
+   Compiling pio-proc v0.2.2
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.97s
+```
+
+This builds the default target, which is the for the ARM at `./target/thumbv8m.main-none-eabihf/debug/blinky`:
+```console
 $ file ./target/thumbv8m.main-none-eabihf/debug/blinky
 ./target/thumbv8m.main-none-eabihf/debug/blinky: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-You can also 'run' an example, which thanks to our supplied
-[`.cargo/config.toml`](./.cargo/config.toml) will invoke Raspberry Pi's
-`picotool` to copy it to an RP235x in USB Bootloader mode. You should install
-that if you don't have it already, from
-<https://github.com/raspberrypi/pico-sdk-tools/releases>.
-
+If you want to build the RISC-V you can specify the target directly to override the default:
 ```console
-$ cargo run --bin blinky --target=thumbv8m.main-none-eabihf
-   Compiling rp235x-hal v0.10.0 (/home/user/rp-hal/rp235x-hal)
-   Compiling rp235x-hal-examples v0.1.0 (/home/user/rp-hal/rp235x-hal-examples)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.62s
-     Running `picotool load -u -v -x -t elf target/thumbv8m.main-none-eabihf/debug/blinky`
+$ cargo build --target=riscv32imac-unknown-none-elf --bin blinky
+   Compiling nb v1.1.0
+   Compiling byteorder v1.5.0
+   Compiling stable_deref_trait v1.2.0
+..
+   Compiling futures v0.3.31
+   Compiling frunk v0.4.3
+   Compiling rp235x-hal v0.2.0 (/home/wink/prgs/rpi-pico/myrepos/rp-hal-clone/rp235x-hal)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.23s```
+```
+
+And we see the RISC-V at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
+```console
+$ file ./target/riscv32imac-unknown-none-elf/debug/blinky
+./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
+```
+
+You can also specify the ARM target directly just pass
+`--target thumbv8m.main-none-eabihf` instead of `--target riscv32imac-unknown-none-elf`.
+
+You can also easily build, flash and start the application on the RP235x
+by using the `cargo run` using command:
+```console
+$ cargo run --target thumbv8m.main-none-eabihf --bin blinky
+$ cargo run --target riscv32imac-unknown-none-elf --bin blinky
+```
+
+You can also specify a release build by passing `--release` to the `cargo build`
+or `cargo run` commands. This will build the example with optimizations enabled:
+```console
+$ cargo run --target thumbv8m.main-none-eabihf --release --bin blinky
+$ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
+```
+
+The above work well but the commands are somewhat verbose. To make building and running
+more succinct we have added some aliases in .carog/config.toml:
+
+```toml
+# Add aliases for building and running for the ARM and RISC-V targets.
+[alias]
+
+# Build arm or riscv using defaults or other options
+bld-arm = "build --target=thumbv8m.main-none-eabihf"
+bld-riscv = "build --target=riscv32imac-unknown-none-elf"
+
+# Run arm or riscv using defaults or other options
+run-arm = "run --target=thumbv8m.main-none-eabihf"
+run-riscv = "run --target=riscv32imac-unknown-none-elf"
+
+# Build dev and release profiles for arm
+bda = "bld-arm"
+bra = "bld-arm --release"
+
+# Build dev and release for profiles risc-v
+bdr = "bld-riscv"
+brr = "bld-riscv --release"
+
+# Run dev and release for profiles arm
+rda = "run-arm"
+rra = "run-arm --release"
+
+# Run dev and release for profiles risc-v
+rdr = "run-riscv"
+rrr = "run-riscv --release"
+```
+
+Using the aliases the commands are much shorter the first is for
+running on ARM in rlease mode and the second is for running on RISC-V in release mode:
+```console
+$ cargo rra --bin blinky
+$ cargo rrr --bin blinky
+```
+
+These are exactly the same as:
+```console
+$ cargo run --target thumbv8m.main-none-eabihf --release --bin blinky
+$ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
+```
+
+Here is the output of running in release mode the `blinky` example on ARM
+after cleaning the build **Note:** have the pico 2 in BOOTSEL mode:
+```console
+$ cargo clean
+     Removed 3565 files, 1.4GiB total
+$ cargo rra --bin blinky
+   Compiling proc-macro2 v1.0.89
+   Compiling unicode-ident v1.0.13
+..
+   Compiling rp235x-hal v0.2.0 (/home/wink/prgs/rpi-pico/myrepos/rp-hal/rp235x-hal)
+   Compiling pio-proc v0.2.2
+    Finished `release` profile [optimized] target(s) in 11.72s
+     Running `picotool load -u -v -x -t elf target/thumbv8m.main-none-eabihf/release/blinky`
+Family id 'rp2350-arm-s' can be downloaded in absolute space:
+  00000000->02000000
+Loading into Flash: [==============================]  100%
+Verifying Flash:    [==============================]  100%
+  OK
+
+The device was rebooted to start the application.
+```
+
+And you can build first and then run, in this case the `blinky` example was already built:
+```console
+$ cargo bra --bin blinky
+    Finished `release` profile [optimized] target(s) in 0.05s
+$ cargo rra --bin blinky
+    Finished `release` profile [optimized] target(s) in 0.05s
+     Running `picotool load -u -v -x -t elf target/thumbv8m.main-none-eabihf/release/blinky`
 Family id 'rp2350-arm-s' can be downloaded in absolute space:
   00000000->02000000
 Loading into Flash: [==============================]  100%
@@ -107,14 +220,13 @@ It is currently possible to build *some* of the examples in RISC-V mode. See
 work. The missing ones probably rely on interrupts, or some other thing we
 haven't ported to work in RISC-V mode yet.
 
+Here is an example using the `blinky` example in RISC-V mode:
 ```console
-$ cargo build --bin blinky --target=riscv32imac-unknown-none-elf
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
-$ file ./target/riscv32imac-unknown-none-elf/debug/blinky
-./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
-$ cargo run --bin blinky --target=riscv32imac-unknown-none-elf
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
-     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/debug/blinky`
+$ cargo brr --bin blinky
+    Finished `release` profile [optimized] target(s) in 0.06s
+$ cargo rrr --bin blinky
+    Finished `release` profile [optimized] target(s) in 0.06s
+     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/release/blinky`
 Family id 'rp2350-riscv' can be downloaded in absolute space:
   00000000->02000000
 Loading into Flash: [==============================]  100%

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -99,7 +99,7 @@ $ file ./target/thumbv8m.main-none-eabihf/debug/blinky
 ./target/thumbv8m.main-none-eabihf/debug/blinky: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-If you want to build the RISC-V mode you specify the target directly to override the default:
+If you want to build a binary that runs in RISC-V mode, then you must specify the RISC-V target to override the default:
 
 ```console
 $ cargo build --target=riscv32imac-unknown-none-elf --bin blinky

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -62,10 +62,9 @@ To build the examples, first grab a copy of the source code:
 $ git clone https://github.com/rp-rs/rp-hal.git
 ```
 
-Then use `rustup` to grab the Rust Standard Library for the appropriate targets. the RP2350
-has two possible targets, thumbv8m.main-none-eabihf for the ARM cpu. And riscv32imac-unknown-none-elf
-for the RISC-V cpu.
-
+Then use `rustup` to grab the Rust Standard Library for the appropriate targets.
+RP2350 has two possible targets: thumbv8m.main-none-eabihf for the ARM cpu, and
+riscv32imac-unknown-none-elf for the RISC-V cpu.
 ```console
 $ rustup target add thumbv8m.main-none-eabihf
 $ rustup target add riscv32imac-unknown-none-elf
@@ -85,7 +84,7 @@ $ cargo build --bin blinky
    Compiling syn v1.0.109
 ...
    Compiling pio-parser v0.2.2
-   Compiling rp235x-hal v0.2.0 (/home/wink/prgs/rpi-pico/myrepos/rp-hal-clone/rp235x-hal)
+   Compiling rp235x-hal v0.2.0
    Compiling pio-proc v0.2.2
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.97s
 ```
@@ -105,21 +104,21 @@ $ cargo build --target=riscv32imac-unknown-none-elf --bin blinky
 ..
    Compiling futures v0.3.31
    Compiling frunk v0.4.3
-   Compiling rp235x-hal v0.2.0 (/home/wink/prgs/rpi-pico/myrepos/rp-hal-clone/rp235x-hal)
+   Compiling rp235x-hal v0.2.0
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.23s```
 ```
 
-And we see the RISC-V at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
+And we can see that a RISC-V elf file is now present at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
 ```console
 $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 ./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-You can also specify the ARM target directly just pass
+You can also specify the ARM target directly by using
 `--target thumbv8m.main-none-eabihf` instead of `--target riscv32imac-unknown-none-elf`.
 
 You can also easily build, flash and start the application on the RP235x
-by using the `cargo run` using command:
+by using the `cargo run` with one of the following commands:
 ```console
 $ cargo run --target thumbv8m.main-none-eabihf --bin blinky
 $ cargo run --target riscv32imac-unknown-none-elf --bin blinky
@@ -133,39 +132,20 @@ $ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
 ```
 
 The above work well but the commands are somewhat verbose. To make building and running
-more succinct we have added some aliases in .carog/config.toml:
+commands more succinct an `[alias]` section is added to [.cargo/config.toml](../.cargo/config.toml)
+that define:
+| Command Alias   | Description |
+|-----------|-------------|
+| bld-arm   | build for ARM |
+| bld-riscv | build for RISC-V |
+| run-arm   | run on ARM |
+| run-riscv | run on RISC-V |
+| rra       | run release ARM |
+| rrr       | run release RISC-V |
 
-```toml
-# Add aliases for building and running for the ARM and RISC-V targets.
-[alias]
-
-# Build arm or riscv using defaults or other options
-bld-arm = "build --target=thumbv8m.main-none-eabihf"
-bld-riscv = "build --target=riscv32imac-unknown-none-elf"
-
-# Run arm or riscv using defaults or other options
-run-arm = "run --target=thumbv8m.main-none-eabihf"
-run-riscv = "run --target=riscv32imac-unknown-none-elf"
-
-# Build dev and release profiles for arm
-bda = "bld-arm"
-bra = "bld-arm --release"
-
-# Build dev and release for profiles risc-v
-bdr = "bld-riscv"
-brr = "bld-riscv --release"
-
-# Run dev and release for profiles arm
-rda = "run-arm"
-rra = "run-arm --release"
-
-# Run dev and release for profiles risc-v
-rdr = "run-riscv"
-rrr = "run-riscv --release"
-```
-
-Using the aliases the commands are much shorter the first is for
-running on ARM in rlease mode and the second is for running on RISC-V in release mode:
+When using these aliases your build/run commands are much shorter.
+Lets run the blinky example again, using `cargo rra` for running
+on ARM in release mode and `cargo rrr` for running on RISC-V in release mode:
 ```console
 $ cargo rra --bin blinky
 $ cargo rrr --bin blinky
@@ -177,8 +157,9 @@ $ cargo run --target thumbv8m.main-none-eabihf --release --bin blinky
 $ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
 ```
 
-Here is the output of running in release mode the `blinky` example on ARM
-after cleaning the build **Note:** have the pico 2 in BOOTSEL mode:
+Here is the output of running the `blinky` example in release mode on ARM
+after cleaning the build **Note:** have the pico 2 in BOOTSEL mode before
+running this command:
 ```console
 $ cargo clean
      Removed 3565 files, 1.4GiB total
@@ -186,7 +167,7 @@ $ cargo rra --bin blinky
    Compiling proc-macro2 v1.0.89
    Compiling unicode-ident v1.0.13
 ..
-   Compiling rp235x-hal v0.2.0 (/home/wink/prgs/rpi-pico/myrepos/rp-hal/rp235x-hal)
+   Compiling rp235x-hal v0.2.0
    Compiling pio-proc v0.2.2
     Finished `release` profile [optimized] target(s) in 11.72s
      Running `picotool load -u -v -x -t elf target/thumbv8m.main-none-eabihf/release/blinky`
@@ -222,11 +203,13 @@ haven't ported to work in RISC-V mode yet.
 
 Here is an example using the `blinky` example in RISC-V mode:
 ```console
-$ cargo brr --bin blinky
-    Finished `release` profile [optimized] target(s) in 0.06s
-$ cargo rrr --bin blinky
-    Finished `release` profile [optimized] target(s) in 0.06s
-     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/release/blinky`
+cargo build --bin blinky --target=riscv32imac-unknown-none-elf
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
+$ file ./target/riscv32imac-unknown-none-elf/debug/blinky
+./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
+$ cargo run --bin blinky --target=riscv32imac-unknown-none-elf
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
+     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/debug/blinky`
 Family id 'rp2350-riscv' can be downloaded in absolute space:
   00000000->02000000
 Loading into Flash: [==============================]  100%

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -89,13 +89,14 @@ $ cargo build --bin blinky
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.97s
 ```
 
-This builds the default target, which is the for the ARM at `./target/thumbv8m.main-none-eabihf/debug/blinky`:
+This builds the default target, which is the for the ARM and the elf file
+is located at `./target/thumbv8m.main-none-eabihf/debug/blinky`:
 ```console
 $ file ./target/thumbv8m.main-none-eabihf/debug/blinky
 ./target/thumbv8m.main-none-eabihf/debug/blinky: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-If you want to build the RISC-V you can specify the target directly to override the default:
+If you want to build the RISC-V you specify the target directly to override the default:
 ```console
 $ cargo build --target=riscv32imac-unknown-none-elf --bin blinky
    Compiling nb v1.1.0
@@ -108,7 +109,7 @@ $ cargo build --target=riscv32imac-unknown-none-elf --bin blinky
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.23s```
 ```
 
-And we can see that a RISC-V elf file is now present at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
+And we see that the RISC-V elf file is now present at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
 ```console
 $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 ./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
@@ -117,99 +118,140 @@ $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 You can also specify the ARM target directly by using
 `--target thumbv8m.main-none-eabihf` instead of `--target riscv32imac-unknown-none-elf`.
 
-You can also easily build, flash and start the application on the RP235x
-by using the `cargo run` with one of the following commands:
+To build, flash and start the application on the RP235x
+you use `cargo run` with one of the following commands:
 ```console
 $ cargo run --target thumbv8m.main-none-eabihf --bin blinky
 $ cargo run --target riscv32imac-unknown-none-elf --bin blinky
 ```
 
-You can also specify a release build by passing `--release` to the `cargo build`
+For a release build pass `--release` to the `cargo build`
 or `cargo run` commands. This will build the example with optimizations enabled:
 ```console
 $ cargo run --target thumbv8m.main-none-eabihf --release --bin blinky
 $ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
 ```
 
-The above work well but the commands are somewhat verbose. To make building and running
-commands more succinct an `[alias]` section is added to [.cargo/config.toml](../.cargo/config.toml)
-that define:
-| Command Alias   | Description |
-|-----------|-------------|
-| bld-arm   | build for ARM |
-| bld-riscv | build for RISC-V |
-| run-arm   | run on ARM |
-| run-riscv | run on RISC-V |
-| rra       | run release ARM |
-| rrr       | run release RISC-V |
-
-When using these aliases your build/run commands are much shorter.
-Lets run the blinky example again, using `cargo rra` for running
-on ARM in release mode and `cargo rrr` for running on RISC-V in release mode:
-```console
-$ cargo rra --bin blinky
-$ cargo rrr --bin blinky
-```
-
-These are exactly the same as:
-```console
-$ cargo run --target thumbv8m.main-none-eabihf --release --bin blinky
-$ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
-```
-
-Here is the output of running the `blinky` example in release mode on ARM
-after cleaning the build **Note:** have the pico 2 in BOOTSEL mode before
-running this command:
+For the ARM target all of the examples are built if no `--bin` is specified:
 ```console
 $ cargo clean
-     Removed 3565 files, 1.4GiB total
-$ cargo rra --bin blinky
+     Removed 1488 files, 398.6MiB total
+$ cargo build --target thumbv8m.main-none-eabihf
    Compiling proc-macro2 v1.0.89
    Compiling unicode-ident v1.0.13
 ..
    Compiling rp235x-hal v0.2.0
    Compiling pio-proc v0.2.2
-    Finished `release` profile [optimized] target(s) in 11.72s
-     Running `picotool load -u -v -x -t elf target/thumbv8m.main-none-eabihf/release/blinky`
-Family id 'rp2350-arm-s' can be downloaded in absolute space:
-  00000000->02000000
-Loading into Flash: [==============================]  100%
-Verifying Flash:    [==============================]  100%
-  OK
-
-The device was rebooted to start the application.
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.08s
+$ find target/thumbv8m.main-none-eabihf/debug/ -maxdepth 1 -type f -executable | sort
+target/thumbv8m.main-none-eabihf/debug/adc
+target/thumbv8m.main-none-eabihf/debug/adc_fifo_dma
+..
+target/thumbv8m.main-none-eabihf/debug/blinky
+..
+target/thumbv8m.main-none-eabihf/debug/vector_table
+target/thumbv8m.main-none-eabihf/debug/watchdog
 ```
 
-And you can build first and then run, in this case the `blinky` example was already built:
-```console
-$ cargo bra --bin blinky
-    Finished `release` profile [optimized] target(s) in 0.05s
-$ cargo rra --bin blinky
-    Finished `release` profile [optimized] target(s) in 0.05s
-     Running `picotool load -u -v -x -t elf target/thumbv8m.main-none-eabihf/release/blinky`
-Family id 'rp2350-arm-s' can be downloaded in absolute space:
-  00000000->02000000
-Loading into Flash: [==============================]  100%
-Verifying Flash:    [==============================]  100%
-  OK
-
-The device was rebooted to start the application.
-```
-
-It is currently possible to build *some* of the examples in RISC-V mode. See
-[`riscv_examples.txt`](./riscv_examples.txt) for a list of the examples known to
-work. The missing ones probably rely on interrupts, or some other thing we
+For the RISC-V it is currently possible to build only *some* of the examples. See
+[`riscv_examples.txt`](./riscv_examples.txt) for a list of known working examples.
+The missing ones probably rely on interrupts, or some other thing we
 haven't ported to work in RISC-V mode yet.
 
-Here is an example using the `blinky` example in RISC-V mode:
+Here is an example using the `blinky` example in RISC-V mode. We'll build and
+run it first in non-release emulating the developement cycle **Note:** be sure
+the pico 2 is in BOOTSEL mode before the `run` command:
 ```console
-cargo build --bin blinky --target=riscv32imac-unknown-none-elf
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
+$ cargo build --bin blinky --target=riscv32imac-unknown-none-elf
+   Compiling rp235x-hal-examples v0.1.0
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
+$ cargo run --bin blinky --target=riscv32imac-unknown-none-elf
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
+     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/debug/blinky`
+Family id 'rp2350-riscv' can be downloaded in absolute space:
+  00000000->02000000
+Loading into Flash: [==============================]  100%
+Verifying Flash:    [==============================]  100%
+  OK
+
+The device was rebooted to start the application.
+```
+
+At this point the development version is running on the RP2350 and the LED is blinking.
+When we look at `blinky` using `file` we see we have an RISC-V ELF file and using `ls`
+we see it is quite large, 2.4M:
+```console
 $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 ./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
-$ cargo run --bin blinky --target=riscv32imac-unknown-none-elf
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
+$ ls -l ./target/riscv32imac-unknown-none-elf/debug/blinky
+-rwxr-xr-x 2 wink users 2432556 Oct 29 12:59 ./target/riscv32imac-unknown-none-elf/debug/blinky
+$ ls -lh ./target/riscv32imac-unknown-none-elf/debug/blinky
+-rwxr-xr-x 2 wink users 2.4M Oct 29 12:59 ./target/riscv32imac-unknown-none-elf/debug/blinky
+```
+
+Next we'll build and run it in release mode for "final" testing,
+again be sure the pico 2 is in BOOTSEL mode:
+```console
+$ cargo run --bin blinky --target=riscv32imac-unknown-none-elf --release
+   Compiling proc-macro2 v1.0.89
+   Compiling unicode-ident v1.0.13
+..
+   Compiling pio-parser v0.2.2
+   Compiling pio-proc v0.2.2
+    Finished `release` profile [optimized] target(s) in 17.05s
+     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/release/blinky`
+Family id 'rp2350-riscv' can be downloaded in absolute space:
+  00000000->02000000
+Loading into Flash: [==============================]  100%
+Verifying Flash:    [==============================]  100%
+  OK
+
+The device was rebooted to start the application.
+```
+
+The LED should be blinking and looking at `blinky` we see
+it is now much smaller at 87K:
+```console
+$ file ./target/riscv32imac-unknown-none-elf/release/blinky
+./target/riscv32imac-unknown-none-elf/release/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, not stripped
+$ ls -lh ./target/riscv32imac-unknown-none-elf/release/blinky
+-rwxr-xr-x 2 wink users 87K Oct 29 12:55 ./target/riscv32imac-unknown-none-elf/release/blinky
+```
+
+The above commands work well, but the commands are somewhat verbose.
+To make building and running commands more succinct an `[alias]` section
+has been added to [.cargo/config.toml](../.cargo/config.toml) that define:
+| Command Alias   | Description |
+|---|---|
+| build-arm   | build for ARM |
+| build-riscv | build for RISC-V |
+| run-arm   | run on ARM |
+| run-riscv | run on RISC-V |
+| rrr-blinky | run release on RISC-V blinky |
+
+When using these aliases your build and run commands are much shorter.
+Below we see the development cycle using `build-riscv` and `run-riscv`:
+```console
+$ cargo build-riscv --bin blinky
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
+$ cargo run-riscv --bin blinky
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
      Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/debug/blinky`
+Family id 'rp2350-riscv' can be downloaded in absolute space:
+  00000000->02000000
+Loading into Flash: [==============================]  100%
+Verifying Flash:    [==============================]  100%
+  OK
+
+The device was rebooted to start the application.
+```
+
+And for the `run` command in `--release` mode for the RISC-V we added the `rrr-blinky` alias
+as an example of customization. You might want to add others as you see fit:
+```console
+$ cargo rrr-blinky
+    Finished `release` profile [optimized] target(s) in 0.05s
+     Running `picotool load -u -v -x -t elf target/riscv32imac-unknown-none-elf/release/blinky`
 Family id 'rp2350-riscv' can be downloaded in absolute space:
   00000000->02000000
 Loading into Flash: [==============================]  100%

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -63,20 +63,22 @@ $ git clone https://github.com/rp-rs/rp-hal.git
 ```
 
 Then use `rustup` to grab the Rust Standard Library for the appropriate targets.
-RP2350 has two possible targets: thumbv8m.main-none-eabihf for the ARM cpu, and
-riscv32imac-unknown-none-elf for the RISC-V cpu.
+RP2350 has two possible targets: `thumbv8m.main-none-eabihf` for the Arm mode, and
+`riscv32imac-unknown-none-elf` for the RISC-V mode.
+
 ```console
 $ rustup target add thumbv8m.main-none-eabihf
 $ rustup target add riscv32imac-unknown-none-elf
 ```
 
-**Note: all examples assume the current directory is <repo root>/rp235x-hal-examples.**
+**Note: all examples assume the current directory is `<repo root>/rp235x-hal-examples`.**
 ```
 cd rp235x-hal-examples
 ```
 
 The most basic method is to use `cargo build` with the `--bin` flag to specify the example you want to
 build. For example, to build the `blinky` example:
+
 ```console
 $ cargo build --bin blinky
    Compiling proc-macro2 v1.0.89
@@ -89,14 +91,16 @@ $ cargo build --bin blinky
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.97s
 ```
 
-This builds the default target, which is the for the ARM and the elf file
+This builds the default target, which is Arm mode and the ELF file
 is located at `./target/thumbv8m.main-none-eabihf/debug/blinky`:
+
 ```console
 $ file ./target/thumbv8m.main-none-eabihf/debug/blinky
 ./target/thumbv8m.main-none-eabihf/debug/blinky: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-If you want to build the RISC-V you specify the target directly to override the default:
+If you want to build the RISC-V mode you specify the target directly to override the default:
+
 ```console
 $ cargo build --target=riscv32imac-unknown-none-elf --bin blinky
    Compiling nb v1.1.0
@@ -109,30 +113,34 @@ $ cargo build --target=riscv32imac-unknown-none-elf --bin blinky
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.23s```
 ```
 
-And we see that the RISC-V elf file is now present at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
+And we see that the RISC-V mode ELF file is now present at `./target/riscv32imac-unknown-none-elf/debug/blinky`:
+
 ```console
 $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 ./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
 ```
 
-You can also specify the ARM target directly by using
+You can also specify the Arm mode target directly by using
 `--target thumbv8m.main-none-eabihf` instead of `--target riscv32imac-unknown-none-elf`.
 
 To build, flash and start the application on the RP235x
 you use `cargo run` with one of the following commands:
+
 ```console
 $ cargo run --target thumbv8m.main-none-eabihf --bin blinky
 $ cargo run --target riscv32imac-unknown-none-elf --bin blinky
 ```
 
-For a release build pass `--release` to the `cargo build`
+For the release profile build pass `--release` to the `cargo build`
 or `cargo run` commands. This will build the example with optimizations enabled:
+
 ```console
 $ cargo run --target thumbv8m.main-none-eabihf --release --bin blinky
 $ cargo run --target riscv32imac-unknown-none-elf --release --bin blinky
 ```
 
-For the ARM target all of the examples are built if no `--bin` is specified:
+For the Arm mode target all of the examples are built if no `--bin` is specified:
+
 ```console
 $ cargo clean
      Removed 1488 files, 398.6MiB total
@@ -153,14 +161,15 @@ target/thumbv8m.main-none-eabihf/debug/vector_table
 target/thumbv8m.main-none-eabihf/debug/watchdog
 ```
 
-For the RISC-V it is currently possible to build only *some* of the examples. See
+For the RISC-V mode it is currently possible to build only *some* of the examples. See
 [`riscv_examples.txt`](./riscv_examples.txt) for a list of known working examples.
 The missing ones probably rely on interrupts, or some other thing we
 haven't ported to work in RISC-V mode yet.
 
 Here is an example using the `blinky` example in RISC-V mode. We'll build and
-run it first in non-release emulating the developement cycle **Note:** be sure
+run it first using the default dev profile, emulating the development cycle **Note:** be sure
 the pico 2 is in BOOTSEL mode before the `run` command:
+
 ```console
 $ cargo build --bin blinky --target=riscv32imac-unknown-none-elf
    Compiling rp235x-hal-examples v0.1.0
@@ -178,19 +187,16 @@ The device was rebooted to start the application.
 ```
 
 At this point the development version is running on the RP2350 and the LED is blinking.
-When we look at `blinky` using `file` we see we have an RISC-V ELF file and using `ls`
-we see it is quite large, 2.4M:
+When we look at `blinky` using `file` we see we have generated a RISC-V mode ELF file:
+
 ```console
 $ file ./target/riscv32imac-unknown-none-elf/debug/blinky
 ./target/riscv32imac-unknown-none-elf/debug/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, with debug_info, not stripped
-$ ls -l ./target/riscv32imac-unknown-none-elf/debug/blinky
--rwxr-xr-x 2 wink users 2432556 Oct 29 12:59 ./target/riscv32imac-unknown-none-elf/debug/blinky
-$ ls -lh ./target/riscv32imac-unknown-none-elf/debug/blinky
--rwxr-xr-x 2 wink users 2.4M Oct 29 12:59 ./target/riscv32imac-unknown-none-elf/debug/blinky
 ```
 
-Next we'll build and run it in release mode for "final" testing,
+Next we'll build and run it using the release profile for "final" testing,
 again be sure the pico 2 is in BOOTSEL mode:
+
 ```console
 $ cargo run --bin blinky --target=riscv32imac-unknown-none-elf --release
    Compiling proc-macro2 v1.0.89
@@ -209,13 +215,11 @@ Verifying Flash:    [==============================]  100%
 The device was rebooted to start the application.
 ```
 
-The LED should be blinking and looking at `blinky` we see
-it is now much smaller at 87K:
+The LED should be blinking and looking at `blinky`
+
 ```console
 $ file ./target/riscv32imac-unknown-none-elf/release/blinky
 ./target/riscv32imac-unknown-none-elf/release/blinky: ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked, not stripped
-$ ls -lh ./target/riscv32imac-unknown-none-elf/release/blinky
--rwxr-xr-x 2 wink users 87K Oct 29 12:55 ./target/riscv32imac-unknown-none-elf/release/blinky
 ```
 
 The above commands work well, but the commands are somewhat verbose.
@@ -231,6 +235,7 @@ has been added to [.cargo/config.toml](../.cargo/config.toml) that define:
 
 When using these aliases your build and run commands are much shorter.
 Below we see the development cycle using `build-riscv` and `run-riscv`:
+
 ```console
 $ cargo build-riscv --bin blinky
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
@@ -246,8 +251,9 @@ Verifying Flash:    [==============================]  100%
 The device was rebooted to start the application.
 ```
 
-And for the `run` command in `--release` mode for the RISC-V we added the `rrr-blinky` alias
+And for the `run` command in `--release` profile and a RISC-V mode we added the `rrr-blinky` alias
 as an example of customization. You might want to add others as you see fit:
+
 ```console
 $ cargo rrr-blinky
     Finished `release` profile [optimized] target(s) in 0.05s

--- a/rp235x-hal-examples/README.md
+++ b/rp235x-hal-examples/README.md
@@ -215,7 +215,7 @@ Verifying Flash:    [==============================]  100%
 The device was rebooted to start the application.
 ```
 
-The LED should be blinking and looking at `blinky`
+The LED should be blinking as we are now running this binary:
 
 ```console
 $ file ./target/riscv32imac-unknown-none-elf/release/blinky


### PR DESCRIPTION
    Create aliases build-arm run-arm build-riscv and run-riscv in
    .cargo/config.toml. With these defined you can now use the alias which
    will be converted to the full target name:

      cargo build-arm   -> cargo build --target thumbv8m.main-none-eabihf
      cargo run-arm     -> cargo run --target thumbv8m.main-none-eabihf
      cargo build-riscv -> cargo build --target riscv32imac-unknown-none-elf
      cargo run-risv    -> cargo run --target riscv32imac-unknown-none-elf

    Append --release parameter to do release builds and runs. For example:

      cargo run-riscv --release ->
             cargo run --target riscv32imac-unknown-none-elf --release

feat: Make it easier to specify target architecture

Create aliases build-arm run-arm build-riscv and run-riscv in .cargo/config.toml. With these defined you can now use the alias which will be converted to the full target name:

  cargo build-arm --bin blinky ->
  	cargo build --bin blinky --target=thumbv8m.main-none-eabihf
  cargo run-arm --bin blinky ->
  	cargo run --bin blinky --target=thumbv8m.main-none-eabihf
  cargo build-riscv --bin blinky ->
  	cargo build --bin blinky --target=riscv32imac-unknown-none-elf
  cargo run-risv --bin blinky ->
  	cargo run --bin blinky --target=riscv32imac-unknown-none-elf

Append --release parameter to do release builds and runs. For example:

  cargo run-risv --bin blinky --release ->
  	cargo run --bin blinky --target=thumbv8m.main-none-eabihf --release