### PR TITLE
Update number of DMA channels from 12 to 16 (on RP235x)

### DIFF
--- a/rp235x-hal/src/dma/mod.rs
+++ b/rp235x-hal/src/dma/mod.rs
@@ -134,6 +134,10 @@ channels! {
     CH9: (ch9, 9),
     CH10:(ch10, 10),
     CH11:(ch11, 11),
+    CH12:(ch12, 12),
+    CH13:(ch13, 13),
+    CH14:(ch14, 14),
+    CH15:(ch15, 15),
 }
 
 trait ChannelRegs {


### PR DESCRIPTION
RP235x has 16 DMA channels, but rp235x-hal currently only exposes 12 of them. I assume this is left over from rp2040-hal.