### PR TITLE
Set version of rp-binary-info to 0.1.2

### DIFF
--- a/rp-binary-info/Cargo.toml
+++ b/rp-binary-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rp-binary-info"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 authors = ["The rp-rs Developers"]
 homepage = "https://github.com/rp-rs/rp-hal"

--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -37,6 +37,9 @@ pio = "0.3.0"
 portable-atomic = {version = "1.7.0", features = ["critical-section"]}
 rp2040-boot2 = "0.3.0"
 rp2040-hal = {path = "../rp2040-hal", version = "0.11.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
+# The examples use features not yet available in rp-binary-info 0.1.0,
+# so the minimum version implied by the rp2040-hal 0.11.0 dependency is not sufficient.
+rp-binary-info = {path = "../rp-binary-info", version ="0.1.2"}
 static_cell = "2.1.0"
 
 [target.'cfg( target_arch = "arm" )'.dependencies]

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -35,7 +35,7 @@ nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
 rand_core = "0.6.3"
-rp-binary-info = { version = "0.2.0", path = "../rp-binary-info" }
+rp-binary-info = { version = "0.1.2", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
 rp2040-hal-macros = {version = "0.1.0", path = "../rp2040-hal-macros"}
 rp2040-pac = {version = "0.6.0", features = ["critical-section"]}

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -32,6 +32,9 @@ nb = "1.0"
 panic-halt = "0.2.0"
 pio = "0.3.0"
 rp235x-hal = {path = "../rp235x-hal", version = "0.3.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
+# The examples use features not yet available in rp-binary-info 0.1.0,
+# so the minimum version implied by the rp235x-hal 0.3.0 dependency is not sufficient.
+rp-binary-info = {path = "../rp-binary-info", version ="0.1.2"}
 usb-device = "0.3.2"
 usbd-serial = "0.2.2"
 static_cell = "2.1.0"

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -35,7 +35,7 @@ nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
 rand_core = "0.6.3"
-rp-binary-info = {version = "0.2.0", path = "../rp-binary-info"}
+rp-binary-info = {version = "0.1.2", path = "../rp-binary-info"}
 rp-hal-common = {version = "0.1.0", path = "../rp-hal-common"}
 rp235x-hal-macros = {version = "0.1.0", path = "../rp235x-hal-macros"}
 rp235x-pac = {version = "0.1.0", features = ["critical-section", "rt"]}


### PR DESCRIPTION
See https://github.com/rp-rs/rp-hal/pull/932#pullrequestreview-2887101694: The change to rp-binary-info in #932 is not considered a breaking change, so no need to do a semver-breaking release.