### PR TITLE
Fix rp235x USB example enumeration on Windows

### DIFF
--- a/rp235x-hal-examples/src/bin/usb.rs
+++ b/rp235x-hal-examples/src/bin/usb.rs
@@ -86,6 +86,8 @@ fn main() -> ! {
             .product("Serial port")
             .serial_number("TEST")])
         .unwrap()
+        .max_packet_size_0(64)
+        .unwrap()
         .device_class(2) // from: https://www.usb.org/defined-class-codes
         .build();
 


### PR DESCRIPTION
Increase max_packet_size_0 from 8 to 64 in example as workaround for https://docs.rs/rp235x-hal/0.3.0/rp235x_hal/usb/index.html (Enumeration issue with small EP0 max packet size)

Fixes #937 

Enumeration on Windows:
![image](https://github.com/user-attachments/assets/8cf013f6-ba4e-4c7e-9dea-8355790280fd)

Cyme:
```
Bus 000 Device 021: ID 16c0:27dd Van Ooijen Technische Informatica CDC-ACM class devices (modems)
Negotiated speed: Full Speed (12Mbps)
```