### PR TITLE
Add a nice wrapper for `get_sys_info`

### DIFF
--- a/rp235x-hal-examples/src/bin/rom_funcs.rs
+++ b/rp235x-hal-examples/src/bin/rom_funcs.rs
@@ -237,13 +237,11 @@ where
 {
     let result = hal::rom_data::sys_info_api::chip_info();
     let result = match result {
-        Ok(result) => {
-            match result {
-                Some(result) => result,
-                None => {
-                    _ = writeln!(uart, "chip_info() not supported");
-                    return;
-                }
+        Ok(result) => match result {
+            Some(result) => result,
+            None => {
+                _ = writeln!(uart, "chip_info() not supported");
+                return;
             }
         },
         Err(e) => {
@@ -265,13 +263,11 @@ where
 {
     let result = hal::rom_data::sys_info_api::cpu_info();
     let result = match result {
-        Ok(result) => {
-            match result {
-                Some(result) => result,
-                None => {
-                    _ = writeln!(uart, "cpu_info() not supported");
-                    return;
-                }
+        Ok(result) => match result {
+            Some(result) => result,
+            None => {
+                _ = writeln!(uart, "cpu_info() not supported");
+                return;
             }
         },
         Err(e) => {
@@ -298,13 +294,11 @@ where
 {
     let result = hal::rom_data::sys_info_api::flash_dev_info();
     let result = match result {
-        Ok(result) => {
-            match result {
-                Some(result) => result,
-                None => {
-                    _ = writeln!(uart, "flash_dev_info() not supported");
-                    return;
-                }
+        Ok(result) => match result {
+            Some(result) => result,
+            None => {
+                _ = writeln!(uart, "flash_dev_info() not supported");
+                return;
             }
         },
         Err(e) => {
@@ -331,7 +325,11 @@ where
         FlashDevInfoSize::Unknown => "Unknown",
     };
     _ = writeln!(uart, "\tCS1 GPIO: {}", result.cs1_gpio());
-    _ = writeln!(uart, "\tD8H Erase Supported: {}", result.d8h_erase_supported());
+    _ = writeln!(
+        uart,
+        "\tD8H Erase Supported: {}",
+        result.d8h_erase_supported()
+    );
     _ = writeln!(uart, "\tCS0 Size: {}", size_lookup(result.cs0_size()));
     _ = writeln!(uart, "\tCS1 Size: {}", size_lookup(result.cs1_size()));
 }
@@ -343,13 +341,11 @@ where
 {
     let result = hal::rom_data::sys_info_api::boot_random();
     let result = match result {
-        Ok(result) => {
-            match result {
-                Some(result) => result,
-                None => {
-                    _ = writeln!(uart, "boot_random() not supported");
-                    return;
-                }
+        Ok(result) => match result {
+            Some(result) => result,
+            None => {
+                _ = writeln!(uart, "boot_random() not supported");
+                return;
             }
         },
         Err(e) => {
@@ -369,13 +365,11 @@ where
 {
     let result = hal::rom_data::sys_info_api::boot_info();
     let result = match result {
-        Ok(result) => {
-            match result {
-                Some(result) => result,
-                None => {
-                    _ = writeln!(uart, "boot_info() not supported");
-                    return;
-                }
+        Ok(result) => match result {
+            Some(result) => result,
+            None => {
+                _ = writeln!(uart, "boot_info() not supported");
+                return;
             }
         },
         Err(e) => {
@@ -385,27 +379,39 @@ where
     };
 
     _ = writeln!(uart, "get_sys_info(start_block/0x0040)");
-    _ = writeln!(uart, "\tDiagnostic Partition: {}", match result.diagnostic_partition {
-        PartitionIndex::Partition(_) => "Numbered partition",
-        PartitionIndex::None => "None",
-        PartitionIndex::Slot0 => "Slot 0",
-        PartitionIndex::Slot1 => "Slot 1",
-        PartitionIndex::Image => "Image",
-        PartitionIndex::Unknown => "Unknown",
-    });
-    _ = writeln!(uart, "\tBoot Type: {}", match result.boot_type {
-        BootType::Normal => "Normal",
-        BootType::BootSel => "bootsel",
-        BootType::RamImage => "RAM image",
-        BootType::FlashUpdate => "Flash update",
-        BootType::PcSp => "pc_sp",
-        BootType::Unknown => "Unknown",
-    });
+    _ = writeln!(
+        uart,
+        "\tDiagnostic Partition: {}",
+        match result.diagnostic_partition {
+            PartitionIndex::Partition(_) => "Numbered partition",
+            PartitionIndex::None => "None",
+            PartitionIndex::Slot0 => "Slot 0",
+            PartitionIndex::Slot1 => "Slot 1",
+            PartitionIndex::Image => "Image",
+            PartitionIndex::Unknown => "Unknown",
+        }
+    );
+    _ = writeln!(
+        uart,
+        "\tBoot Type: {}",
+        match result.boot_type {
+            BootType::Normal => "Normal",
+            BootType::BootSel => "bootsel",
+            BootType::RamImage => "RAM image",
+            BootType::FlashUpdate => "Flash update",
+            BootType::PcSp => "pc_sp",
+            BootType::Unknown => "Unknown",
+        }
+    );
     _ = writeln!(uart, "\tChained: {}", result.chained);
     _ = writeln!(uart, "\tPartition: {}", result.partition);
     _ = writeln!(uart, "\tTBYB Info: {:02x}", result.tbyb_update_info);
     _ = writeln!(uart, "\tBoot Diagnostic: {:04x}", result.boot_diagnostic);
-    _ = writeln!(uart, "\tBoot Params: {:04x}, {:04x}", result.boot_params[0], result.boot_params[1]);
+    _ = writeln!(
+        uart,
+        "\tBoot Params: {:04x}, {:04x}",
+        result.boot_params[0], result.boot_params[1]
+    );
 }
 
 /// Run get_partition_table_info

--- a/rp235x-hal-examples/src/bin/rom_funcs.rs
+++ b/rp235x-hal-examples/src/bin/rom_funcs.rs
@@ -240,7 +240,7 @@ where
         Ok(None) => {
             _ = writeln!(uart, "chip_info() not supported");
             return;
-        },
+        }
         Err(e) => {
             _ = writeln!(uart, "Failed to get chip info : {:?}", e);
             return;
@@ -263,7 +263,7 @@ where
         Ok(None) => {
             _ = writeln!(uart, "cpu_info() not supported");
             return;
-        },
+        }
         Err(e) => {
             _ = writeln!(uart, "Failed to get cpu info: {:?}", e);
             return;
@@ -291,7 +291,7 @@ where
         Ok(None) => {
             _ = writeln!(uart, "flash_dev_info() not supported");
             return;
-        },
+        }
         Err(e) => {
             _ = writeln!(uart, "Failed to get flash device info: {:?}", e);
             return;
@@ -335,7 +335,7 @@ where
         Ok(None) => {
             _ = writeln!(uart, "boot_random() not supported");
             return;
-        },
+        }
         Err(e) => {
             _ = writeln!(uart, "Failed to get random boot integer: {:?}", e);
             return;
@@ -356,7 +356,7 @@ where
         Ok(None) => {
             _ = writeln!(uart, "boot_info() not supported");
             return;
-        },
+        }
         Err(e) => {
             _ = writeln!(uart, "Failed to get boot info: {:?}", e);
             return;

--- a/rp235x-hal-examples/src/bin/rom_funcs.rs
+++ b/rp235x-hal-examples/src/bin/rom_funcs.rs
@@ -235,14 +235,11 @@ fn get_sys_info_chip_info<T>(uart: &mut T)
 where
     T: core::fmt::Write,
 {
-    let result = hal::rom_data::sys_info_api::chip_info();
-    let result = match result {
-        Ok(result) => match result {
-            Some(result) => result,
-            None => {
-                _ = writeln!(uart, "chip_info() not supported");
-                return;
-            }
+    let result = match hal::rom_data::sys_info_api::chip_info() {
+        Ok(Some(result)) => result,
+        Ok(None) => {
+            _ = writeln!(uart, "chip_info() not supported");
+            return;
         },
         Err(e) => {
             _ = writeln!(uart, "Failed to get chip info : {:?}", e);
@@ -261,14 +258,11 @@ fn get_sys_info_cpu_info<T>(uart: &mut T)
 where
     T: core::fmt::Write,
 {
-    let result = hal::rom_data::sys_info_api::cpu_info();
-    let result = match result {
-        Ok(result) => match result {
-            Some(result) => result,
-            None => {
-                _ = writeln!(uart, "cpu_info() not supported");
-                return;
-            }
+    let result = match hal::rom_data::sys_info_api::cpu_info() {
+        Ok(Some(result)) => result,
+        Ok(None) => {
+            _ = writeln!(uart, "cpu_info() not supported");
+            return;
         },
         Err(e) => {
             _ = writeln!(uart, "Failed to get cpu info: {:?}", e);
@@ -292,14 +286,11 @@ fn get_sys_info_flash_dev_info<T>(uart: &mut T)
 where
     T: core::fmt::Write,
 {
-    let result = hal::rom_data::sys_info_api::flash_dev_info();
-    let result = match result {
-        Ok(result) => match result {
-            Some(result) => result,
-            None => {
-                _ = writeln!(uart, "flash_dev_info() not supported");
-                return;
-            }
+    let result = match hal::rom_data::sys_info_api::flash_dev_info() {
+        Ok(Some(result)) => result,
+        Ok(None) => {
+            _ = writeln!(uart, "flash_dev_info() not supported");
+            return;
         },
         Err(e) => {
             _ = writeln!(uart, "Failed to get flash device info: {:?}", e);
@@ -339,14 +330,11 @@ fn get_sys_info_boot_random<T>(uart: &mut T)
 where
     T: core::fmt::Write,
 {
-    let result = hal::rom_data::sys_info_api::boot_random();
-    let result = match result {
-        Ok(result) => match result {
-            Some(result) => result,
-            None => {
-                _ = writeln!(uart, "boot_random() not supported");
-                return;
-            }
+    let result = match hal::rom_data::sys_info_api::boot_random() {
+        Ok(Some(result)) => result,
+        Ok(None) => {
+            _ = writeln!(uart, "boot_random() not supported");
+            return;
         },
         Err(e) => {
             _ = writeln!(uart, "Failed to get random boot integer: {:?}", e);
@@ -363,14 +351,11 @@ fn get_sys_info_start_block<T>(uart: &mut T)
 where
     T: core::fmt::Write,
 {
-    let result = hal::rom_data::sys_info_api::boot_info();
-    let result = match result {
-        Ok(result) => match result {
-            Some(result) => result,
-            None => {
-                _ = writeln!(uart, "boot_info() not supported");
-                return;
-            }
+    let result = match hal::rom_data::sys_info_api::boot_info() {
+        Ok(Some(result)) => result,
+        Ok(None) => {
+            _ = writeln!(uart, "boot_info() not supported");
+            return;
         },
         Err(e) => {
             _ = writeln!(uart, "Failed to get boot info: {:?}", e);

--- a/rp235x-hal/src/rom_data.rs
+++ b/rp235x-hal/src/rom_data.rs
@@ -116,8 +116,8 @@ pub enum BootRomApiErrorCode {
     /// The operation was disallowed by a security constraint
     NotPermitted = -4,
     /// One or more parameters passed to the function is outside the range of
-    /// supported values; BOOTROM_ERROR_INVALID_ADDRESS and
-    /// BOOTROM_ERROR_BAD_ALIGNMENT are more specific errors.
+    /// supported values; [`BootRomApiErrorCode::InvalidAddress`] and
+    /// [`BootRomApiErrorCode::BadAlignment`] are more specific errors.
     InvalidArg = -5,
     /// An address argument was out-of-bounds or was determined to be an address
     /// that the caller may not access
@@ -400,9 +400,10 @@ mod sys_info_api {
         /// be executable
         ValidImageDef = 0x0008,
         /// Whether a partition table is present. This partition table must have a correct structure
-        /// formed if VALID_BLOCK_LOOP is set. If the partition table turns out to be invalid, then
-        /// INVALID_BLOCK_LOOP is set too (thus both VALID_BLOCK_LOOP and INVALID_BLOCK_LOOP will
-        /// both be set)
+        /// formed if [`BootDiagnosticFlags::ValidBlockLoop`] is set. If the partition table turns
+        /// out to be invalid, then [`BootDiagnosticFlags::InvalidBlockLoop`] is set too (thus both
+        /// [`BootDiagnosticFlags::ValidBlockLoop`] and [`BootDiagnosticFlags::InvalidBlockLoop`]
+        /// will both be set)
         HasPartitionTable = 0x0010,
         /// There was a choice of partition/slot and this one was considered. The first slot/partition
         /// is chosen based on a number of factors. If the first choice fails verification, then the
@@ -418,7 +419,7 @@ mod sys_info_api {
         /// PARTITION_TABLE is signed with a key matching one of the four stored in OTP
         PartitionTableMatchingKeyForVerify = 0x0080,
         /// set if a hash value check could be performed. In the case a signature is required, this
-        /// value is identical to PARTITION_TABLE_MATCHING_KEY_FOR_VERIFY
+        /// value is identical to [`BootDiagnosticFlags::PartitionTableMatchingKeyForVerify`]
         PartitionTableHashForVerify = 0x0100,
         /// whether the PARTITION_TABLE passed verification (signature/hash if present/required)
         PartitionTableVerifiedOk = 0x0200,
@@ -426,7 +427,7 @@ mod sys_info_api {
         /// IMAGE_DEF is signed with a key matching one of the four stored in OTP
         ImageDefMatchingKeyForVerify = 0x0400,
         /// set if a hash value check could be performed. In the case a signature is required, this
-        /// value is identical to IMAGE_DEF_MATCHING_KEY_FOR_VERIFY
+        /// value is identical to [`BootDiagnosticFlags::ImageDefMatchingKeyForVerify`]
         ImageDefHashForVerify = 0x0800,
         /// whether the PARTITION_TABLE passed verification (signature/hash if present/required) and
         /// any LOAD_MAP is valid

--- a/rp235x-hal/src/rom_data.rs
+++ b/rp235x-hal/src/rom_data.rs
@@ -194,6 +194,10 @@ pub mod sys_info_api {
     }
 
     impl GetSysInfoFlag {
+        /// Returns the length of the buffer needed to hold the data for the related operation returned
+        /// by [`super::get_sys_info()`]. This includes the initial segment to indicate which flags
+        /// were supported. The underlying enum represent a bitmask and these masks can be OR'd
+        /// together, however the safe API only uses one at a time so adding sizes is not a concern.
         const fn buffer_length(&self) -> usize {
             match self {
                 GetSysInfoFlag::ChipInfo => 4,

--- a/rp235x-hal/src/rom_data.rs
+++ b/rp235x-hal/src/rom_data.rs
@@ -668,13 +668,13 @@ pub mod sys_info_api {
     );
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
-    declare_get_sys_info_function!(
+    declare_get_sys_info_ns_function!(
         /// Get the unique identifier for the chip
         chip_info_ns, ChipInfo, GetSysInfoFlag::ChipInfo
     );
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
-    declare_get_sys_info_function!(
+    declare_get_sys_info_ns_function!(
         /// Get the value of the OTP critical register
         otp_critical_register_ns,
         OtpCriticalReg,
@@ -682,25 +682,25 @@ pub mod sys_info_api {
     );
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
-    declare_get_sys_info_function!(
+    declare_get_sys_info_ns_function!(
         /// Get the current running CPU's info
         cpu_info_ns, CpuInfo, GetSysInfoFlag::CpuInfo
     );
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
-    declare_get_sys_info_function!(
+    declare_get_sys_info_ns_function!(
         /// Get flash device info in the format of OTP FLASH_DEVINFO
         flash_dev_info_ns, FlashDevInfo, GetSysInfoFlag::FlashDevInfo
     );
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
-    declare_get_sys_info_function!(
+    declare_get_sys_info_ns_function!(
         /// Get a 128-bit random number generated on each boot
         boot_random_ns, BootRandom, GetSysInfoFlag::BootRandom
     );
 
     #[cfg(all(target_arch = "arm", target_os = "none"))]
-    declare_get_sys_info_function!(
+    declare_get_sys_info_ns_function!(
         /// Get diagnostic boot info
         boot_info_ns, BootInfo, GetSysInfoFlag::BootInfo
     );

--- a/rp235x-hal/src/rom_data.rs
+++ b/rp235x-hal/src/rom_data.rs
@@ -622,10 +622,9 @@ pub mod sys_info_api {
 
                 if result < 0 {
                     return Err(BootRomApiErrorCode::from(result));
-                }
-                // The operation returned successfully but the flag wasn't supported
-                // for one reason or another
-                else if buffer[0] == 0 {
+                } else if buffer[0] == 0 {
+                    // The operation returned successfully but the flag wasn't supported
+                    // for one reason or another
                     return Ok(None);
                 }
 

--- a/rp235x-hal/src/rom_data.rs
+++ b/rp235x-hal/src/rom_data.rs
@@ -587,9 +587,9 @@ pub mod sys_info_api {
                 if result < 0 {
                     return Err(BootRomApiErrorCode::from(result));
                 }
-                // The operation returned successfully but the flag wasn't supported
-                // for one reason or another
                 else if buffer[0] == 0 {
+                    // The operation returned successfully but the flag wasn't supported
+                    // for one reason or another
                     return Ok(None);
                 }
 

--- a/rp235x-hal/src/rom_data.rs
+++ b/rp235x-hal/src/rom_data.rs
@@ -586,8 +586,7 @@ pub mod sys_info_api {
 
                 if result < 0 {
                     return Err(BootRomApiErrorCode::from(result));
-                }
-                else if buffer[0] == 0 {
+                } else if buffer[0] == 0 {
                     // The operation returned successfully but the flag wasn't supported
                     // for one reason or another
                     return Ok(None);


### PR DESCRIPTION
Implements a nice safe wrapper for `get_sys_info` as described in #839 .