### PR TITLE
Fix cargo udeps

### DIFF
--- a/.github/workflows/on_target_tests.yml
+++ b/.github/workflows/on_target_tests.yml
@@ -4,7 +4,7 @@ env:
   PACKAGE: on-target-tests
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -16,7 +16,7 @@ jobs:
       - name: Build
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -33,7 +33,7 @@ jobs:
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -46,7 +46,7 @@ jobs:
       - name: Build on-target-tests (on MSRV)
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -57,7 +57,7 @@ jobs:
       - name: Check format
         run: cd ${PACKAGE} && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/on_target_tests.yml
+++ b/.github/workflows/on_target_tests.yml
@@ -21,14 +21,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
           target: thumbv6m-none-eabi
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature
   msrv:

--- a/.github/workflows/rp2040_hal.yml
+++ b/.github/workflows/rp2040_hal.yml
@@ -5,7 +5,7 @@ env:
   TARGET: thumbv6m-none-eabi
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -19,7 +19,7 @@ jobs:
       - name: Build rp2040-hal-macros
         run: cd ${PACKAGE}-macros && cargo hack build --optional-deps --each-feature
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
       - name: Test rp2040-hal-macros docs
         run: cd ${PACKAGE}-macros && cargo hack test --optional-deps --doc --each-feature
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -56,7 +56,7 @@ jobs:
         run: cd ${PACKAGE}-macros && cargo hack udeps --optional-deps --each-feature
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -73,7 +73,7 @@ jobs:
       - name: Build rp2040-hal-macros (on MSRV)
         run: cd ${PACKAGE}-macros && cargo hack build --optional-deps --each-feature
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -86,7 +86,7 @@ jobs:
       - name: Check format of rp2040-hal-macros
         run: cd ${PACKAGE}-macros && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp2040_hal.yml
+++ b/.github/workflows/rp2040_hal.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
           target: ${{ env.TARGET }}
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps on rp2040-hal
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature --target=${TARGET}
       - name: Run cargo-udeps on rp2040-hal-macros

--- a/.github/workflows/rp2040_hal_examples.yml
+++ b/.github/workflows/rp2040_hal_examples.yml
@@ -27,11 +27,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
           target: ${{ env.TARGET }}
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps
         run: cd ${PACKAGE} && cargo udeps
   msrv:

--- a/.github/workflows/rp2040_hal_examples.yml
+++ b/.github/workflows/rp2040_hal_examples.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test picotool
         run: picotool info ${PACKAGE}/target/${TARGET}/debug/binary_info_demo -t elf -a | tee /dev/stderr | grep -q "rp2040-hal Binary Info Example"
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -36,7 +36,7 @@ jobs:
         run: cd ${PACKAGE} && cargo udeps
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -48,7 +48,7 @@ jobs:
       - name: Build on MSRV
         run: cd ${PACKAGE} && cargo build 
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -59,7 +59,7 @@ jobs:
       - name: Check format
         run: cd ${PACKAGE} && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp235x_hal_arm.yml
+++ b/.github/workflows/rp235x_hal_arm.yml
@@ -5,7 +5,7 @@ env:
   TARGET: thumbv8m.main-none-eabihf
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -19,7 +19,7 @@ jobs:
       - name: Build rp235x-hal-macros
         run: cd ${PACKAGE}-macros && cargo hack build --optional-deps --each-feature
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
       - name: Test rp235x-hal-macros docs
         run: cd ${PACKAGE}-macros && cargo hack test --optional-deps --doc --each-feature
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -56,7 +56,7 @@ jobs:
         run: cd ${PACKAGE}-macros && cargo hack udeps --optional-deps --each-feature
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -73,7 +73,7 @@ jobs:
       - name: Build rp235x-hal-macros (on MSRV)
         run: cd ${PACKAGE}-macros && cargo hack build --optional-deps --each-feature
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -86,7 +86,7 @@ jobs:
       - name: Check format of rp235x-hal-macros
         run: cd ${PACKAGE}-macros && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp235x_hal_arm.yml
+++ b/.github/workflows/rp235x_hal_arm.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
           target: ${{ env.TARGET }}
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps on rp235x-hal
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature --target=${TARGET}
       - name: Run cargo-udeps on rp235x-hal-macros

--- a/.github/workflows/rp235x_hal_examples_arm.yml
+++ b/.github/workflows/rp235x_hal_examples_arm.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test picotool
         run: picotool info ${PACKAGE}/target/${TARGET}/debug/binary_info_demo -t elf -a | tee /dev/stderr | grep -q RP2350
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -36,7 +36,7 @@ jobs:
         run: cd ${PACKAGE} && cargo udeps --target=${TARGET}
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -48,7 +48,7 @@ jobs:
       - name: Build on MSRV
         run: cd ${PACKAGE} && cargo build --target=${TARGET}
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -59,7 +59,7 @@ jobs:
       - name: Check format
         run: cd ${PACKAGE} && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp235x_hal_examples_arm.yml
+++ b/.github/workflows/rp235x_hal_examples_arm.yml
@@ -27,11 +27,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
           target: ${{ env.TARGET }}
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps
         run: cd ${PACKAGE} && cargo udeps --target=${TARGET}
   msrv:

--- a/.github/workflows/rp235x_hal_examples_riscv.yml
+++ b/.github/workflows/rp235x_hal_examples_riscv.yml
@@ -5,7 +5,7 @@ env:
   TARGET: riscv32imac-unknown-none-elf
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -20,7 +20,7 @@ jobs:
           done
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -37,7 +37,7 @@ jobs:
             cargo build --target=${TARGET} --bin $example
           done
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -48,7 +48,7 @@ jobs:
       - name: Check format
         run: cd ${PACKAGE} && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp235x_hal_riscv.yml
+++ b/.github/workflows/rp235x_hal_riscv.yml
@@ -5,7 +5,7 @@ env:
   TARGET: riscv32imac-unknown-none-elf
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -19,7 +19,7 @@ jobs:
       - name: Build rp235x-hal-macros
         run: cd ${PACKAGE}-macros && cargo hack build --optional-deps --each-feature
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
       - name: Test rp235x-hal-macros docs
         run: cd ${PACKAGE}-macros && cargo hack test --optional-deps --doc --each-feature
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -56,7 +56,7 @@ jobs:
         run: cd ${PACKAGE}-macros && cargo hack udeps --optional-deps --each-feature
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -73,7 +73,7 @@ jobs:
       - name: Build rp235x-hal-macros (on MSRV)
         run: cd ${PACKAGE}-macros && cargo hack build --optional-deps --each-feature
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -86,7 +86,7 @@ jobs:
       - name: Check format of rp235x-hal-macros
         run: cd ${PACKAGE}-macros && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp235x_hal_riscv.yml
+++ b/.github/workflows/rp235x_hal_riscv.yml
@@ -42,14 +42,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
           target: ${{ env.TARGET }}
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps on rp235x-hal
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature --target=${TARGET}
       - name: Run cargo-udeps on rp235x-hal-macros

--- a/.github/workflows/rp_binary_info.yml
+++ b/.github/workflows/rp_binary_info.yml
@@ -31,13 +31,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature
   msrv:

--- a/.github/workflows/rp_binary_info.yml
+++ b/.github/workflows/rp_binary_info.yml
@@ -4,7 +4,7 @@ env:
   PACKAGE: rp-binary-info
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -14,7 +14,7 @@ jobs:
       - name: Build
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -26,7 +26,7 @@ jobs:
       - name: Test docs
         run: cd ${PACKAGE} && cargo hack test --optional-deps --each-feature --doc
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -42,7 +42,7 @@ jobs:
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -54,7 +54,7 @@ jobs:
       - name: Build on MSRV
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -65,7 +65,7 @@ jobs:
       - name: Check format
         run: cd ${PACKAGE} && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.github/workflows/rp_hal_common.yml
+++ b/.github/workflows/rp_hal_common.yml
@@ -31,13 +31,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-11-14
+          toolchain: nightly-2025-02-28
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
       - name: Install cargo-udeps
         run: |
-          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.45/cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.45-x86_64-unknown-linux-gnu/cargo-udeps
+          curl -sSL https://github.com/est31/cargo-udeps/releases/download/v0.1.55/cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - --strip-components=2 -C ~/.cargo/bin ./cargo-udeps-v0.1.55-x86_64-unknown-linux-gnu/cargo-udeps
       - name: Run cargo-udeps
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature
   msrv:

--- a/.github/workflows/rp_hal_common.yml
+++ b/.github/workflows/rp_hal_common.yml
@@ -4,7 +4,7 @@ env:
   PACKAGE: rp-hal-common
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -14,7 +14,7 @@ jobs:
       - name: Build
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -26,7 +26,7 @@ jobs:
       - name: Test docs
         run: cd ${PACKAGE} && cargo hack test --optional-deps --each-feature --doc
   udeps:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -42,7 +42,7 @@ jobs:
         run: cd ${PACKAGE} && cargo hack udeps --optional-deps --each-feature
   msrv:
     name: Verify build on MSRV
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -54,7 +54,7 @@ jobs:
       - name: Build on MSRV
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature
   fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -65,7 +65,7 @@ jobs:
       - name: Check format
         run: cd ${PACKAGE} && cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/rp235x-hal/src/arch.rs
+++ b/rp235x-hal/src/arch.rs
@@ -44,7 +44,7 @@ mod inner {
         unsafe {
             (*cortex_m::peripheral::SCB::PTR)
                 .cpacr
-                .modify(|value| value | 3 | 3 << 8 | (3 << 20) | (3 << 22))
+                .modify(|value| value | 3 | (3 << 8) | (3 << 20) | (3 << 22))
         }
     }
 }


### PR DESCRIPTION
- use current versions of "cargo-udeps" and of rust nightly to fix errors regarding Cargo.lock version
- update runner image to ubuntu-24.04 (precompiled updated version of cargo-udeps had library issues with ubuntu-20.04, and ubuntu-20.04 is being deprecated anyway, see https://github.com/actions/runner-images/issues/11101
- fix another clippy lint that triggered another CI pipeline error

See https://github.com/rp-rs/rp-hal/actions/runs/13615045124/job/38057015487 for a pipeline failing without this fix.