### PR TITLE
Implement support for XipCS1 pin function.

### DIFF
--- a/rp235x-hal/src/gpio/func.rs
+++ b/rp235x-hal/src/gpio/func.rs
@@ -48,6 +48,8 @@ pub enum DynFunction {
     /// The 'Clock' function. This can be used to input or output clock references to or from the
     /// rp235x.
     Clock,
+    /// The XIP CS1 function.
+    XipCs1,
     /// The 'USB' function. Only VBUS detect, VBUS enable and overcurrent detect are configurable.
     /// Other USB io have dedicated pins.
     Usb,
@@ -105,7 +107,7 @@ macro_rules! pin_func {
         })*
     };
 }
-pin_func!(Xip, Spi, Uart, I2c as I2C, Pwm, Pio0, Pio1, Pio2, Clock, Usb, UartAux, Null);
+pin_func!(Xip, Spi, Uart, I2c as I2C, Pwm, Pio0, Pio1, Pio2, Clock, XipCs1, Usb, UartAux, Null);
 
 //==============================================================================
 // SIO sub-types
@@ -169,6 +171,7 @@ impl DynFunction {
         let dyn_pin = id.as_dyn();
         match (self, dyn_pin.bank, dyn_pin.num) {
             (Xip, Bank0, _) => false,
+            (XipCs1, Bank0, 0 | 8 | 19 | 47) => true,
             (Clock, _, 0..=19 | 26..=29) => false,
             (UartAux, _, n) if (n & 0x02) == 0 => false,
             (_, Bank0, 0..=29) => true,
@@ -205,6 +208,7 @@ pin_valid_func!(
     [2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27]
 );
 pin_valid_func!(bank0 as Gpio, [Clock], [20, 21, 22, 23, 24, 25]);
+pin_valid_func!(bank0 as Gpio, [XipCs1], [0, 8, 19, 47]);
 pin_valid_func!(qspi as Qspi, [Xip, Null], [Sclk, Sd0, Sd1, Sd2, Sd3, Ss]);
 
 macro_rules! pin_valid_func_sio {

--- a/rp235x-hal/src/gpio/pin.rs
+++ b/rp235x-hal/src/gpio/pin.rs
@@ -168,6 +168,7 @@ pub(crate) fn set_function<P: PinId>(pin: &P, function: DynFunction) {
         DynFunction::Pio1 => FUNCSEL_A::PIO1,
         DynFunction::Pio2 => FUNCSEL_A::PIO2,
         DynFunction::Clock => FUNCSEL_A::GPCK,
+        DynFunction::XipCs1 => FUNCSEL_A::GPCK,
         DynFunction::Usb => FUNCSEL_A::USB,
         DynFunction::UartAux => FUNCSEL_A::UART_AUX,
         DynFunction::Null => FUNCSEL_A::NULL,


### PR DESCRIPTION
Implement support for XipCS1 pin function which is necessary to implement support for external ram or flash.


Note: The rp235x-pac is missing function select definition for XipCS1:
https://github.com/rp-rs/rp235x-pac/blob/main/svd/RP2350.yaml#L321

But `FUNCSEL_A::GPCK` has the same value (9). We should add a variant specific for XipCS1.