### PR TITLE
Fix rp_binary_end

### DIFF
--- a/rp-binary-info/Cargo.toml
+++ b/rp-binary-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp-binary-info"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["The rp-rs Developers"]
 homepage = "https://github.com/rp-rs/rp-hal"

--- a/rp-binary-info/src/lib.rs
+++ b/rp-binary-info/src/lib.rs
@@ -65,7 +65,7 @@
 //!     ),
 //! ];
 //!
-//! unsafe extern "C" {
+//! extern "C" {
 //!     static __flash_binary_end: u32;
 //! }
 //! ```

--- a/rp-binary-info/src/lib.rs
+++ b/rp-binary-info/src/lib.rs
@@ -174,8 +174,8 @@ pub const fn rp_program_build_date_string(value: &'static core::ffi::CStr) -> St
 ///
 /// * Tag: [`consts::TAG_RASPBERRY_PI`]
 /// * Id: [`consts::ID_RP_BINARY_END`]
-pub const fn rp_binary_end(value: u32) -> IntegerEntry {
-    IntegerEntry::new(consts::TAG_RASPBERRY_PI, consts::ID_RP_BINARY_END, value)
+pub const fn rp_binary_end(value: *const ()) -> AddrEntry {
+    AddrEntry::new(consts::TAG_RASPBERRY_PI, consts::ID_RP_BINARY_END, value)
 }
 
 /// Create a 'Binary Info' with a description of the program

--- a/rp-binary-info/src/lib.rs
+++ b/rp-binary-info/src/lib.rs
@@ -41,6 +41,12 @@
 //!         __bi_entries_end = .;
 //!     } > FLASH
 //! } INSERT AFTER .text;
+//!
+//! SECTIONS {
+//!     .flash_end : {
+//!         __flash_binary_end = .;
+//!     } > FLASH
+//! } INSERT AFTER .uninit;
 //! ```
 //!
 //! Then, add this to your Rust code:
@@ -48,15 +54,20 @@
 //! ```
 //! #[link_section = ".bi_entries"]
 //! #[used]
-//! pub static PICOTOOL_ENTRIES: [rp_binary_info::EntryAddr; 3] = [
+//! pub static PICOTOOL_ENTRIES: [rp_binary_info::EntryAddr; 4] = [
 //!     rp_binary_info::rp_program_name!(c"Program Name Here"),
 //!     rp_binary_info::rp_cargo_version!(),
+//!     rp_binary_info::rp_binary_end!(__flash_binary_end),
 //!     rp_binary_info::int!(
 //!         rp_binary_info::make_tag(b"JP"),
 //!         0x0000_0001,
 //!         0x12345678
 //!     ),
 //! ];
+//!
+//! unsafe extern "C" {
+//!     static __flash_binary_end: u32;
+//! }
 //! ```
 //!
 //! ## Cargo features
@@ -174,8 +185,8 @@ pub const fn rp_program_build_date_string(value: &'static core::ffi::CStr) -> St
 ///
 /// * Tag: [`consts::TAG_RASPBERRY_PI`]
 /// * Id: [`consts::ID_RP_BINARY_END`]
-pub const fn rp_binary_end(value: *const ()) -> AddrEntry {
-    AddrEntry::new(consts::TAG_RASPBERRY_PI, consts::ID_RP_BINARY_END, value)
+pub const fn rp_binary_end(value: *const ()) -> PointerEntry {
+    PointerEntry::new(consts::TAG_RASPBERRY_PI, consts::ID_RP_BINARY_END, value)
 }
 
 /// Create a 'Binary Info' with a description of the program

--- a/rp-binary-info/src/macros.rs
+++ b/rp-binary-info/src/macros.rs
@@ -30,7 +30,7 @@ macro_rules! str {
     }};
 }
 
-/// Generate a static item containing the given string, and return its
+/// Generate a static item containing the given integer, and return its
 /// [`EntryAddr`](super::EntryAddr).
 ///
 /// You must pass a numeric tag, a numeric ID, and `&CStr` (which is always
@@ -39,6 +39,18 @@ macro_rules! str {
 macro_rules! int {
     ($tag:expr, $id:expr, $int:expr) => {{
         static ENTRY: $crate::IntegerEntry = $crate::IntegerEntry::new($tag, $id, $int);
+        ENTRY.addr()
+    }};
+}
+
+/// Generate a static item containing the given pointer, and return its
+/// [`EntryAddr`](super::EntryAddr).
+///
+/// You must pass a numeric tag, a numeric ID, and a pointer
+#[macro_export]
+macro_rules! pointer {
+    ($tag:expr, $id:expr, $ptr:expr) => {{
+        static ENTRY: $crate::PointerEntry = $crate::PointerEntry::new($tag, $id, $ptr);
         ENTRY.addr()
     }};
 }
@@ -164,6 +176,20 @@ macro_rules! rp_pico_board {
             $board
         )
     };
+}
+
+/// Generate a static item containing the binary end address, and return its
+/// [`EntryAddr`](super::EntryAddr). The argument should be a symbol provided
+/// by the linker script that is located at the end of the binary.
+#[macro_export]
+macro_rules! rp_binary_end {
+    ($ptr:ident) => {{
+        $crate::pointer!(
+            $crate::consts::TAG_RASPBERRY_PI,
+            $crate::consts::ID_RP_BINARY_END,
+            core::ptr::addr_of!($ptr).cast()
+        )
+    }};
 }
 
 // End of file

--- a/rp-binary-info/src/macros.rs
+++ b/rp-binary-info/src/macros.rs
@@ -187,7 +187,9 @@ macro_rules! rp_binary_end {
         $crate::pointer!(
             $crate::consts::TAG_RASPBERRY_PI,
             $crate::consts::ID_RP_BINARY_END,
-            core::ptr::addr_of!($ptr).cast()
+            // `unsafe` only needed because MSRV does not yet
+            // contain https://github.com/rust-lang/rust/pull/125834
+            unsafe { core::ptr::addr_of!($ptr).cast() }
         )
     }};
 }

--- a/rp-binary-info/src/types.rs
+++ b/rp-binary-info/src/types.rs
@@ -189,4 +189,37 @@ impl IntegerEntry {
     }
 }
 
+/// An alias for IntegerEntry, taking an address instead of an integer
+#[repr(C)]
+pub struct AddrEntry {
+    header: EntryCommon,
+    id: u32,
+    value: *const (),
+}
+
+impl AddrEntry {
+    /// Create a new `StringEntry`
+    pub const fn new(tag: u16, id: u32, value: *const ()) -> AddrEntry {
+        AddrEntry {
+            header: EntryCommon {
+                data_type: DataType::IdAndInt,
+                tag,
+            },
+            id,
+            value,
+        }
+    }
+
+    /// Get this entry's address
+    pub const fn addr(&self) -> EntryAddr {
+        EntryAddr(self as *const Self as *const u32)
+    }
+}
+
+// We need this as rustc complains that is is unsafe to share `*const u32`
+// pointers between threads. We only allow these to be created with static
+// data, so this is OK.
+unsafe impl Sync for AddrEntry {}
+
+
 // End of file

--- a/rp-binary-info/src/types.rs
+++ b/rp-binary-info/src/types.rs
@@ -171,7 +171,7 @@ pub struct IntegerEntry {
 }
 
 impl IntegerEntry {
-    /// Create a new `StringEntry`
+    /// Create a new `IntegerEntry`
     pub const fn new(tag: u16, id: u32, value: u32) -> IntegerEntry {
         IntegerEntry {
             header: EntryCommon {
@@ -189,7 +189,7 @@ impl IntegerEntry {
     }
 }
 
-/// An alias for IntegerEntry, taking a pointerinstead of an integer
+/// An alias for IntegerEntry, taking a pointer instead of an integer
 #[repr(C)]
 pub struct PointerEntry {
     header: EntryCommon,
@@ -198,7 +198,13 @@ pub struct PointerEntry {
 }
 
 impl PointerEntry {
-    /// Create a new `StringEntry`
+    /// Create a new `PointerEntry`
+    ///
+    /// Pointers will be marked as 32-bit integers in the binary information
+    /// structure, as there is no separate data type tag for pointers. This
+    /// assumes that pointers are 32 bit wide, which is obviously true for
+    /// rp2040/rp2350. On 64 bit architectures, it will create a binary
+    /// structure that likely can't be parsed by picotool.
     pub const fn new(tag: u16, id: u32, value: *const ()) -> PointerEntry {
         PointerEntry {
             header: EntryCommon {

--- a/rp-binary-info/src/types.rs
+++ b/rp-binary-info/src/types.rs
@@ -189,18 +189,18 @@ impl IntegerEntry {
     }
 }
 
-/// An alias for IntegerEntry, taking an address instead of an integer
+/// An alias for IntegerEntry, taking a pointerinstead of an integer
 #[repr(C)]
-pub struct AddrEntry {
+pub struct PointerEntry {
     header: EntryCommon,
     id: u32,
     value: *const (),
 }
 
-impl AddrEntry {
+impl PointerEntry {
     /// Create a new `StringEntry`
-    pub const fn new(tag: u16, id: u32, value: *const ()) -> AddrEntry {
-        AddrEntry {
+    pub const fn new(tag: u16, id: u32, value: *const ()) -> PointerEntry {
+        PointerEntry {
             header: EntryCommon {
                 data_type: DataType::IdAndInt,
                 tag,
@@ -219,7 +219,6 @@ impl AddrEntry {
 // We need this as rustc complains that is is unsafe to share `*const u32`
 // pointers between threads. We only allow these to be created with static
 // data, so this is OK.
-unsafe impl Sync for AddrEntry {}
-
+unsafe impl Sync for PointerEntry {}
 
 // End of file

--- a/rp2040-hal-examples/memory.x
+++ b/rp2040-hal-examples/memory.x
@@ -85,7 +85,5 @@ SECTIONS {
 SECTIONS {
     .flash_end : {
         __flash_binary_end = .;
-        KEEP(*(.embedded_end_block*))
     } > FLASH
 } INSERT AFTER .uninit;
-

--- a/rp2040-hal-examples/memory.x
+++ b/rp2040-hal-examples/memory.x
@@ -81,3 +81,11 @@ SECTIONS {
         __bi_entries_end = .;
     } > FLASH
 } INSERT AFTER .text;
+
+SECTIONS {
+    .flash_end : {
+        __flash_binary_end = .;
+        KEEP(*(.embedded_end_block*))
+    } > FLASH
+} INSERT AFTER .uninit;
+

--- a/rp2040-hal-examples/src/bin/binary_info_demo.rs
+++ b/rp2040-hal-examples/src/bin/binary_info_demo.rs
@@ -107,7 +107,7 @@ pub static PICOTOOL_ENTRIES: [binary_info::EntryAddr; 8] = [
     binary_info::int!(binary_info::make_tag(b"JP"), 0x0000_0001, 0x12345678),
 ];
 
-unsafe extern "C" {
+extern "C" {
     static __flash_binary_end: u32;
 }
 

--- a/rp2040-hal-examples/src/bin/binary_info_demo.rs
+++ b/rp2040-hal-examples/src/bin/binary_info_demo.rs
@@ -102,15 +102,10 @@ pub static PICOTOOL_ENTRIES: [binary_info::EntryAddr; 8] = [
     binary_info::rp_program_url!(c"https://github.com/rp-rs/rp-hal"),
     binary_info::rp_program_build_attribute!(),
     binary_info::rp_pico_board!(c"pico"),
-    binary_end(),
+    binary_info::rp_binary_end!(__flash_binary_end),
     // An example with a non-Raspberry-Pi tag
     binary_info::int!(binary_info::make_tag(b"JP"), 0x0000_0001, 0x12345678),
 ];
-
-const fn binary_end() -> binary_info::EntryAddr {
-    static ENTRY: binary_info::AddrEntry = binary_info::rp_binary_end(core::ptr::addr_of!(__flash_binary_end).cast());
-    ENTRY.addr()
-}
 
 unsafe extern "C" {
     static __flash_binary_end: u32;

--- a/rp2040-hal-examples/src/bin/binary_info_demo.rs
+++ b/rp2040-hal-examples/src/bin/binary_info_demo.rs
@@ -95,15 +95,25 @@ fn main() -> ! {
 /// end addresses of that section.
 #[link_section = ".bi_entries"]
 #[used]
-pub static PICOTOOL_ENTRIES: [binary_info::EntryAddr; 7] = [
+pub static PICOTOOL_ENTRIES: [binary_info::EntryAddr; 8] = [
     binary_info::rp_program_name!(c"rp2040-hal Binary Info Example"),
     binary_info::rp_cargo_version!(),
     binary_info::rp_program_description!(c"A GPIO blinky with extra metadata."),
     binary_info::rp_program_url!(c"https://github.com/rp-rs/rp-hal"),
     binary_info::rp_program_build_attribute!(),
     binary_info::rp_pico_board!(c"pico"),
+    binary_end(),
     // An example with a non-Raspberry-Pi tag
     binary_info::int!(binary_info::make_tag(b"JP"), 0x0000_0001, 0x12345678),
 ];
+
+const fn binary_end() -> binary_info::EntryAddr {
+    static ENTRY: binary_info::AddrEntry = binary_info::rp_binary_end(core::ptr::addr_of!(__flash_binary_end).cast());
+    ENTRY.addr()
+}
+
+unsafe extern "C" {
+    static __flash_binary_end: u32;
+}
 
 // End of file

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -35,7 +35,7 @@ nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
 rand_core = "0.6.3"
-rp-binary-info = { version = "0.1.0", path = "../rp-binary-info" }
+rp-binary-info = { version = "0.2.0", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
 rp2040-hal-macros = {version = "0.1.0", path = "../rp2040-hal-macros"}
 rp2040-pac = {version = "0.6.0", features = ["critical-section"]}

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -32,9 +32,6 @@ nb = "1.0"
 panic-halt = "0.2.0"
 pio = "0.3.0"
 rp235x-hal = {path = "../rp235x-hal", version = "0.3.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
-# The examples use features not yet available in rp-binary-info 0.1.0,
-# so the minimum version implied by the rp235x-hal 0.3.0 dependency is not sufficient.
-rp-binary-info = {path = "../rp-binary-info", version ="0.1.1"}
 usb-device = "0.3.2"
 usbd-serial = "0.2.2"
 static_cell = "2.1.0"

--- a/rp235x-hal-examples/memory.x
+++ b/rp235x-hal-examples/memory.x
@@ -67,6 +67,7 @@ SECTIONS {
     {
         __end_block_addr = .;
         KEEP(*(.end_block));
+        __flash_binary_end = .;
     } > FLASH
 
 } INSERT AFTER .uninit;

--- a/rp235x-hal-examples/rp235x_riscv.x
+++ b/rp235x-hal-examples/rp235x_riscv.x
@@ -221,6 +221,7 @@ SECTIONS
   {
       __end_block_addr = .;
       KEEP(*(.end_block));
+      __flash_binary_end = .;
   } > FLASH
 
   /* fictitious region that represents the memory available for the heap */

--- a/rp235x-hal-examples/src/bin/binary_info_demo.rs
+++ b/rp235x-hal-examples/src/bin/binary_info_demo.rs
@@ -100,7 +100,7 @@ pub static PICOTOOL_ENTRIES: [hal::binary_info::EntryAddr; 8] = [
     hal::binary_info::int!(binary_info::make_tag(b"JP"), 0x0000_0001, 0x12345678),
 ];
 
-unsafe extern "C" {
+extern "C" {
     static __flash_binary_end: u32;
 }
 

--- a/rp235x-hal-examples/src/bin/binary_info_demo.rs
+++ b/rp235x-hal-examples/src/bin/binary_info_demo.rs
@@ -88,15 +88,20 @@ fn main() -> ! {
 /// end addresses of that section.
 #[link_section = ".bi_entries"]
 #[used]
-pub static PICOTOOL_ENTRIES: [hal::binary_info::EntryAddr; 7] = [
+pub static PICOTOOL_ENTRIES: [hal::binary_info::EntryAddr; 8] = [
     hal::binary_info::rp_cargo_bin_name!(),
     hal::binary_info::rp_cargo_version!(),
     hal::binary_info::rp_program_description!(c"A GPIO blinky with extra metadata."),
     hal::binary_info::rp_cargo_homepage_url!(),
     hal::binary_info::rp_program_build_attribute!(),
     hal::binary_info::rp_pico_board!(c"pico2"),
+    hal::binary_info::rp_binary_end!(__flash_binary_end),
     // An example with a non-Raspberry-Pi tag
     hal::binary_info::int!(binary_info::make_tag(b"JP"), 0x0000_0001, 0x12345678),
 ];
+
+unsafe extern "C" {
+    static __flash_binary_end: u32;
+}
 
 // End of file

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -35,7 +35,7 @@ nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
 rand_core = "0.6.3"
-rp-binary-info = {version = "0.1.1", path = "../rp-binary-info"}
+rp-binary-info = {version = "0.2.0", path = "../rp-binary-info"}
 rp-hal-common = {version = "0.1.0", path = "../rp-hal-common"}
 rp235x-hal-macros = {version = "0.1.0", path = "../rp235x-hal-macros"}
 rp235x-pac = {version = "0.1.0", features = ["critical-section", "rt"]}


### PR DESCRIPTION
Unfortunately the fix to rp_binary_end is a breaking change. And as rp-binary-info is re-exported by the HALs, it will also be a breaking change for them.

I wonder if it's a good idea to re-export this crate from the HALs. If we have a breaking change anyway, we can also use it to remove the re-export. Then future breaking changes to rp-binary-info won't infect the HALs, again.

As far as I can see there's no necessity for the re-export, it's a pure convenience thing. And in this case, the difference between using the re-exports and adding a direct dependency on rp-binary-info is minimal.