### PR TITLE
Prepare release 0.11.0

### DIFF
--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -37,7 +37,7 @@ pio-proc = "0.2.0"
 # Should be fixed in e-h-b 0.3 via https://github.com/rust-embedded/embedded-hal/pull/607
 portable-atomic = {version = "1.7.0", features = ["critical-section"]}
 rp2040-boot2 = "0.3.0"
-rp2040-hal = {path = "../rp2040-hal", version = "0.10.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
+rp2040-hal = {path = "../rp2040-hal", version = "0.11.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
 static_cell = "2.1.0"
 
 [target.'cfg( target_arch = "arm" )'.dependencies]

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2024-12-22
+
 ### MSRV
 
 The Minimum-Supported Rust Version (MSRV) for the next release is 1.79
@@ -437,7 +439,8 @@ The Minimum-Supported Rust Version (MSRV) for this release is 1.54.
 
 - Initial release
 
-[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/rp-rs/rp-hal/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/rp-rs/rp-hal/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/rp-rs/rp-hal/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/rp-rs/rp-hal/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/rp-rs/rp-hal/compare/v0.8.1...v0.9.0

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "rp2040-hal"
 repository = "https://github.com/rp-rs/rp-hal"
 rust-version = "1.79"
-version = "0.10.0"
+version = "0.11.0"
 
 [package.metadata.docs.rs]
 features = ["rt", "rom-v2-intrinsics", "defmt", "rtic-monotonic"]

--- a/rp2040-hal/README.md
+++ b/rp2040-hal/README.md
@@ -64,7 +64,7 @@ https://github.com/rp-rs/rp-hal-boards/ for more details.
 To include this crate in your project, amend your `Cargo.toml` file to include
 
 ```toml
-rp2040-hal = "0.10.0"
+rp2040-hal = "0.11.0"
 ```
 
 To obtain a copy of the source code (e.g. if you want to propose a bug-fix or


### PR DESCRIPTION
Bump to 0.11.0 in:

* `rp2040-hal/Cargo.toml`
* The dependency on `rp2040-hal` in `rp2040-hal-examples/Cargo.toml`
* `rp2040-hal/CHANGELOG.md`
* `rp2040-hal/README.md`
