### PR TITLE
Derive Debug and defmt::Format for StackAllocation

### DIFF
--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -163,6 +163,8 @@ impl<const SIZE: usize> Stack<SIZE> {
 /// No mutable references to that memory must exist.
 /// Therefore, a function that gets passed such an object is free to write
 /// to arbitrary memory locations in the range.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StackAllocation {
     /// Start and end pointer of the StackAllocation as a Range
     mem: Range<*mut usize>,

--- a/rp235x-hal/src/multicore.rs
+++ b/rp235x-hal/src/multicore.rs
@@ -147,6 +147,8 @@ impl<const SIZE: usize> Stack<SIZE> {
 /// No mutable references to that memory must exist.
 /// Therefore, a function that gets passed such an object is free to write
 /// to arbitrary memory locations in the range.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StackAllocation {
     /// Start and end pointer of the StackAllocation as a Range
     mem: Range<*mut usize>,


### PR DESCRIPTION
The derived formatting looks like `StackAllocation { mem: 0x20000040..0x20004040 }`. While this exposes an implementation detail (the naming of the `mem` field), I think it's good enough for debug output.

Closes #888 