### PR TITLE
Add missing enable_coprocessors to arch mod.

### DIFF
--- a/rp235x-hal/src/arch.rs
+++ b/rp235x-hal/src/arch.rs
@@ -47,7 +47,7 @@ mod inner {
 
     /// Enable co-processors.
     ///
-    /// For core0, this is done by the `#[entry]` macro. Fore core1, this function is called
+    /// For core0, this is done by the `#[entry]` macro. For core1, this function is called
     /// from `multicore::Core::spawn`.
     ///
     /// # Safety
@@ -131,7 +131,8 @@ mod inner {
     ///
     /// # Safety
     ///
-    /// No safety requirements for riscv targets, as this function does nothing.
+    /// For thumbv8m.main-none-eabihf targets this must only be called
+    /// immediately after starting up a core.
     pub unsafe fn enable_coprocessors() {}
 
     #[no_mangle]
@@ -570,6 +571,14 @@ mod inner {
 
     /// Placeholder function to mark an IRQ as pending
     pub fn interrupt_pend(_irq: rp235x_pac::Interrupt) {}
+
+    /// Placeholder function to enable co-processors.
+    ///
+    /// # Safety
+    ///
+    /// For thumbv8m.main-none-eabihf targets this must only be called
+    /// immediately after starting up a core.
+    pub unsafe fn enable_coprocessors() {}
 }
 
 #[doc(inline)]

--- a/rp235x-hal/src/arch.rs
+++ b/rp235x-hal/src/arch.rs
@@ -563,8 +563,9 @@ mod inner {
 
 #[doc(inline)]
 pub use inner::{
-    delay, dsb, interrrupt_is_pending, interrupt_disable, interrupt_enable, interrupt_is_enabled,
-    interrupt_mask, interrupt_pend, interrupt_unmask, interrupts_enabled, nop, sev, wfe, wfi,
+    delay, dsb, enable_coprocessors, interrrupt_is_pending, interrupt_disable, interrupt_enable,
+    interrupt_is_enabled, interrupt_mask, interrupt_pend, interrupt_unmask, interrupts_enabled,
+    nop, sev, wfe, wfi,
 };
 
 /// Run the closure without interrupts

--- a/rp235x-hal/src/arch.rs
+++ b/rp235x-hal/src/arch.rs
@@ -123,6 +123,17 @@ mod inner {
         riscv::register::mstatus::read().mie()
     }
 
+    /// Enable co-processors.
+    ///
+    /// The riscv core in rp2350 does not have any co-processors.
+    /// As such, this function does nothing, and only exists to
+    /// provide compatibility between arm and riscv targets.
+    ///
+    /// # Safety
+    ///
+    /// No safety requirements for riscv targets, as this function does nothing.
+    pub unsafe fn enable_coprocessors() {}
+
     #[no_mangle]
     #[allow(non_snake_case)]
     fn MachineExternal() {


### PR DESCRIPTION
The function was added in f98b41e1, after I made the branch merged in #847. Github ran CI on the branch, and it passed, but it didn't pass once the branch was merged into main because this new function wasn't exported.