### PR TITLE
Install picotool from debian/unstable instead of testing

### DIFF
--- a/.github/workflows/rp2040_hal_examples.yml
+++ b/.github/workflows/rp2040_hal_examples.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install picotool
         run: |
           sudo apt-get install -y debian-archive-keyring
-          sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian testing main contrib non-free' >/etc/apt/sources.list.d/debian.list"
+          sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian unstable main contrib non-free' >/etc/apt/sources.list.d/debian.list"
           sudo apt-get update
           sudo apt-get install -y libxml2-utils picotool
       - name: Test picotool

--- a/.github/workflows/rp235x_hal_examples_arm.yml
+++ b/.github/workflows/rp235x_hal_examples_arm.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install picotool
         run: |
           sudo apt-get install -y debian-archive-keyring
-          sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian testing main contrib non-free' >/etc/apt/sources.list.d/debian.list"
+          sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian unstable main contrib non-free' >/etc/apt/sources.list.d/debian.list"
           sudo apt-get update
           sudo apt-get install -y libxml2-utils picotool
       - name: Test picotool


### PR DESCRIPTION
Currently, it's not available in testing.