### PR TITLE
Expose watchdog reset reason

### DIFF
--- a/rp235x-hal/src/watchdog.rs
+++ b/rp235x-hal/src/watchdog.rs
@@ -47,6 +47,14 @@ pub struct Watchdog {
     load_value: u32, // decremented by 2 per tick (µs)
 }
 
+/// Watchdog reset reason
+pub enum ResetReason {
+    /// A manual watchdog trigger caused the reset.
+    Force,
+    /// A watchdog timeout caused the reset.
+    Timeout,
+}
+
 #[derive(Debug)]
 #[allow(missing_docs)]
 /// Scratch registers of the watchdog peripheral
@@ -112,6 +120,18 @@ impl Watchdog {
 
     fn enable(&self, bit: bool) {
         self.watchdog.ctrl().write(|w| w.enable().bit(bit))
+    }
+
+    /// Get the watchdog reset reason.
+    pub fn reason(&self) -> Option<ResetReason> {
+        let bits = self.watchdog.reason().read().bits();
+        if bits & 0b10 != 0 {
+            Some(ResetReason::Force)
+        } else if bits & 0b01 != 0 {
+            Some(ResetReason::Timeout)
+        } else {
+            None
+        }
     }
 
     /// Read a scratch register


### PR DESCRIPTION
This PR adds a `reason()` method to `rp235x_hal::watchdog::Watchdog`, returning the reset reason from the watchdog peripheral.

![Screenshot from RP2350 datasheet showing watchdog REASON register](https://github.com/user-attachments/assets/37421c9e-8a5e-4406-824c-1699e9ea37ee)

Both the force and timer bits could technically be set simultaneously, but I've not been able to reproduce this.

One thing to note is that some ways to reboot the RP2350 give unexpected reasons:

| Method | Reason |
|-|-|
| [`reboot(RebootKind::Normal, RebootArch::Normal)`](https://docs.rs/rp235x-hal/0.3.0/rp235x_hal/reboot/fn.reboot.html) | Timeout |
| [`explicit_buy`](https://docs.rs/rp235x-hal/0.3.0/rp235x_hal/rom_data/fn.explicit_buy.html) | Timeout |

The official SDK avoids this confusion by not exposing the reason directly and instead providing [`watchdog_caused_reboot`](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_watchdog_1ga65f5d24169045b8c7dc709e572535d94) (which checks reason and boot type) and [`watchdog_enable_caused_reboot`](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_watchdog_1ga455aa48ca6f11298e184d2ae0e81a085) (which checks reason and a scratch register set by `watchdog_enable`).