### PR TITLE
Fix clippy::precedence warning in current beta

### DIFF
--- a/rp2040-hal/src/adc.rs
+++ b/rp2040-hal/src/adc.rs
@@ -873,7 +873,7 @@ where
     B: AdcChannel,
 {
     fn from(pins: (&A, &B)) -> Self {
-        Self(1 << pins.0.channel() | 1 << pins.1.channel())
+        Self((1 << pins.0.channel()) | (1 << pins.1.channel()))
     }
 }
 
@@ -884,7 +884,7 @@ where
     C: AdcChannel,
 {
     fn from(pins: (&A, &B, &C)) -> Self {
-        Self(1 << pins.0.channel() | 1 << pins.1.channel() | 1 << pins.2.channel())
+        Self((1 << pins.0.channel()) | (1 << pins.1.channel()) | (1 << pins.2.channel()))
     }
 }
 
@@ -897,10 +897,10 @@ where
 {
     fn from(pins: (&A, &B, &C, &D)) -> Self {
         Self(
-            1 << pins.0.channel()
-                | 1 << pins.1.channel()
-                | 1 << pins.2.channel()
-                | 1 << pins.3.channel(),
+            (1 << pins.0.channel())
+                | (1 << pins.1.channel())
+                | (1 << pins.2.channel())
+                | (1 << pins.3.channel()),
         )
     }
 }
@@ -915,11 +915,11 @@ where
 {
     fn from(pins: (&A, &B, &C, &D, &E)) -> Self {
         Self(
-            1 << pins.0.channel()
-                | 1 << pins.1.channel()
-                | 1 << pins.2.channel()
-                | 1 << pins.3.channel()
-                | 1 << pins.4.channel(),
+            (1 << pins.0.channel())
+                | (1 << pins.1.channel())
+                | (1 << pins.2.channel())
+                | (1 << pins.3.channel())
+                | (1 << pins.4.channel()),
         )
     }
 }

--- a/rp2040-hal/src/dma/single_channel.rs
+++ b/rp2040-hal/src/dma/single_channel.rs
@@ -251,7 +251,7 @@ impl<CH: SingleChannel> ChannelConfig for CH {
     fn start_both<CH2: SingleChannel>(&mut self, other: &mut CH2) {
         // Safety: The write does not interfere with any other writes, it only affects this
         // channel and other (which we have an exclusive borrow of).
-        let channel_flags = 1 << self.id() | 1 << other.id();
+        let channel_flags = (1 << self.id()) | (1 << other.id());
         unsafe { &*crate::pac::DMA::ptr() }
             .multi_chan_trigger()
             .write(|w| unsafe { w.bits(channel_flags) });

--- a/rp2040-hal/src/float/conv.rs
+++ b/rp2040-hal/src/float/conv.rs
@@ -127,7 +127,7 @@ intrinsics! {
                 // Preserve NaN or inf
                 ((f.repr() & f32::SIGNIFICAND_MASK) as u64) |
                 // Preserve sign
-                ((f.repr() & f32::SIGN_MASK) as u64) << (f64::BITS-f32::BITS)
+                (((f.repr() & f32::SIGN_MASK) as u64) << (f64::BITS-f32::BITS))
             );
         }
         rom_data::float_funcs::float_to_double(f)

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -170,21 +170,21 @@ impl defmt::Format for Error {
 impl embedded_hal::i2c::Error for Error {
     fn kind(&self) -> embedded_hal::i2c::ErrorKind {
         match &self {
-            Error::Abort(v) if v & 1<<12 != 0 // ARB_LOST
+            Error::Abort(v) if v & (1<<12) != 0 // ARB_LOST
                 => embedded_hal::i2c::ErrorKind::ArbitrationLoss,
-            Error::Abort(v) if v & 1<<7 != 0 // ABRT_SBYTE_ACKDET
+            Error::Abort(v) if v & (1<<7) != 0 // ABRT_SBYTE_ACKDET
                 => embedded_hal::i2c::ErrorKind::Bus,
-            Error::Abort(v) if v & 1<<6 != 0 // ABRT_HS_ACKDET
+            Error::Abort(v) if v & (1<<6) != 0 // ABRT_HS_ACKDET
                 => embedded_hal::i2c::ErrorKind::Bus,
-            Error::Abort(v) if v & 1<<4 != 0 // ABRT_GCALL_NOACK
+            Error::Abort(v) if v & (1<<4) != 0 // ABRT_GCALL_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
-            Error::Abort(v) if v & 1<<3 != 0 // ABRT_TXDATA_NOACK
+            Error::Abort(v) if v & (1<<3) != 0 // ABRT_TXDATA_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Data),
-            Error::Abort(v) if v & 1<<2 != 0 // ABRT_10ADDR2_NOACK
+            Error::Abort(v) if v & (1<<2) != 0 // ABRT_10ADDR2_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
-            Error::Abort(v) if v & 1<<1 != 0 // ABRT_10ADDR1_NOACK
+            Error::Abort(v) if v & (1<<1) != 0 // ABRT_10ADDR1_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
-            Error::Abort(v) if v & 1<<0 != 0 // ABRT_7B_ADDR_NOACK
+            Error::Abort(v) if v & (1<<0) != 0 // ABRT_7B_ADDR_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
             _ => embedded_hal::i2c::ErrorKind::Other,
         }

--- a/rp235x-hal-examples/src/bin/rom_funcs.rs
+++ b/rp235x-hal-examples/src/bin/rom_funcs.rs
@@ -200,9 +200,9 @@ where
     T: core::fmt::Write,
 {
     _ = writeln!(uart, "Reading OTP_DATA");
-    let package_id = (otp_data.chipid1().read().chipid1().bits() as u32) << 16
+    let package_id = ((otp_data.chipid1().read().chipid1().bits() as u32) << 16)
         | otp_data.chipid0().read().chipid0().bits() as u32;
-    let device_id = (otp_data.chipid3().read().chipid3().bits() as u32) << 16
+    let device_id = ((otp_data.chipid3().read().chipid3().bits() as u32) << 16)
         | otp_data.chipid2().read().chipid2().bits() as u32;
     _ = writeln!(uart, "\tRP2350 Package ID: {:#010x}", package_id);
     _ = writeln!(uart, "\tRP2350 Device ID : {:#010x}", device_id);

--- a/rp235x-hal/src/adc.rs
+++ b/rp235x-hal/src/adc.rs
@@ -898,7 +898,7 @@ where
     B: AdcChannel,
 {
     fn from(pins: (&A, &B)) -> Self {
-        Self(1 << pins.0.channel() | 1 << pins.1.channel())
+        Self((1 << pins.0.channel()) | (1 << pins.1.channel()))
     }
 }
 
@@ -909,7 +909,7 @@ where
     C: AdcChannel,
 {
     fn from(pins: (&A, &B, &C)) -> Self {
-        Self(1 << pins.0.channel() | 1 << pins.1.channel() | 1 << pins.2.channel())
+        Self((1 << pins.0.channel()) | (1 << pins.1.channel()) | (1 << pins.2.channel()))
     }
 }
 
@@ -922,10 +922,10 @@ where
 {
     fn from(pins: (&A, &B, &C, &D)) -> Self {
         Self(
-            1 << pins.0.channel()
-                | 1 << pins.1.channel()
-                | 1 << pins.2.channel()
-                | 1 << pins.3.channel(),
+            (1 << pins.0.channel())
+                | (1 << pins.1.channel())
+                | (1 << pins.2.channel())
+                | (1 << pins.3.channel()),
         )
     }
 }
@@ -940,11 +940,11 @@ where
 {
     fn from(pins: (&A, &B, &C, &D, &E)) -> Self {
         Self(
-            1 << pins.0.channel()
-                | 1 << pins.1.channel()
-                | 1 << pins.2.channel()
-                | 1 << pins.3.channel()
-                | 1 << pins.4.channel(),
+            (1 << pins.0.channel())
+                | (1 << pins.1.channel())
+                | (1 << pins.2.channel())
+                | (1 << pins.3.channel())
+                | (1 << pins.4.channel()),
         )
     }
 }

--- a/rp235x-hal/src/block.rs
+++ b/rp235x-hal/src/block.rs
@@ -365,7 +365,7 @@ impl Partition {
         assert!(last_sector < 0x2000);
         assert!(first_sector <= last_sector);
         Self {
-            permissions_and_location: (last_sector as u32) << 13 | first_sector as u32,
+            permissions_and_location: ((last_sector as u32) << 13) | first_sector as u32,
             permissions_and_flags: 0,
             id: None,
             extra_families: [0; 4],
@@ -430,7 +430,7 @@ impl Partition {
             extra_families_len: extra_families.len(),
             permissions_and_flags: (self.permissions_and_flags
                 & !Self::FLAGS_HAS_EXTRA_FAMILIES_MASK)
-                | (extra_families.len() as u32) << Self::FLAGS_HAS_EXTRA_FAMILIES_SHIFT,
+                | ((extra_families.len() as u32) << Self::FLAGS_HAS_EXTRA_FAMILIES_SHIFT),
             ..self
         }
     }
@@ -708,7 +708,7 @@ impl PartitionTableBlock {
         // 1. add item
         new_table.contents[idx] = item_generic_2bs(0, 2, ITEM_1BS_VERSION);
         idx += 1;
-        new_table.contents[idx] = (major as u32) << 16 | minor as u32;
+        new_table.contents[idx] = ((major as u32) << 16) | minor as u32;
         idx += 1;
 
         // 2. New Footer

--- a/rp235x-hal/src/dma/single_channel.rs
+++ b/rp235x-hal/src/dma/single_channel.rs
@@ -255,7 +255,7 @@ impl<CH: SingleChannel> ChannelConfig for CH {
     fn start_both<CH2: SingleChannel>(&mut self, other: &mut CH2) {
         // Safety: The write does not interfere with any other writes, it only affects this
         // channel and other (which we have an exclusive borrow of).
-        let channel_flags = 1 << self.id() | 1 << other.id();
+        let channel_flags = (1 << self.id()) | (1 << other.id());
         unsafe { &*crate::pac::DMA::ptr() }
             .multi_chan_trigger()
             .write(|w| unsafe { w.bits(channel_flags) });

--- a/rp235x-hal/src/i2c.rs
+++ b/rp235x-hal/src/i2c.rs
@@ -175,21 +175,21 @@ impl defmt::Format for Error {
 impl embedded_hal::i2c::Error for Error {
     fn kind(&self) -> embedded_hal::i2c::ErrorKind {
         match &self {
-            Error::Abort(v) if v & 1<<12 != 0 // ARB_LOST
+            Error::Abort(v) if v & (1<<12) != 0 // ARB_LOST
                 => embedded_hal::i2c::ErrorKind::ArbitrationLoss,
-            Error::Abort(v) if v & 1<<7 != 0 // ABRT_SBYTE_ACKDET
+            Error::Abort(v) if v & (1<<7) != 0 // ABRT_SBYTE_ACKDET
                 => embedded_hal::i2c::ErrorKind::Bus,
-            Error::Abort(v) if v & 1<<6 != 0 // ABRT_HS_ACKDET
+            Error::Abort(v) if v & (1<<6) != 0 // ABRT_HS_ACKDET
                 => embedded_hal::i2c::ErrorKind::Bus,
-            Error::Abort(v) if v & 1<<4 != 0 // ABRT_GCALL_NOACK
+            Error::Abort(v) if v & (1<<4) != 0 // ABRT_GCALL_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
-            Error::Abort(v) if v & 1<<3 != 0 // ABRT_TXDATA_NOACK
+            Error::Abort(v) if v & (1<<3) != 0 // ABRT_TXDATA_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Data),
-            Error::Abort(v) if v & 1<<2 != 0 // ABRT_10ADDR2_NOACK
+            Error::Abort(v) if v & (1<<2) != 0 // ABRT_10ADDR2_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
-            Error::Abort(v) if v & 1<<1 != 0 // ABRT_10ADDR1_NOACK
+            Error::Abort(v) if v & (1<<1) != 0 // ABRT_10ADDR1_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
-            Error::Abort(v) if v & 1<<0 != 0 // ABRT_7B_ADDR_NOACK
+            Error::Abort(v) if v & (1<<0) != 0 // ABRT_7B_ADDR_NOACK
                 => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
             _ => embedded_hal::i2c::ErrorKind::Other,
         }

--- a/rp235x-hal/src/powman.rs
+++ b/rp235x-hal/src/powman.rs
@@ -77,7 +77,7 @@ impl FractionalFrequency {
 
     /// Construct a fractional frequency from the raw register contents
     const fn from_registers(i: u16, f: u16) -> FractionalFrequency {
-        let raw = (i as u32) << 16 | (f as u32);
+        let raw = ((i as u32) << 16) | (f as u32);
         FractionalFrequency(raw)
     }
 
@@ -397,7 +397,7 @@ impl Powman {
             let upper2 = self.device.read_time_upper().read().bits();
             if upper1 == upper2 {
                 // we did not cross a boundary
-                return u64::from(upper1) << 32 | u64::from(lower);
+                return (u64::from(upper1) << 32) | u64::from(lower);
             }
         }
     }
@@ -428,7 +428,7 @@ impl Powman {
             .read()
             .alarm_time_63to48()
             .bits() as u64;
-        alarm3 << 48 | alarm2 << 32 | alarm1 << 16 | alarm0
+        (alarm3 << 48) | (alarm2 << 32) | (alarm1 << 16) | alarm0
     }
 
     /// Clear the Always-On-Timer


### PR DESCRIPTION
With current beta (1.85.0-beta.1), rustc introduced new clippy warnings regarding non-obvious operator precedence:

```
warning: operator precedence can trip the unwary
   --> src/adc.rs:876:14
    |
876 |         Self(1 << pins.0.channel() | 1 << pins.1.channel())
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `(1 << pins.0.channel()) | (1 << pins.1.channel())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
    = note: `#[warn(clippy::precedence)]` on by default
```

These can be easily fixed by adding some parentheses, as shown in this pull request.

I'm not sure if this really helps readability. Alternatively, we could silence clippy for this warning. (`#[allow(clippy::precedence)]`)