### PR TITLE
Update rand_core to 0.9.3

### DIFF
--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ The Minimum-Supported Rust Version (MSRV) for the next release is 1.81
 ### Changed
 
 - Update to pio 0.3.0
+- Update rand\_core to 0.9.3
 
 ## [0.11.0] - 2024-12-22
 

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -34,7 +34,7 @@ itertools = {version = "0.10.1", default-features = false}
 nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
-rand_core = "0.6.3"
+rand_core = "0.9.3"
 rp-binary-info = { version = "0.1.2", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
 rp2040-hal-macros = {version = "0.1.0", path = "../rp2040-hal-macros"}
@@ -51,7 +51,7 @@ rtic-monotonic = {version = "1.0.0", optional = true}
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-rand = {version = "0.8.5", default-features = false}
+rand = {version = "0.9.1", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.
 # None

--- a/rp2040-hal/src/rosc.rs
+++ b/rp2040-hal/src/rosc.rs
@@ -140,9 +140,4 @@ impl rand_core::RngCore for RingOscillator<Enabled> {
             }
         }
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }

--- a/rp235x-hal/CHANGELOG.md
+++ b/rp235x-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ The Minimum-Supported Rust Version (MSRV) for the next release is 1.81
 ### Changed
 
 - Update to pio 0.3.0
+- Update rand\_core to 0.9.3
 
 ## [0.3.0] - 2025-03-02
 

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -34,7 +34,7 @@ itertools = {version = "0.13.0", default-features = false}
 nb = "1.0"
 paste = "1.0"
 pio = "0.3.0"
-rand_core = "0.6.3"
+rand_core = "0.9.3"
 rp-binary-info = {version = "0.1.2", path = "../rp-binary-info"}
 rp-hal-common = {version = "0.1.0", path = "../rp-hal-common"}
 rp235x-hal-macros = {version = "0.1.0", path = "../rp235x-hal-macros"}
@@ -59,7 +59,7 @@ riscv-rt = "0.12"
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-rand = {version = "0.8.5", default-features = false}
+rand = {version = "0.9.1", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.
 # None

--- a/rp235x-hal/src/rosc.rs
+++ b/rp235x-hal/src/rosc.rs
@@ -144,9 +144,4 @@ impl rand_core::RngCore for RingOscillator<Enabled> {
             }
         }
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }


### PR DESCRIPTION
We could easily implement both rand_core 0.6 and rand_core 0.9, if there's demand to do so. I prefer to only implement the latest version to avoid accumulating technical debt.