### PR TITLE
Fix clippy warnings in current beta

### DIFF
--- a/rp2040-hal-examples/src/bin/adc_fifo_dma.rs
+++ b/rp2040-hal-examples/src/bin/adc_fifo_dma.rs
@@ -177,7 +177,7 @@ fn main() -> ! {
         .unwrap();
     }
 
-    writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();
+    writeln!(uart, "Sampling took: {time_taken}\r").unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/rp2040-hal-examples/src/bin/adc_fifo_irq.rs
+++ b/rp2040-hal-examples/src/bin/adc_fifo_irq.rs
@@ -146,7 +146,7 @@ mod app {
                 |done, buf, uart| {
                     if *done {
                         for sample in buf {
-                            writeln!(uart, "Sample: {}\r", sample).unwrap();
+                            writeln!(uart, "Sample: {sample}\r").unwrap();
                         }
                         writeln!(uart, "All done, going to sleep 😴\r").unwrap();
                         true

--- a/rp2040-hal-examples/src/bin/adc_fifo_poll.rs
+++ b/rp2040-hal-examples/src/bin/adc_fifo_poll.rs
@@ -184,7 +184,7 @@ fn main() -> ! {
         .unwrap();
     }
 
-    writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();
+    writeln!(uart, "Sampling took: {time_taken}\r").unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/rp2040-hal-examples/src/bin/spi_eh_bus.rs
+++ b/rp2040-hal-examples/src/bin/spi_eh_bus.rs
@@ -281,7 +281,7 @@ fn main() -> ! {
         }
         Err(e) => {
             // Do something on failure
-            _ = writeln!(uart, "Device write error: {:?}", e);
+            _ = writeln!(uart, "Device write error: {e:?}");
         }
     }
 
@@ -289,11 +289,11 @@ fn main() -> ! {
     match driver.get_value() {
         Ok(value) => {
             // Do something on success
-            _ = writeln!(uart, "Read value: {}", value);
+            _ = writeln!(uart, "Read value: {value}");
         }
         Err(e) => {
             // Do something on failure
-            _ = writeln!(uart, "Device write error: {:?}", e);
+            _ = writeln!(uart, "Device write error: {e:?}");
         }
     }
 

--- a/rp2040-hal-examples/src/bin/uart_loopback.rs
+++ b/rp2040-hal-examples/src/bin/uart_loopback.rs
@@ -263,7 +263,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
     _ = writeln!(uart0, "I want to see RX: [4, 5, 6]");
@@ -272,7 +272,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
     _ = writeln!(uart0, "I want to see WouldBlock");
@@ -281,7 +281,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 
@@ -352,7 +352,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
     _ = writeln!(uart0, "I want to see ParityError");
@@ -361,7 +361,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 
@@ -371,17 +371,17 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 
     _ = writeln!(uart0, "I want to see RX ready: false");
     match embedded_io::ReadReady::read_ready(&mut uart0) {
         Ok(ready) => {
-            _ = writeln!(uart0, "RX ready: {}", ready);
+            _ = writeln!(uart0, "RX ready: {ready}");
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 

--- a/rp2040-hal/src/i2c.rs
+++ b/rp2040-hal/src/i2c.rs
@@ -142,8 +142,8 @@ impl core::fmt::Debug for Error {
         match self {
             Error::InvalidReadBufferLength => write!(fmt, "InvalidReadBufferLength"),
             Error::InvalidWriteBufferLength => write!(fmt, "InvalidWriteBufferLength"),
-            Error::AddressOutOfRange(addr) => write!(fmt, "AddressOutOfRange({:x})", addr),
-            Error::AddressReserved(addr) => write!(fmt, "AddressReserved({:x})", addr),
+            Error::AddressOutOfRange(addr) => write!(fmt, "AddressOutOfRange({addr:x})"),
+            Error::AddressReserved(addr) => write!(fmt, "AddressReserved({addr:x})"),
             Error::Abort(_) => {
                 write!(fmt, "{:?}", self.kind())
             }

--- a/rp235x-hal-examples/src/bin/adc_fifo_dma.rs
+++ b/rp235x-hal-examples/src/bin/adc_fifo_dma.rs
@@ -172,7 +172,7 @@ fn main() -> ! {
         .unwrap();
     }
 
-    writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();
+    writeln!(uart, "Sampling took: {time_taken}\r").unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/rp235x-hal-examples/src/bin/adc_fifo_irq.rs
+++ b/rp235x-hal-examples/src/bin/adc_fifo_irq.rs
@@ -147,7 +147,7 @@ mod app {
                 |done, buf, uart| {
                     if *done {
                         for sample in buf {
-                            writeln!(uart, "Sample: {}\r", sample).unwrap();
+                            writeln!(uart, "Sample: {sample}\r").unwrap();
                         }
                         writeln!(uart, "All done, going to sleep 😴\r").unwrap();
                         true

--- a/rp235x-hal-examples/src/bin/adc_fifo_poll.rs
+++ b/rp235x-hal-examples/src/bin/adc_fifo_poll.rs
@@ -177,7 +177,7 @@ fn main() -> ! {
         .unwrap();
     }
 
-    writeln!(uart, "Sampling took: {}\r", time_taken).unwrap();
+    writeln!(uart, "Sampling took: {time_taken}\r").unwrap();
 
     loop {
         delay.delay_ms(1000);

--- a/rp235x-hal-examples/src/bin/float_test.rs
+++ b/rp235x-hal-examples/src/bin/float_test.rs
@@ -267,7 +267,7 @@ where
     )
     .unwrap();
     let mut acc: T = acc;
-    writeln!(&GLOBAL_UART, "Start: acc={}, arg={}", acc, arg).unwrap();
+    writeln!(&GLOBAL_UART, "Start: acc={acc}, arg={arg}").unwrap();
 
     let start_count = dwt.cyccnt.read();
     for _ in 0..LOOPS {
@@ -286,7 +286,7 @@ where
 
 #[exception]
 unsafe fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
-    let _ = writeln!(&GLOBAL_UART, "HARD FAULT:\n{:#?}", ef);
+    let _ = writeln!(&GLOBAL_UART, "HARD FAULT:\n{ef:#?}");
 
     hal::reboot::reboot(
         hal::reboot::RebootKind::BootSel {
@@ -299,7 +299,7 @@ unsafe fn HardFault(ef: &cortex_m_rt::ExceptionFrame) -> ! {
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    let _ = writeln!(&GLOBAL_UART, "PANIC:\n{:?}", info);
+    let _ = writeln!(&GLOBAL_UART, "PANIC:\n{info:?}");
 
     hal::reboot::reboot(
         hal::reboot::RebootKind::BootSel {

--- a/rp235x-hal-examples/src/bin/powman_test.rs
+++ b/rp235x-hal-examples/src/bin/powman_test.rs
@@ -146,13 +146,13 @@ fn main() -> ! {
     alarm_test(&mut powman);
 
     let source = AotClockSource::Xosc(FractionalFrequency::from_hz(12_000_000));
-    _ = writeln!(&GLOBAL_UART, "Switching AOT to {}", source);
+    _ = writeln!(&GLOBAL_UART, "Switching AOT to {source}");
     powman.aot_set_clock(source).expect("selecting XOSC");
     print_aot_status(&mut powman);
     loop_test(&mut powman, &mtimer);
 
     let source = AotClockSource::Lposc(FractionalFrequency::from_hz(32768));
-    _ = writeln!(&GLOBAL_UART, "Switching AOT to {}", source);
+    _ = writeln!(&GLOBAL_UART, "Switching AOT to {source}");
     powman.aot_set_clock(source).expect("selecting LPOSC");
     print_aot_status(&mut powman);
     loop_test(&mut powman, &mtimer);
@@ -180,8 +180,7 @@ fn rollover_test(powman: &mut Powman) {
     let end_loop = 0x0000_0001_0000_00FFu64;
     _ = writeln!(
         &GLOBAL_UART,
-        "Setting AOT to 0x{:016x} and waiting for rollover...",
-        start_loop
+        "Setting AOT to 0x{start_loop:016x} and waiting for rollover..."
     );
     powman.aot_stop();
     powman.aot_set_time(start_loop);
@@ -209,8 +208,7 @@ fn loop_test(powman: &mut Powman, mtimer: &hal::sio::MachineTimer) {
     let end_loop = 2_000; // 2 seconds
     _ = writeln!(
         &GLOBAL_UART,
-        "Setting AOT to 0x{:016x} and benchmarking...",
-        start_loop
+        "Setting AOT to 0x{start_loop:016x} and benchmarking..."
     );
     powman.aot_stop();
     powman.aot_set_time(start_loop);
@@ -291,7 +289,7 @@ fn POWMAN_IRQ_TIMER() {
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    let _ = writeln!(&GLOBAL_UART, "PANIC:\n{:?}", info);
+    let _ = writeln!(&GLOBAL_UART, "PANIC:\n{info:?}");
 
     hal::reboot::reboot(
         hal::reboot::RebootKind::BootSel {

--- a/rp235x-hal-examples/src/bin/rom_funcs.rs
+++ b/rp235x-hal-examples/src/bin/rom_funcs.rs
@@ -123,23 +123,23 @@ fn main() -> ! {
     _ = writeln!(uart, "Reading OTP:");
     _ = write!(uart, "Page Adr: ");
     for col in 0..WORDS_PER_SCREEN_LINE {
-        _ = write!(uart, " {:04x}", col);
+        _ = write!(uart, " {col:04x}");
     }
     // These are the factory programmed pages
     for page in [0, 1, 62, 63] {
         for row in 0..hal::otp::NUM_ROWS_PER_PAGE {
             let index = page * hal::otp::NUM_ROWS_PER_PAGE + row;
             if row == 0 {
-                _ = write!(uart, "\nP{:02} {:04x}: ", page, index);
+                _ = write!(uart, "\nP{page:02} {index:04x}: ");
             } else if (index % WORDS_PER_SCREEN_LINE) == 0 {
-                _ = write!(uart, "\n    {:04x}: ", index);
+                _ = write!(uart, "\n    {index:04x}: ");
             }
             match hal::otp::read_ecc_word(index) {
                 Ok(0) => {
                     _ = write!(uart, " ----");
                 }
                 Ok(word) => {
-                    _ = write!(uart, " {:04x}", word);
+                    _ = write!(uart, " {word:04x}");
                 }
                 Err(hal::otp::Error::InvalidPermissions) => {
                     _ = write!(uart, " xxxx");
@@ -155,23 +155,23 @@ fn main() -> ! {
     _ = writeln!(uart, "Reading raw OTP:");
     _ = write!(uart, "Page Adr: ");
     for col in 0..WORDS_PER_SCREEN_LINE {
-        _ = write!(uart, " {:06x}", col);
+        _ = write!(uart, " {col:06x}");
     }
     // These are the factory programmed pages
     for page in [0, 1, 62, 63] {
         for row in 0..hal::otp::NUM_ROWS_PER_PAGE {
             let index = page * hal::otp::NUM_ROWS_PER_PAGE + row;
             if row == 0 {
-                _ = write!(uart, "\nP{:02} {:04x}: ", page, index);
+                _ = write!(uart, "\nP{page:02} {index:04x}: ");
             } else if (index % WORDS_PER_SCREEN_LINE) == 0 {
-                _ = write!(uart, "\n    {:04x}: ", index);
+                _ = write!(uart, "\n    {index:04x}: ");
             }
             match hal::otp::read_raw_word(index) {
                 Ok(0) => {
                     _ = write!(uart, " ------");
                 }
                 Ok(word) => {
-                    _ = write!(uart, " {:06x}", word);
+                    _ = write!(uart, " {word:06x}");
                 }
                 Err(hal::otp::Error::InvalidPermissions) => {
                     _ = write!(uart, " xxxxxx");
@@ -204,8 +204,8 @@ where
         | otp_data.chipid0().read().chipid0().bits() as u32;
     let wafer_id = ((otp_data.chipid3().read().chipid3().bits() as u32) << 16)
         | otp_data.chipid2().read().chipid2().bits() as u32;
-    _ = writeln!(uart, "\tRP2350 Device ID: {:#010x}", device_id);
-    _ = writeln!(uart, "\tRP2350 Wafer ID : {:#010x}", wafer_id);
+    _ = writeln!(uart, "\tRP2350 Device ID: {device_id:#010x}");
+    _ = writeln!(uart, "\tRP2350 Wafer ID : {wafer_id:#010x}");
 }
 
 /// Read OTP in raw mode using the PAC
@@ -242,7 +242,7 @@ where
             return;
         }
         Err(e) => {
-            _ = writeln!(uart, "Failed to get chip info : {:?}", e);
+            _ = writeln!(uart, "Failed to get chip info : {e:?}");
             return;
         }
     };
@@ -274,7 +274,7 @@ where
             return;
         }
         Err(e) => {
-            _ = writeln!(uart, "Failed to get cpu info: {:?}", e);
+            _ = writeln!(uart, "Failed to get cpu info: {e:?}");
             return;
         }
     };
@@ -302,7 +302,7 @@ where
             return;
         }
         Err(e) => {
-            _ = writeln!(uart, "Failed to get flash device info: {:?}", e);
+            _ = writeln!(uart, "Failed to get flash device info: {e:?}");
             return;
         }
     };
@@ -346,7 +346,7 @@ where
             return;
         }
         Err(e) => {
-            _ = writeln!(uart, "Failed to get random boot integer: {:?}", e);
+            _ = writeln!(uart, "Failed to get random boot integer: {e:?}");
             return;
         }
     };
@@ -367,7 +367,7 @@ where
             return;
         }
         Err(e) => {
-            _ = writeln!(uart, "Failed to get boot info: {:?}", e);
+            _ = writeln!(uart, "Failed to get boot info: {e:?}");
             return;
         }
     };
@@ -417,21 +417,16 @@ where
     let result = unsafe {
         hal::rom_data::get_partition_table_info(buffer.as_mut_ptr(), buffer.len(), 0x0001)
     };
-    _ = writeln!(
-        uart,
-        "get_partition_table_info(PT_INFO/0x0001) -> {}",
-        result
-    );
+    _ = writeln!(uart, "get_partition_table_info(PT_INFO/0x0001) -> {result}");
     _ = writeln!(uart, "\tSupported Flags: {:#06x}", buffer[0]);
     let partition_count = buffer[1] & 0xFF;
     let has_partition_table = (buffer[1] & (1 << 8)) != 0;
     let unpart = hal::block::UnpartitionedSpace::from_raw(buffer[2], buffer[3]);
     _ = writeln!(
         uart,
-        "\tNum Partitions: {} (Has Partition Table? {})",
-        partition_count, has_partition_table
+        "\tNum Partitions: {partition_count} (Has Partition Table? {has_partition_table})"
     );
-    _ = writeln!(uart, "\tUnpartitioned Space: {}", unpart);
+    _ = writeln!(uart, "\tUnpartitioned Space: {unpart}");
     for part_idx in 0..partition_count {
         let result = unsafe {
             hal::rom_data::get_partition_table_info(
@@ -442,12 +437,11 @@ where
         };
         _ = writeln!(
             uart,
-            "get_partition_table_info(PARTITION_LOCATION_AND_FLAGS|SINGLE_PARTITION/0x8010) -> {}",
-            result
+            "get_partition_table_info(PARTITION_LOCATION_AND_FLAGS|SINGLE_PARTITION/0x8010) -> {result}"
         );
         _ = writeln!(uart, "\tSupported Flags: {:#06x}", buffer[0]);
         let part = hal::block::Partition::from_raw(buffer[1], buffer[2]);
-        _ = writeln!(uart, "\tPartition {}: {}", part_idx, part);
+        _ = writeln!(uart, "\tPartition {part_idx}: {part}");
     }
 }
 

--- a/rp235x-hal-examples/src/bin/uart_loopback.rs
+++ b/rp235x-hal-examples/src/bin/uart_loopback.rs
@@ -260,7 +260,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
     _ = writeln!(uart0, "I want to see RX: [4, 5, 6]");
@@ -269,7 +269,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
     _ = writeln!(uart0, "I want to see WouldBlock");
@@ -278,7 +278,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 
@@ -349,7 +349,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
     _ = writeln!(uart0, "I want to see ParityError");
@@ -358,7 +358,7 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 
@@ -368,17 +368,17 @@ fn main() -> ! {
             _ = writeln!(uart0, "RX: {:?}", &buffer[0..n]);
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 
     _ = writeln!(uart0, "I want to see RX ready: false");
     match embedded_io::ReadReady::read_ready(&mut uart0) {
         Ok(ready) => {
-            _ = writeln!(uart0, "RX ready: {}", ready);
+            _ = writeln!(uart0, "RX ready: {ready}");
         }
         Err(e) => {
-            _ = writeln!(uart0, "RXE: {:?}", e);
+            _ = writeln!(uart0, "RXE: {e:?}");
         }
     }
 

--- a/rp235x-hal-examples/src/bin/usb.rs
+++ b/rp235x-hal-examples/src/bin/usb.rs
@@ -98,7 +98,7 @@ fn main() -> ! {
 
             let time = timer.get_counter().ticks();
             let mut text: String<64> = String::new();
-            writeln!(&mut text, "Current timer ticks: {}", time).unwrap();
+            writeln!(&mut text, "Current timer ticks: {time}").unwrap();
 
             // This only works reliably because the number of bytes written to
             // the serial port is smaller than the buffers available to the USB

--- a/rp235x-hal/src/i2c.rs
+++ b/rp235x-hal/src/i2c.rs
@@ -147,8 +147,8 @@ impl core::fmt::Debug for Error {
         match self {
             Error::InvalidReadBufferLength => write!(fmt, "InvalidReadBufferLength"),
             Error::InvalidWriteBufferLength => write!(fmt, "InvalidWriteBufferLength"),
-            Error::AddressOutOfRange(addr) => write!(fmt, "AddressOutOfRange({:x})", addr),
-            Error::AddressReserved(addr) => write!(fmt, "AddressReserved({:x})", addr),
+            Error::AddressOutOfRange(addr) => write!(fmt, "AddressOutOfRange({addr:x})"),
+            Error::AddressReserved(addr) => write!(fmt, "AddressReserved({addr:x})"),
             Error::Abort(_) => {
                 write!(fmt, "{:?}", self.kind())
             }

--- a/rp235x-hal/src/powman.rs
+++ b/rp235x-hal/src/powman.rs
@@ -160,13 +160,13 @@ impl core::fmt::Display for AotClockSource {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             AotClockSource::Xosc(frac) => {
-                write!(f, "Crystal @ {}", frac)
+                write!(f, "Crystal @ {frac}")
             }
             AotClockSource::Lposc(frac) => {
-                write!(f, "On-Chip LowPower @ {}", frac)
+                write!(f, "On-Chip LowPower @ {frac}")
             }
             AotClockSource::GpioLpOsc(frac) => {
-                write!(f, "GPIO LowPower @ {}", frac)
+                write!(f, "GPIO LowPower @ {frac}")
             }
             AotClockSource::Gpio1kHz => write!(f, "GPIO 1kHz"),
             AotClockSource::Gpio1Hz => write!(f, "GPIO 1 Hz"),


### PR DESCRIPTION
Current beta (rustc 1.88.0-beta.3) warns about `clippy::uninlined_format_args` in calls to `writeln!`. Avoid that warning by inlining the arguments.