### PR TITLE
Update RP2040-hal example urls

### DIFF
--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -38,7 +38,7 @@
 //! let temperature_adc_counts: u16 = adc.read(&mut temperature_sensor).unwrap();
 //! ```
 //!
-//! See [examples/adc.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/adc.rs) and
+//! See [examples/adc.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/adc.rs) and
 //! [pimoroni_pico_explorer_showcase.rs](https://github.com/rp-rs/rp-hal-boards/tree/main/boards/pimoroni-pico-explorer/examples/pimoroni_pico_explorer_showcase.rs) for more complete examples
 //!
 //! ### Free running mode with FIFO
@@ -69,7 +69,7 @@
 //!   }
 //! }
 //! ```
-//! See [examples/adc_fifo_poll.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/adc_fifo_poll.rs) for a more complete example.
+//! See [examples/adc_fifo_poll.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/adc_fifo_poll.rs) for a more complete example.
 //!
 //! ### Using DMA
 //!
@@ -117,7 +117,7 @@
 //! //...
 //!
 //! ```
-//! //! See [examples/adc_fifo_dma.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/adc_fifo_dma.rs) for a more complete example.
+//! //! See [examples/adc_fifo_dma.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/adc_fifo_dma.rs) for a more complete example.
 //!
 //! ### Free running mode without FIFO
 //!
@@ -455,7 +455,7 @@ where
 
 /// Used to configure & build an [`AdcFifo`]
 ///
-/// See [`Adc::build_fifo`] for details, as well as the `adc_fifo_*` [examples](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples).
+/// See [`Adc::build_fifo`] for details, as well as the `adc_fifo_*` [examples](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples).
 pub struct AdcFifoBuilder<'a, Word> {
     adc: &'a mut Adc,
     marker: PhantomData<Word>,

--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -28,7 +28,7 @@
 //! let button_pin = pins.gpio23.into_pull_down_input();
 //! let button2_pin = pins.gpio22.into_pull_up_input();
 //! ```
-//! See [examples/gpio_in_out.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/gpio_in_out.rs) for a more practical example
+//! See [examples/gpio_in_out.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/gpio_in_out.rs) for a more practical example
 
 // Design Notes:
 //

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -40,13 +40,13 @@
 //! i2c.write_read(0x2Cu8, &[1, 2, 3], &mut readbuf).unwrap();
 //! ```
 //!
-//! See [examples/i2c.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/i2c.rs)
+//! See [examples/i2c.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/i2c.rs)
 //! for a complete example
 //!
 //! ## Async Usage
 //!
-//! See [examples/i2c_async.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/i2c_async.rs)
-//! and [examples/i2c_async_irq.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/i2c_async_irq.rs)
+//! See [examples/i2c_async.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/i2c_async.rs)
+//! and [examples/i2c_async_irq.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/i2c_async_irq.rs)
 //! for complete examples.
 
 use core::{marker::PhantomData, ops::Deref};

--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -32,7 +32,7 @@
 //!
 //! For inter-processor communications, see [`crate::sio::SioFifo`] and [`crate::sio::Spinlock0`]
 //!
-//! For a detailed example, see [examples/multicore_fifo_blink.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/multicore_fifo_blink.rs)
+//! For a detailed example, see [examples/multicore_fifo_blink.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/multicore_fifo_blink.rs)
 
 use core::cell::Cell;
 use core::cell::UnsafeCell;

--- a/rp2040-hal/src/uart/mod.rs
+++ b/rp2040-hal/src/uart/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Usage
 //!
-//! See [examples/uart.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/uart.rs) for a more complete example
+//! See [examples/uart.rs](https://github.com/rp-rs/rp-hal/blob/main/rp2040-hal-examples/src/bin/uart.rs) for a more complete example
 //! ```no_run
 //! use rp2040_hal::{Clock, clocks::init_clocks_and_plls, gpio::{Pins, FunctionUart}, pac, sio::Sio, uart::{self, DataBits, StopBits, UartConfig, UartPeripheral}, watchdog::Watchdog};
 //! use fugit::RateExtU32;

--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -32,7 +32,7 @@
 //! // Stop feeding, now we'll reset
 //! loop {}
 //! ```
-//! See [examples/watchdog.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/watchdog.rs) for a more complete example
+//! See [examples/watchdog.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/watchdog.rs) for a more complete example
 
 // Embedded HAL 1.0.0 doesn't have an ADC trait, so use the one from 0.2
 use embedded_hal_0_2::watchdog;


### PR DESCRIPTION
Hello,

Here a comment fix :
`https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal/examples/` is outdated

replaced by:
`https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/`

🚀