### PR TITLE
Updates all outdated dependencies, makes embedded_hal_0_2 opt-out

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `pio`
+- Updated `ring`
+- Updated `itertools`
+- Updated `bitfield`
+- Made `embedded_hal_0_2` an optional dependency that's on by default
+
 ## [0.11.0] - 2024-12-22
 
 ### MSRV

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -34,7 +34,7 @@ itertools = {version = "0.14.0", default-features = false}
 nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
-rand_core = "0.6.3"
+rand_core = "0.9.3"
 rp-binary-info = { version = "0.1.0", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
 rp2040-hal-macros = {version = "0.1.0", path = "../rp2040-hal-macros"}
@@ -51,7 +51,7 @@ rtic-monotonic = {version = "1.0.0", optional = true}
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-rand = {version = "0.8.5", default-features = false}
+rand = {version = "0.9.0", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.
 # None

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["thumbv6m-none-eabi"]
 
 [dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-bitfield = {version = "0.14.0"}
+bitfield = {version = "0.19.0"}
 cortex-m = "0.7.2"
 critical-section = {version = "1.2.0"}
 embedded-dma = "0.2.0"
@@ -30,7 +30,7 @@ embedded-io = "0.6.1"
 embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"]}
 frunk = {version = "0.4.1", default-features = false}
 fugit = "0.3.6"
-itertools = {version = "0.10.1", default-features = false}
+itertools = {version = "0.14.0", default-features = false}
 nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -33,7 +33,7 @@ fugit = "0.3.6"
 itertools = {version = "0.10.1", default-features = false}
 nb = "1.0"
 paste = "1.0"
-pio = "0.2.0"
+pio = "0.3.0"
 rand_core = "0.6.3"
 rp-binary-info = { version = "0.1.0", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
@@ -51,7 +51,6 @@ rtic-monotonic = {version = "1.0.0", optional = true}
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-pio-proc = "0.2.0"
 rand = {version = "0.8.5", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.79"
 version = "0.11.0"
 
 [package.metadata.docs.rs]
-features = ["rt", "rom-v2-intrinsics", "defmt", "rtic-monotonic"]
+features = ["rt", "rom-v2-intrinsics", "defmt", "rtic-monotonic", "embedded-hal-02"]
 targets = ["thumbv6m-none-eabi"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -27,7 +27,7 @@ embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-hal-nb = "1.0.0"
 embedded-io = "0.6.1"
-embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"]}
+embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"], optional = true }
 frunk = {version = "0.4.1", default-features = false}
 fugit = "0.3.6"
 itertools = {version = "0.14.0", default-features = false}
@@ -57,6 +57,7 @@ rand = {version = "0.9.0", default-features = false}
 # None
 
 [features]
+default = ["embedded-hal-02"]
 # Minimal startup / runtime for Cortex-M microcontrollers
 rt = ["rp2040-pac/rt"]
 
@@ -97,3 +98,5 @@ i2c-write-iter = ["dep:i2c-write-iter"]
 # Requires 'rt' so that the vector table is correctly sized and therefore the
 # header is within reach of picotool.
 binary-info = ["rt", "rp-binary-info/binary-info"]
+
+embedded-hal-02 = ["dep:embedded_hal_0_2"]

--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -912,6 +912,7 @@ pub struct AsInputPin<'a, I: PinId, F: func::Function, P: PullType>(&'a Pin<I, F
 /// GPIO error type.
 pub type Error = core::convert::Infallible;
 
+#[cfg(feature = "embedded-hal-02")]
 impl<I, P> embedded_hal_0_2::digital::v2::OutputPin for Pin<I, FunctionSio<SioOutput>, P>
 where
     I: PinId,
@@ -932,6 +933,7 @@ where
 
 /// Deprecated: Instead of implicitly implementing InputPin for function SioOutput,
 /// use `pin.as_input()` to get access to input values independent of the selected function.
+#[cfg(feature = "embedded-hal-02")]
 impl<I, P> embedded_hal_0_2::digital::v2::InputPin for Pin<I, FunctionSio<SioOutput>, P>
 where
     I: PinId,
@@ -948,6 +950,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<I: PinId, F: func::Function, P: PullType> embedded_hal_0_2::digital::v2::InputPin
     for AsInputPin<'_, I, F, P>
 {
@@ -962,6 +965,7 @@ impl<I: PinId, F: func::Function, P: PullType> embedded_hal_0_2::digital::v2::In
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<I, P> embedded_hal_0_2::digital::v2::StatefulOutputPin for Pin<I, FunctionSio<SioOutput>, P>
 where
     I: PinId,
@@ -976,6 +980,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<I, P> embedded_hal_0_2::digital::v2::ToggleableOutputPin for Pin<I, FunctionSio<SioOutput>, P>
 where
     I: PinId,
@@ -988,6 +993,7 @@ where
         Ok(())
     }
 }
+#[cfg(feature = "embedded-hal-02")]
 impl<I, P> embedded_hal_0_2::digital::v2::InputPin for Pin<I, FunctionSio<SioInput>, P>
 where
     I: PinId,
@@ -1434,6 +1440,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T: AnyPin> embedded_hal_0_2::digital::v2::InputPin for InOutPin<T> {
     type Error = Error;
     fn is_high(&self) -> Result<bool, Error> {
@@ -1445,6 +1452,7 @@ impl<T: AnyPin> embedded_hal_0_2::digital::v2::InputPin for InOutPin<T> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T: AnyPin> embedded_hal_0_2::digital::v2::OutputPin for InOutPin<T> {
     type Error = Error;
     fn set_low(&mut self) -> Result<(), Error> {

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -4,6 +4,8 @@
 //!
 //! ## Usage
 //! ```no_run
+//! #[cfg(feature = "embedded-hal-02")]
+//! {
 //! use fugit::RateExtU32;
 //! use rp2040_hal::{i2c::I2C, gpio::Pins, pac, Sio};
 //! let mut peripherals = pac::Peripherals::take().unwrap();
@@ -38,6 +40,8 @@
 //! use embedded_hal_0_2::prelude::_embedded_hal_blocking_i2c_WriteRead;
 //! let mut readbuf: [u8; 1] = [0; 1];
 //! i2c.write_read(0x2Cu8, &[1, 2, 3], &mut readbuf).unwrap();
+//!
+//! }
 //! ```
 //!
 //! See [examples/i2c.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/i2c.rs)
@@ -81,6 +85,7 @@ impl I2cDevice for I2C1 {
 }
 
 /// Marks valid/supported address types
+#[cfg(feature = "embedded-hal-02")]
 pub trait ValidAddress:
     Into<u16> + embedded_hal::i2c::AddressMode + embedded_hal_0_2::blocking::i2c::AddressMode + Copy
 {
@@ -92,6 +97,19 @@ pub trait ValidAddress:
     /// Validates the address against address ranges supported by the hardware.
     fn is_valid(self) -> Result<(), Error>;
 }
+
+/// Marks valid/supported address types
+#[cfg(not(feature = "embedded-hal-02"))]
+pub trait ValidAddress: Into<u16> + embedded_hal::i2c::AddressMode + Copy {
+    /// Variant for the IC_CON.10bitaddr_master field
+    const BIT_ADDR_M: IC_10BITADDR_MASTER_A;
+    /// Variant for the IC_CON.10bitaddr_slave field
+    const BIT_ADDR_S: IC_10BITADDR_SLAVE_A;
+
+    /// Validates the address against address ranges supported by the hardware.
+    fn is_valid(self) -> Result<(), Error>;
+}
+
 impl ValidAddress for u8 {
     const BIT_ADDR_M: IC_10BITADDR_MASTER_A = IC_10BITADDR_MASTER_A::ADDR_7BITS;
     const BIT_ADDR_S: IC_10BITADDR_SLAVE_A = IC_10BITADDR_SLAVE_A::ADDR_7BITS;

--- a/rp2040-hal/src/i2c/controller.rs
+++ b/rp2040-hal/src/i2c/controller.rs
@@ -1,5 +1,4 @@
 use core::{ops::Deref, task::Poll};
-use embedded_hal_0_2::blocking::i2c::{Read, Write, WriteIter, WriteIterRead, WriteRead};
 use fugit::HertzU32;
 
 use embedded_hal::i2c as eh1;
@@ -414,7 +413,10 @@ impl<T: Deref<Target = Block>, PINS> I2C<T, PINS, Controller> {
     }
 }
 
-impl<A: ValidAddress, T: Deref<Target = Block>, PINS> Read<A> for I2C<T, PINS, Controller> {
+#[cfg(feature = "embedded-hal-02")]
+impl<A: ValidAddress, T: Deref<Target = Block>, PINS> embedded_hal_0_2::blocking::i2c::Read<A>
+    for I2C<T, PINS, Controller>
+{
     type Error = Error;
 
     fn read(&mut self, addr: A, buffer: &mut [u8]) -> Result<(), Error> {
@@ -422,7 +424,11 @@ impl<A: ValidAddress, T: Deref<Target = Block>, PINS> Read<A> for I2C<T, PINS, C
         self.read_internal(true, buffer, true)
     }
 }
-impl<A: ValidAddress, T: Deref<Target = Block>, PINS> WriteRead<A> for I2C<T, PINS, Controller> {
+
+#[cfg(feature = "embedded-hal-02")]
+impl<A: ValidAddress, T: Deref<Target = Block>, PINS> embedded_hal_0_2::blocking::i2c::WriteRead<A>
+    for I2C<T, PINS, Controller>
+{
     type Error = Error;
 
     fn write_read(&mut self, addr: A, tx: &[u8], rx: &mut [u8]) -> Result<(), Error> {
@@ -433,7 +439,10 @@ impl<A: ValidAddress, T: Deref<Target = Block>, PINS> WriteRead<A> for I2C<T, PI
     }
 }
 
-impl<A: ValidAddress, T: Deref<Target = Block>, PINS> Write<A> for I2C<T, PINS, Controller> {
+#[cfg(feature = "embedded-hal-02")]
+impl<A: ValidAddress, T: Deref<Target = Block>, PINS> embedded_hal_0_2::blocking::i2c::Write<A>
+    for I2C<T, PINS, Controller>
+{
     type Error = Error;
 
     fn write(&mut self, addr: A, tx: &[u8]) -> Result<(), Error> {
@@ -442,7 +451,10 @@ impl<A: ValidAddress, T: Deref<Target = Block>, PINS> Write<A> for I2C<T, PINS, 
     }
 }
 
-impl<A: ValidAddress, T: Deref<Target = Block>, PINS> WriteIter<A> for I2C<T, PINS, Controller> {
+#[cfg(feature = "embedded-hal-02")]
+impl<A: ValidAddress, T: Deref<Target = Block>, PINS> embedded_hal_0_2::blocking::i2c::WriteIter<A>
+    for I2C<T, PINS, Controller>
+{
     type Error = Error;
 
     fn write<B>(&mut self, address: A, bytes: B) -> Result<(), Self::Error>
@@ -453,8 +465,9 @@ impl<A: ValidAddress, T: Deref<Target = Block>, PINS> WriteIter<A> for I2C<T, PI
     }
 }
 
-impl<A: ValidAddress, T: Deref<Target = Block>, PINS> WriteIterRead<A>
-    for I2C<T, PINS, Controller>
+#[cfg(feature = "embedded-hal-02")]
+impl<A: ValidAddress, T: Deref<Target = Block>, PINS>
+    embedded_hal_0_2::blocking::i2c::WriteIterRead<A> for I2C<T, PINS, Controller>
 {
     type Error = Error;
 

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -285,7 +285,7 @@ impl<P: PIOExt> PIO<P> {
 /// let mut peripherals = pac::Peripherals::take().unwrap();
 /// let (mut pio, sm0, _, _, _) = peripherals.PIO0.split(&mut peripherals.RESETS);
 /// // Install a program in instruction memory.
-/// let program = pio_proc::pio_asm!(
+/// let program = ::pio::pio_asm!(
 ///     ".wrap_target",
 ///     "set pins, 1 [31]",
 ///     "set pins, 0 [31]",

--- a/rp2040-hal/src/pwm/mod.rs
+++ b/rp2040-hal/src/pwm/mod.rs
@@ -625,6 +625,7 @@ impl<S: AnySlice, C: ChannelId> Channel<S, C> {
 
 impl<S: AnySlice, C: ChannelId> Sealed for Channel<S, C> {}
 
+#[cfg(feature = "embedded-hal-02")]
 impl<S: AnySlice> embedded_hal_0_2::PwmPin for Channel<S, A> {
     type Duty = u16;
 
@@ -653,6 +654,7 @@ impl<S: AnySlice> embedded_hal_0_2::PwmPin for Channel<S, A> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<S: AnySlice> embedded_hal_0_2::PwmPin for Channel<S, B> {
     type Duty = u16;
 
@@ -860,6 +862,8 @@ pub struct SliceDmaWriteCc<S: SliceId, M: ValidSliceMode<S>> {
 /// Type representing DMA access to PWM top register.
 ///
 /// ```no_run
+/// #[cfg(feature = "embedded-hal-02")]
+/// {
 /// use cortex_m::{prelude::*, singleton};
 /// use rp2040_hal::dma::{double_buffer, DMAExt};
 /// use rp2040_hal::pwm::{SliceDmaWrite, Slices, TopFormat};
@@ -887,6 +891,7 @@ pub struct SliceDmaWriteCc<S: SliceId, M: ValidSliceMode<S>> {
 /// let dma_pwm = SliceDmaWrite::from(pwm);
 ///
 /// let dma_conf = double_buffer::Config::new((dma.ch0, dma.ch1), buf, dma_pwm.top);
+/// }
 /// ```
 pub struct SliceDmaWriteTop<S: SliceId, M: ValidSliceMode<S>> {
     slice: PhantomData<S>,

--- a/rp2040-hal/src/rosc.rs
+++ b/rp2040-hal/src/rosc.rs
@@ -140,9 +140,4 @@ impl rand_core::RngCore for RingOscillator<Enabled> {
             }
         }
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }

--- a/rp2040-hal/src/timer.rs
+++ b/rp2040-hal/src/timer.rs
@@ -9,7 +9,7 @@
 //! See [Chapter 4 Section 6](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf) of the datasheet for more details.
 
 use core::sync::atomic::{AtomicU8, Ordering};
-use fugit::{MicrosDurationU32, MicrosDurationU64, TimerInstantU64};
+use fugit::{MicrosDurationU32, TimerInstantU64};
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},
@@ -88,10 +88,11 @@ impl Timer {
     }
 
     /// Initialized a Count Down instance without starting it.
+    #[cfg(feature = "embedded-hal-02")]
     pub fn count_down(&self) -> CountDown {
         CountDown {
             timer: *self,
-            period: MicrosDurationU64::nanos(0),
+            period: fugit::MicrosDurationU64::nanos(0),
             next_end: None,
         }
     }
@@ -140,6 +141,7 @@ impl Timer {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 macro_rules! impl_delay_traits {
     ($($t:ty),+) => {
         $(
@@ -164,6 +166,7 @@ macro_rules! impl_delay_traits {
 }
 
 // The implementation for i32 is a workaround to allow `delay_ms(42)` construction without specifying a type.
+#[cfg(feature = "embedded-hal-02")]
 impl_delay_traits!(u8, u16, u32, i32);
 
 impl embedded_hal::delay::DelayNs for Timer {
@@ -213,14 +216,16 @@ impl embedded_hal::delay::DelayNs for Timer {
 /// // Cancel it immediately
 /// count_down.cancel();
 /// ```
+#[cfg(feature = "embedded-hal-02")]
 pub struct CountDown {
     timer: Timer,
-    period: MicrosDurationU64,
+    period: fugit::MicrosDurationU64,
     next_end: Option<u64>,
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_0_2::timer::CountDown for CountDown {
-    type Time = MicrosDurationU64;
+    type Time = fugit::MicrosDurationU64;
 
     fn start<T>(&mut self, count: T)
     where
@@ -250,8 +255,10 @@ impl embedded_hal_0_2::timer::CountDown for CountDown {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_0_2::timer::Periodic for CountDown {}
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_0_2::timer::Cancel for CountDown {
     type Error = &'static str;
 

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -4,7 +4,6 @@
 //! UartPeripheral object that can both read and write.
 
 use core::{convert::Infallible, fmt};
-use embedded_hal_0_2::serial as eh0;
 use fugit::HertzU32;
 use nb::Error::{Other, WouldBlock};
 
@@ -219,6 +218,8 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Enabled, D, P> {
     /// # Example
     ///
     /// ```no_run
+    /// #[cfg(feature = "embedded-hal-02")]
+    /// {
     /// # use rp2040_hal::uart::{Pins, ValidUartPinout, Enabled, UartPeripheral};
     /// # use rp2040_hal::pac::UART0;
     /// # use rp2040_hal::timer::Timer;
@@ -226,11 +227,14 @@ impl<D: UartDevice, P: ValidUartPinout<D>> UartPeripheral<Enabled, D, P> {
     /// # use embedded_hal_0_2::blocking::delay::DelayUs;
     /// # type PINS = Pins<OptionTNone, OptionTNone, OptionTNone, OptionTNone>;
     /// # fn example(mut serial: UartPeripheral<Enabled, rp2040_hal::pac::UART0, PINS>, mut timer: Timer) {
-    /// serial.lowlevel_break_start();
-    /// // at 115_200Bps on 8N1 configuration, 20bits takes (20*10⁶)/115200 = 173.611…μs.
-    /// timer.delay_us(175);
-    /// serial.lowlevel_break_stop();
+    ///     serial.lowlevel_break_start();
+    ///     // at 115_200Bps on 8N1 configuration, 20bits takes (20*10⁶)/115200 = 173.611…μs.
+    ///     timer.delay_us(175);
+    ///     serial.lowlevel_break_stop();
+    ///   }
     /// }
+    ///
+    ///
     /// ```
     pub fn lowlevel_break_start(&mut self) {
         self.device.uartlcr_h().modify(|_, w| w.brk().set_bit());
@@ -391,7 +395,10 @@ fn set_format<'w>(
     w
 }
 
-impl<D: UartDevice, P: ValidUartPinout<D>> eh0::Read<u8> for UartPeripheral<Enabled, D, P> {
+#[cfg(feature = "embedded-hal-02")]
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_hal_0_2::serial::Read<u8>
+    for UartPeripheral<Enabled, D, P>
+{
     type Error = ReadErrorType;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -425,7 +432,10 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Read<u8> for UartPeripheral<Enabled, 
     }
 }
 
-impl<D: UartDevice, P: ValidUartPinout<D>> eh0::Write<u8> for UartPeripheral<Enabled, D, P> {
+#[cfg(feature = "embedded-hal-02")]
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_hal_0_2::serial::Write<u8>
+    for UartPeripheral<Enabled, D, P>
+{
     type Error = Infallible;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {

--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -5,7 +5,6 @@
 use super::{FifoWatermark, UartDevice, ValidUartPinout};
 use crate::dma::{EndlessReadTarget, ReadTarget};
 use crate::pac::uart0::RegisterBlock;
-use embedded_hal_0_2::serial::Read as Read02;
 use nb::Error::*;
 
 use embedded_hal_nb::serial::{Error, ErrorKind, ErrorType, Read};
@@ -277,7 +276,8 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ReadReady for Reader<D, 
     }
 }
 
-impl<D: UartDevice, P: ValidUartPinout<D>> Read02<u8> for Reader<D, P> {
+#[cfg(feature = "embedded-hal-02")]
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_hal_0_2::serial::Read<u8> for Reader<D, P> {
     type Error = ReadErrorType;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {

--- a/rp2040-hal/src/uart/writer.rs
+++ b/rp2040-hal/src/uart/writer.rs
@@ -7,7 +7,6 @@ use crate::dma::{EndlessWriteTarget, WriteTarget};
 use crate::pac::uart0::RegisterBlock;
 use core::fmt;
 use core::{convert::Infallible, marker::PhantomData};
-use embedded_hal_0_2::serial::Write as Write02;
 use embedded_hal_nb::serial::{ErrorType, Write};
 use nb::Error::*;
 
@@ -184,6 +183,8 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Writer<D, P> {
     /// # Example
     ///
     /// ```no_run
+    /// #[cfg(feature = "embedded-hal-02")]
+    /// {
     /// # use rp2040_hal::uart::{Pins, ValidUartPinout, Enabled, UartPeripheral};
     /// # use rp2040_hal::pac::UART0;
     /// # use rp2040_hal::typelevel::OptionTNone;
@@ -195,6 +196,7 @@ impl<D: UartDevice, P: ValidUartPinout<D>> Writer<D, P> {
     /// // at 115_200Bps on 8N1 configuration, 20bits takes (20*10⁶)/115200 = 173.611…μs.
     /// timer.delay_us(175);
     /// serial.lowlevel_break_stop();
+    /// }
     /// ```
     pub fn lowlevel_break_start(&mut self) {
         self.device.uartlcr_h().modify(|_, w| w.brk().set_bit());
@@ -230,7 +232,8 @@ impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::WriteReady for Writer<D,
     }
 }
 
-impl<D: UartDevice, P: ValidUartPinout<D>> Write02<u8> for Writer<D, P> {
+#[cfg(feature = "embedded-hal-02")]
+impl<D: UartDevice, P: ValidUartPinout<D>> embedded_hal_0_2::serial::Write<u8> for Writer<D, P> {
     type Error = Infallible;
 
     fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {

--- a/rp2040-hal/src/watchdog.rs
+++ b/rp2040-hal/src/watchdog.rs
@@ -8,6 +8,8 @@
 //!
 //! ## Usage
 //! ```no_run
+//! #[cfg(feature = "embedded-hal-02")]
+//! {
 //! use cortex_m::prelude::{_embedded_hal_watchdog_Watchdog, _embedded_hal_watchdog_WatchdogEnable};
 //! use fugit::ExtU32;
 //! use rp2040_hal::{clocks::init_clocks_and_plls, pac, watchdog::Watchdog};
@@ -31,11 +33,10 @@
 //! }
 //! // Stop feeding, now we'll reset
 //! loop {}
+//! }
 //! ```
 //! See [examples/watchdog.rs](https://github.com/rp-rs/rp-hal/tree/main/rp2040-hal-examples/src/bin/watchdog.rs) for a more complete example
 
-// Embedded HAL 1.0.0 doesn't have an ADC trait, so use the one from 0.2
-use embedded_hal_0_2::watchdog;
 use fugit::MicrosDurationU32;
 
 use crate::pac::{self, WATCHDOG};
@@ -205,13 +206,15 @@ impl Watchdog {
     }
 }
 
-impl watchdog::Watchdog for Watchdog {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_0_2::watchdog::Watchdog for Watchdog {
     fn feed(&mut self) {
         (*self).feed()
     }
 }
 
-impl watchdog::WatchdogEnable for Watchdog {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_0_2::watchdog::WatchdogEnable for Watchdog {
     type Time = MicrosDurationU32;
 
     fn start<T: Into<Self::Time>>(&mut self, period: T) {
@@ -219,7 +222,8 @@ impl watchdog::WatchdogEnable for Watchdog {
     }
 }
 
-impl watchdog::WatchdogDisable for Watchdog {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_0_2::watchdog::WatchdogDisable for Watchdog {
     fn disable(&mut self) {
         (*self).disable()
     }


### PR DESCRIPTION
Bring rp2040-hal up-to-date with its dependencies.

Made embedded_hal_2_0 an optional dependency which can be opted out of if the user doesn't want to compile in the old version