### PR TITLE
Add HSTX support

### DIFF
--- a/rp235x-hal/src/clocks/mod.rs
+++ b/rp235x-hal/src/clocks/mod.rs
@@ -647,6 +647,10 @@ impl ClocksManager {
         self.adc_clock
             .configure_clock(pll_usb, pll_usb.get_freq())?;
 
+        // CLK HSTX = PLL SYS (150MHz) / 1 = 150MHz
+        self.hstx_clock
+            .configure_clock(pll_sys, pll_sys.get_freq())?;
+
         // CLK PERI = clk_sys. Used as reference clock for Peripherals. No dividers so just select and enable
         // Normally choose clk_sys or clk_usb
         self.peripheral_clock

--- a/rp235x-hal/src/gpio/func.rs
+++ b/rp235x-hal/src/gpio/func.rs
@@ -27,6 +27,8 @@ pub trait Function: func_sealed::Function {}
 pub enum DynFunction {
     /// The 'XIP' (or Execute-in-place) function, which means talking to the QSPI Flash.
     Xip,
+    /// The 'HSTX' function.
+    Hstx,
     /// The 'SPI' (or serial-peripheral-interface) function.
     Spi,
     /// The 'UART' (or serial-port) function.
@@ -107,7 +109,9 @@ macro_rules! pin_func {
         })*
     };
 }
-pin_func!(Xip, Spi, Uart, I2c as I2C, Pwm, Pio0, Pio1, Pio2, Clock, XipCs1, Usb, UartAux, Null);
+pin_func!(
+    Xip, Hstx, Spi, Uart, I2c as I2C, Pwm, Pio0, Pio1, Pio2, Clock, XipCs1, Usb, UartAux, Null
+);
 
 //==============================================================================
 // SIO sub-types
@@ -207,6 +211,9 @@ pin_valid_func!(
     [UartAux],
     [2, 3, 6, 7, 10, 11, 14, 15, 18, 19, 22, 23, 26, 27]
 );
+
+pin_valid_func!(bank0 as Gpio, [Hstx], [12, 13, 14, 15, 16, 17, 18, 19]);
+
 pin_valid_func!(bank0 as Gpio, [Clock], [20, 21, 22, 23, 24, 25]);
 pin_valid_func!(bank0 as Gpio, [XipCs1], [0, 8, 19, 47]);
 pin_valid_func!(qspi as Qspi, [Xip, Null], [Sclk, Sd0, Sd1, Sd2, Sd3, Ss]);

--- a/rp235x-hal/src/gpio/mod.rs
+++ b/rp235x-hal/src/gpio/mod.rs
@@ -198,7 +198,13 @@ pub unsafe fn new_pin(id: DynPinId) -> Pin<DynPinId, DynFunction, DynPullType> {
         .variant()
         .expect("Invalid funcsel read from register.");
     let function = match funcsel {
-        FUNCSEL_A::JTAG => DynFunction::Xip,
+        FUNCSEL_A::JTAG => {
+            if id.bank == DynBankId::Qspi {
+                DynFunction::Xip
+            } else {
+                DynFunction::Hstx
+            }
+        }
         FUNCSEL_A::SPI => DynFunction::Spi,
         FUNCSEL_A::UART => DynFunction::Uart,
         FUNCSEL_A::I2C => DynFunction::I2c,

--- a/rp235x-hal/src/gpio/pin.rs
+++ b/rp235x-hal/src/gpio/pin.rs
@@ -147,6 +147,7 @@ pub(crate) fn set_function<P: PinId>(pin: &P, function: DynFunction) {
     let funcsel = match function {
         // The XIP function has a value of 0, which on bank0 is called JTAG.
         DynFunction::Xip => FUNCSEL_A::JTAG,
+        DynFunction::Hstx => FUNCSEL_A::JTAG,
         DynFunction::Spi => FUNCSEL_A::SPI,
         DynFunction::Uart => FUNCSEL_A::UART,
         DynFunction::I2c => FUNCSEL_A::I2C,

--- a/rp235x-hal/src/hstx.rs
+++ b/rp235x-hal/src/hstx.rs
@@ -193,6 +193,196 @@ impl<
     type Bit7 = Opt7;
 }
 
+impl HstxPins<OptionTNone,
+              OptionTNone,
+              OptionTNone,
+              OptionTNone,
+              OptionTNone,
+              OptionTNone,
+              OptionTNone,
+              OptionTNone> {
+    /// Create an empty set of HstxPins
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> HstxPins<OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone,> {
+        HstxPins {bit0: OptionTNone{},
+                  bit1: OptionTNone{},
+                  bit2: OptionTNone{},
+                  bit3: OptionTNone{},
+                  bit4: OptionTNone{},
+                  bit5: OptionTNone{},
+                  bit6: OptionTNone{},
+                  bit7: OptionTNone{}}
+    }
+}
+
+impl<Opt1: ValidOptionHstxBit1,
+     Opt2: ValidOptionHstxBit2,
+     Opt3: ValidOptionHstxBit3,
+     Opt4: ValidOptionHstxBit4,
+     Opt5: ValidOptionHstxBit5,
+     Opt6: ValidOptionHstxBit6,
+     Opt7: ValidOptionHstxBit7> HstxPins<OptionTNone, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
+    /// Add bit0 pin to HSTX pin set
+    pub fn add_bit0_pin<Bit0: ValidHstxBit0Pin>(self, bit0: Bit0) -> HstxPins<OptionTSome<Bit0>, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {bit0: OptionTSome(bit0),
+                  bit1: self.bit1,
+                  bit2: self.bit2,
+                  bit3: self.bit3,
+                  bit4: self.bit4,
+                  bit5: self.bit5,
+                  bit6: self.bit6,
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt2: ValidOptionHstxBit2,
+     Opt3: ValidOptionHstxBit3,
+     Opt4: ValidOptionHstxBit4,
+     Opt5: ValidOptionHstxBit5,
+     Opt6: ValidOptionHstxBit6,
+     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, OptionTNone, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
+    /// Add bit1 pin to HSTX pin set
+    pub fn add_bit1_pin<Bit1: ValidHstxBit1Pin>(self, bit1: Bit1) -> HstxPins<Opt0, OptionTSome<Bit1>, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {bit0: self.bit0,
+                  bit1: OptionTSome(bit1),
+                  bit2: self.bit2,
+                  bit3: self.bit3,
+                  bit4: self.bit4,
+                  bit5: self.bit5,
+                  bit6: self.bit6,
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt1: ValidOptionHstxBit1,
+     Opt3: ValidOptionHstxBit3,
+     Opt4: ValidOptionHstxBit4,
+     Opt5: ValidOptionHstxBit5,
+     Opt6: ValidOptionHstxBit6,
+     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, OptionTNone, Opt3, Opt4, Opt5, Opt6, Opt7> {
+    /// Add bit2 pin to HSTX pin set
+    pub fn add_bit2_pin<Bit2: ValidHstxBit2Pin>(self, bit2: Bit2) -> HstxPins<Opt0, Opt1, OptionTSome<Bit2>, Opt3, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {bit0: self.bit0,
+                  bit1: self.bit1,
+                  bit2: OptionTSome(bit2),
+                  bit3: self.bit3,
+                  bit4: self.bit4,
+                  bit5: self.bit5,
+                  bit6: self.bit6,
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt1: ValidOptionHstxBit1,
+     Opt2: ValidOptionHstxBit2,
+     Opt4: ValidOptionHstxBit4,
+     Opt5: ValidOptionHstxBit5,
+     Opt6: ValidOptionHstxBit6,
+     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, OptionTNone, Opt4, Opt5, Opt6, Opt7> {
+    /// Add bit3 pin to HSTX pin set
+    pub fn add_bit3_pin<Bit3: ValidHstxBit3Pin>(self, bit3: Bit3) -> HstxPins<Opt0, Opt1, Opt2, OptionTSome<Bit3>, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {bit0: self.bit0,
+                  bit1: self.bit1,
+                  bit2: self.bit2,
+                  bit3: OptionTSome(bit3),
+                  bit4: self.bit4,
+                  bit5: self.bit5,
+                  bit6: self.bit6,
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt1: ValidOptionHstxBit1,
+     Opt2: ValidOptionHstxBit2,
+     Opt3: ValidOptionHstxBit3,
+     Opt5: ValidOptionHstxBit5,
+     Opt6: ValidOptionHstxBit6,
+     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, Opt3, OptionTNone, Opt5, Opt6, Opt7> {
+    /// Add bit4 pin to HSTX pin set
+    pub fn add_bit4_pin<Bit4: ValidHstxBit4Pin>(self, bit4: Bit4) -> HstxPins<Opt0, Opt1, Opt2, Opt3, OptionTSome<Bit4>, Opt5, Opt6, Opt7> {
+        HstxPins {bit0: self.bit0,
+                  bit1: self.bit1,
+                  bit2: self.bit2,
+                  bit3: self.bit3,
+                  bit4: OptionTSome(bit4),
+                  bit5: self.bit5,
+                  bit6: self.bit6,
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt1: ValidOptionHstxBit1,
+     Opt2: ValidOptionHstxBit2,
+     Opt3: ValidOptionHstxBit3,
+     Opt4: ValidOptionHstxBit4,
+     Opt6: ValidOptionHstxBit6,
+     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, OptionTNone, Opt6, Opt7> {
+    /// Add bit5 pin to HSTX pin set
+    pub fn add_bit5_pin<Bit5: ValidHstxBit5Pin>(self, bit5: Bit5) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, OptionTSome<Bit5>, Opt6, Opt7> {
+        HstxPins {bit0: self.bit0,
+                  bit1: self.bit1,
+                  bit2: self.bit2,
+                  bit3: self.bit3,
+                  bit4: self.bit4,
+                  bit5: OptionTSome(bit5),
+                  bit6: self.bit6,
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt1: ValidOptionHstxBit1,
+     Opt2: ValidOptionHstxBit2,
+     Opt3: ValidOptionHstxBit3,
+     Opt4: ValidOptionHstxBit4,
+     Opt5: ValidOptionHstxBit5,
+     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, OptionTNone, Opt7> {
+    /// Add bit6 pin to HSTX pin set
+    pub fn add_bit6_pin<Bit6: ValidHstxBit6Pin>(self, bit6: Bit6) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, OptionTSome<Bit6>, Opt7> {
+        HstxPins {bit0: self.bit0,
+                  bit1: self.bit1,
+                  bit2: self.bit2,
+                  bit3: self.bit3,
+                  bit4: self.bit4,
+                  bit5: self.bit5,
+                  bit6: OptionTSome(bit6),
+                  bit7: self.bit7,
+        }
+    }
+}
+
+impl<Opt0: ValidOptionHstxBit0,
+     Opt1: ValidOptionHstxBit1,
+     Opt2: ValidOptionHstxBit2,
+     Opt3: ValidOptionHstxBit3,
+     Opt4: ValidOptionHstxBit4,
+     Opt5: ValidOptionHstxBit5,
+     Opt6: ValidOptionHstxBit6> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, OptionTNone> {
+    /// Add bit7 pin to HSTX pin set
+    pub fn add_bit7_pin<Bit7: ValidHstxBit7Pin>(self, bit7: Bit7) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, OptionTSome<Bit7>> {
+        HstxPins {bit0: self.bit0,
+                  bit1: self.bit1,
+                  bit2: self.bit2,
+                  bit3: self.bit3,
+                  bit4: self.bit4,
+                  bit5: self.bit5,
+                  bit6: self.bit6,
+                  bit7: OptionTSome(bit7),
+        }
+    }
+}
+
 /// HSTX peripheral
 pub struct Hstx<S: State, P: ValidHstxPinout> {
     ctrl: HSTX_CTRL,

--- a/rp235x-hal/src/hstx.rs
+++ b/rp235x-hal/src/hstx.rs
@@ -1,0 +1,375 @@
+//! High-speed transmitter (HSTX)
+//!
+//! See [Section 12.3](https://rptl.io/rp2350-datasheet#section_hstx) for more details.
+//!
+
+use crate::{
+    dma::{EndlessWriteTarget, WriteTarget},
+    gpio::{bank0::*, AnyPin, FunctionHstx},
+    pac::{dma::ch::ch_ctrl_trig::TREQ_SEL_A, HSTX_CTRL, HSTX_FIFO, RESETS},
+    resets::SubsystemReset,
+    typelevel::{Is, OptionT, OptionTNone, OptionTSome, Sealed},
+};
+use core::marker::PhantomData;
+
+/// State of HSTX
+pub trait State: Sealed {}
+
+/// HSTX is disabled, FIFO is not being drained
+pub struct Disabled {
+    __private: (),
+}
+
+/// HSTX is enabled, data from FIFO is being consumed
+pub struct Enabled {
+    __private: (),
+}
+
+impl State for Disabled {}
+impl Sealed for Disabled {}
+impl State for Enabled {}
+impl Sealed for Enabled {}
+
+/// Configuration of HSTX bit
+pub enum HstxBitConfig {
+    /// Configure a bit as a clock output
+    Clk {
+        /// Invert the output
+        inv: bool,
+    },
+
+    /// Configure a bit to output a bit from the output shifter
+    Shift {
+        /// Shift register bit for the first half of HSTX clock cycle
+        sel_p: u8,
+
+        /// Shift register bit for the second half of HSTX clock cycle
+        sel_n: u8,
+
+        /// Invert the output
+        inv: bool,
+    },
+}
+
+macro_rules! hstx_pins {
+    ( $( $bit:expr => $pin:expr ),* ) => {
+        paste::paste!{
+            $(
+                #[doc = "Indicates a valid bit " $bit " pin for HSTX"]
+                pub trait [<ValidHstxBit $bit Pin>] : Sealed {}
+
+                impl<T> [<ValidHstxBit $bit Pin>] for T
+                where
+                    T: AnyPin<Function = FunctionHstx, Id = [<Gpio $pin>]>
+                {
+                }
+
+                #[doc = "Indicates a valid optional bit " $bit " pin for HSTX"]
+                pub trait [<ValidOptionHstxBit $bit>]: OptionT {}
+
+                impl [<ValidOptionHstxBit $bit>] for OptionTNone {}
+                impl<T> [<ValidOptionHstxBit $bit>] for OptionTSome<T>
+                where
+                    T: [<ValidHstxBit $bit Pin>],
+                {
+                }
+
+                impl<P: ValidHstxPinout, B> Hstx<Disabled, P>
+                    where P::[<Bit $bit>]: Is<Type = OptionTSome<B>>,
+                          B: [<ValidHstxBit $bit Pin>] {
+                    #[doc = "Configure output bit " $bit]
+                    pub fn [<configure_bit$bit>](&mut self, config: HstxBitConfig) {
+                        match config {
+                            HstxBitConfig::Clk{inv: inv} => {
+                                self.ctrl.[<bit $bit>]().write(|w| {
+                                    w.clk().set_bit();
+                                    if inv {
+                                        w.inv().set_bit();
+                                    }
+                                    w
+                                })
+                            },
+                            HstxBitConfig::Shift{sel_p: sel_p, sel_n: sel_n, inv: inv} => {
+                                self.ctrl.[<bit $bit>]().write(|w| unsafe {
+                                    w.sel_p().bits(sel_p)
+                                    .sel_n().bits(sel_n);
+
+                                    if inv {
+                                        w.inv().set_bit();
+                                    }
+
+                                    w
+                                })
+                            }
+                        }
+                    }
+                }
+            )*
+        }
+    }
+}
+
+/// Declares a valid HSTX pinout
+pub trait ValidHstxPinout: Sealed {
+    #[allow(missing_docs)]
+    type Bit0: ValidOptionHstxBit0;
+    #[allow(missing_docs)]
+    type Bit1: ValidOptionHstxBit1;
+    #[allow(missing_docs)]
+    type Bit2: ValidOptionHstxBit2;
+    #[allow(missing_docs)]
+    type Bit3: ValidOptionHstxBit3;
+    #[allow(missing_docs)]
+    type Bit4: ValidOptionHstxBit4;
+    #[allow(missing_docs)]
+    type Bit5: ValidOptionHstxBit5;
+    #[allow(missing_docs)]
+    type Bit6: ValidOptionHstxBit6;
+    #[allow(missing_docs)]
+    type Bit7: ValidOptionHstxBit7;
+}
+
+/// Set of valid HSTX pins
+pub struct HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+where
+    Opt0: ValidOptionHstxBit0,
+    Opt1: ValidOptionHstxBit1,
+    Opt2: ValidOptionHstxBit2,
+    Opt3: ValidOptionHstxBit3,
+    Opt4: ValidOptionHstxBit4,
+    Opt5: ValidOptionHstxBit5,
+    Opt6: ValidOptionHstxBit6,
+    Opt7: ValidOptionHstxBit7,
+{
+    /// Optional bit 0 pin
+    pub bit0: Opt0,
+    /// Optional bit 1 pin
+    pub bit1: Opt1,
+    /// Optional bit 2 pin
+    pub bit2: Opt2,
+    /// Optional bit 3 pin
+    pub bit3: Opt3,
+    /// Optional bit 4 pin
+    pub bit4: Opt4,
+    /// Optional bit 5 pin
+    pub bit5: Opt5,
+    /// Optional bit 6 pin
+    pub bit6: Opt6,
+    /// Optional bit 7 pin
+    pub bit7: Opt7,
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > Sealed for HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > ValidHstxPinout for HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+    type Bit0 = Opt0;
+    type Bit1 = Opt1;
+    type Bit2 = Opt2;
+    type Bit3 = Opt3;
+    type Bit4 = Opt4;
+    type Bit5 = Opt5;
+    type Bit6 = Opt6;
+    type Bit7 = Opt7;
+}
+
+/// HSTX peripheral
+pub struct Hstx<S: State, P: ValidHstxPinout> {
+    ctrl: HSTX_CTRL,
+    fifo: HSTX_FIFO,
+    pins: P,
+    state: PhantomData<S>,
+}
+
+impl<P: ValidHstxPinout> Hstx<Disabled, P> {
+    /// Instantiate and reset HSTX peripheral
+    pub fn new(
+        ctrl: HSTX_CTRL,
+        fifo: HSTX_FIFO,
+        pins: P,
+        resets: &mut RESETS,
+    ) -> Hstx<Disabled, P> {
+        ctrl.reset_bring_down(resets);
+        ctrl.reset_bring_up(resets);
+        Hstx {
+            ctrl,
+            fifo,
+            pins,
+            state: PhantomData,
+        }
+    }
+
+    /// Free HSTX peripheral and get registers and pins back
+    pub fn free(self) -> (HSTX_CTRL, HSTX_FIFO, P) {
+        (self.ctrl, self.fifo, self.pins)
+    }
+
+    /// Configure clock generator
+    pub fn configure_clk(&mut self, div: u8, phase: u8) {
+        if phase >= 2 * div {
+            panic!("phase should be strictly less than double the div");
+        }
+
+        self.ctrl
+            .csr()
+            .modify(|_, w| unsafe { w.clkdiv().bits(div).clkphase().bits(phase) });
+    }
+
+    /// Configure output shifter
+    pub fn configure_shifter(&mut self, shift: u8, n_shifts: u8) {
+        self.ctrl
+            .csr()
+            .modify(|_, w| unsafe { w.shift().bits(shift).n_shifts().bits(n_shifts) });
+    }
+
+    /// Configure expand shifter
+    pub fn configure_expand_shifter(
+        &mut self,
+        enc_shift: u8,
+        enc_n_shifts: u8,
+        raw_shift: u8,
+        raw_n_shifts: u8,
+    ) {
+        self.ctrl.expand_shift().write(|w| unsafe {
+            w.enc_shift()
+                .bits(enc_shift)
+                .enc_n_shifts()
+                .bits(enc_n_shifts)
+                .raw_shift()
+                .bits(raw_shift)
+                .raw_n_shifts()
+                .bits(raw_n_shifts)
+        });
+    }
+
+    /// Configure TMDS expander
+    pub fn configure_tmds(
+        &mut self,
+        l0_rot: u8,
+        l0_nbits: u8,
+        l1_rot: u8,
+        l1_nbits: u8,
+        l2_rot: u8,
+        l2_nbits: u8,
+    ) {
+        self.ctrl.expand_tmds().write(|w| unsafe {
+            w.l0_rot()
+                .bits(l0_rot)
+                .l0_nbits()
+                .bits(l0_nbits)
+                .l1_rot()
+                .bits(l1_rot)
+                .l1_nbits()
+                .bits(l1_nbits)
+                .l2_rot()
+                .bits(l2_rot)
+                .l2_nbits()
+                .bits(l2_nbits)
+        });
+    }
+
+    /// Enable expander
+    pub fn enable_expander(&mut self) {
+        self.ctrl.csr().modify(|_, w| w.expand_en().set_bit());
+    }
+
+    /// Disable expander
+    pub fn disable_expander(&mut self) {
+        self.ctrl.csr().modify(|_, w| w.expand_en().clear_bit());
+    }
+
+    /// Enable the output and start shifting data from the FIFO
+    pub fn enable(self) -> Hstx<Enabled, P> {
+        self.ctrl.csr().modify(|_, w| w.en().set_bit());
+
+        Hstx {
+            ctrl: self.ctrl,
+            fifo: self.fifo,
+            pins: self.pins,
+            state: PhantomData,
+        }
+    }
+}
+
+hstx_pins!(0 => 12, 1 => 13, 2 => 14, 3 => 15, 4 => 16, 5 => 17, 6 => 18, 7 => 19);
+
+impl<P: ValidHstxPinout> Hstx<Enabled, P> {
+    /// Disable the output, stop shifting data from the FIFO
+    pub fn disable(self) -> Hstx<Disabled, P> {
+        self.ctrl.csr().modify(|_, w| w.en().clear_bit());
+
+        Hstx {
+            ctrl: self.ctrl,
+            fifo: self.fifo,
+            pins: self.pins,
+            state: PhantomData,
+        }
+    }
+
+    /// Blocking write to FIFO
+    pub fn fifo_write(&mut self, word: u32) {
+        while self.fifo_is_full() {}
+
+        self.fifo.fifo().write(|w| unsafe { w.bits(word) });
+    }
+
+    /// Check if fifo is empty
+    pub fn fifo_is_empty(&self) -> bool {
+        self.fifo.stat().read().empty().bit_is_set()
+    }
+
+    /// Check if fifo is full
+    pub fn fifo_is_full(&self) -> bool {
+        self.fifo.stat().read().full().bit_is_set()
+    }
+
+    /// Check if fifo was written while full
+    pub fn fifo_is_wof(&self) -> bool {
+        self.fifo.stat().read().wof().bit_is_set()
+    }
+
+    /// Clear "written while full" bit
+    pub fn clear_fifo_wof(&mut self) {
+        self.fifo.stat().write(|w| w.wof().clear_bit_by_one());
+    }
+}
+
+// Safety: This only writes to the TX fifo, so it doesn't
+// interact with rust-managed memory.
+unsafe impl<P: ValidHstxPinout> WriteTarget for Hstx<Enabled, P> {
+    type TransmittedWord = u32;
+
+    fn tx_treq() -> Option<u8> {
+        Some(TREQ_SEL_A::HSTX.into())
+    }
+
+    fn tx_address_count(&mut self) -> (u32, u32) {
+        (self.fifo.fifo().as_ptr() as u32, u32::MAX)
+    }
+
+    fn tx_increment(&self) -> bool {
+        false
+    }
+}
+
+impl<P: ValidHstxPinout> EndlessWriteTarget for Hstx<Enabled, P> {}

--- a/rp235x-hal/src/hstx.rs
+++ b/rp235x-hal/src/hstx.rs
@@ -2,6 +2,42 @@
 //!
 //! See [Section 12.3](https://rptl.io/rp2350-datasheet#section_hstx) for more details.
 //!
+//! ## Usage
+//!
+//! ```no_run
+//! use rp235x_hal::{
+//!     self as hal,
+//!     hstx::{Hstx, HstxPins, HstxBitConfig},
+//!     Sio,
+//! };
+//!
+//! let mut peripherals = hal::pac::Peripherals::take().unwrap();
+//! let sio = Sio::new(peripherals.SIO);
+//! let pins = hal::gpio::Pins::new(
+//!     peripherals.IO_BANK0,
+//!     peripherals.PADS_BANK0,
+//!     sio.gpio_bank0,
+//!     &mut peripherals.RESETS,
+//! );
+//!
+//! let bit0p = pins.gpio12.into_function();
+//! let bit3p = pins.gpio15.into_function();
+//!
+//! let hstx_pins = HstxPins::new().add_bit0_pin(bit0p).add_bit3_pin(bit3p);
+//!
+//! let mut hstx = Hstx::new(peripherals.HSTX_CTRL, peripherals.HSTX_FIFO, hstx_pins,
+//!                          &mut peripherals.RESETS);
+//! hstx.configure_clk(5, 0);
+//! hstx.configure_shifter(2, 5);
+//! hstx.configure_bit0(HstxBitConfig::Clk { inv: false });
+//! hstx.configure_bit3(HstxBitConfig::Shift { sel_p:0, sel_n: 1, inv: false });
+//!
+//! let mut hstx = hstx.enable();
+//!
+//! loop {
+//!     hstx.fifo_write(0xaabbccdd);
+//! }
+//! ```
 
 use crate::{
     dma::{EndlessWriteTarget, WriteTarget},

--- a/rp235x-hal/src/hstx.rs
+++ b/rp235x-hal/src/hstx.rs
@@ -5,13 +5,14 @@
 
 use crate::{
     dma::{EndlessWriteTarget, WriteTarget},
-    gpio::{bank0::*, AnyPin, FunctionHstx},
     pac::{dma::ch::ch_ctrl_trig::TREQ_SEL_A, HSTX_CTRL, HSTX_FIFO, RESETS},
     resets::SubsystemReset,
-    typelevel::{Is, OptionT, OptionTNone, OptionTSome, Sealed},
+    typelevel::{Is, OptionTSome, Sealed},
 };
 use core::marker::PhantomData;
 
+mod pins;
+pub use pins::*;
 /// State of HSTX
 pub trait State: Sealed {}
 
@@ -29,359 +30,6 @@ impl State for Disabled {}
 impl Sealed for Disabled {}
 impl State for Enabled {}
 impl Sealed for Enabled {}
-
-/// Configuration of HSTX bit
-pub enum HstxBitConfig {
-    /// Configure a bit as a clock output
-    Clk {
-        /// Invert the output
-        inv: bool,
-    },
-
-    /// Configure a bit to output a bit from the output shifter
-    Shift {
-        /// Shift register bit for the first half of HSTX clock cycle
-        sel_p: u8,
-
-        /// Shift register bit for the second half of HSTX clock cycle
-        sel_n: u8,
-
-        /// Invert the output
-        inv: bool,
-    },
-}
-
-macro_rules! hstx_pins {
-    ( $( $bit:expr => $pin:expr ),* ) => {
-        paste::paste!{
-            $(
-                #[doc = "Indicates a valid bit " $bit " pin for HSTX"]
-                pub trait [<ValidHstxBit $bit Pin>] : Sealed {}
-
-                impl<T> [<ValidHstxBit $bit Pin>] for T
-                where
-                    T: AnyPin<Function = FunctionHstx, Id = [<Gpio $pin>]>
-                {
-                }
-
-                #[doc = "Indicates a valid optional bit " $bit " pin for HSTX"]
-                pub trait [<ValidOptionHstxBit $bit>]: OptionT {}
-
-                impl [<ValidOptionHstxBit $bit>] for OptionTNone {}
-                impl<T> [<ValidOptionHstxBit $bit>] for OptionTSome<T>
-                where
-                    T: [<ValidHstxBit $bit Pin>],
-                {
-                }
-
-                impl<P: ValidHstxPinout, B> Hstx<Disabled, P>
-                    where P::[<Bit $bit>]: Is<Type = OptionTSome<B>>,
-                          B: [<ValidHstxBit $bit Pin>] {
-                    #[doc = "Configure output bit " $bit]
-                    pub fn [<configure_bit$bit>](&mut self, config: HstxBitConfig) {
-                        match config {
-                            HstxBitConfig::Clk{inv: inv} => {
-                                self.ctrl.[<bit $bit>]().write(|w| {
-                                    w.clk().set_bit();
-                                    if inv {
-                                        w.inv().set_bit();
-                                    }
-                                    w
-                                })
-                            },
-                            HstxBitConfig::Shift{sel_p: sel_p, sel_n: sel_n, inv: inv} => {
-                                self.ctrl.[<bit $bit>]().write(|w| unsafe {
-                                    w.sel_p().bits(sel_p)
-                                    .sel_n().bits(sel_n);
-
-                                    if inv {
-                                        w.inv().set_bit();
-                                    }
-
-                                    w
-                                })
-                            }
-                        }
-                    }
-                }
-            )*
-        }
-    }
-}
-
-/// Declares a valid HSTX pinout
-pub trait ValidHstxPinout: Sealed {
-    #[allow(missing_docs)]
-    type Bit0: ValidOptionHstxBit0;
-    #[allow(missing_docs)]
-    type Bit1: ValidOptionHstxBit1;
-    #[allow(missing_docs)]
-    type Bit2: ValidOptionHstxBit2;
-    #[allow(missing_docs)]
-    type Bit3: ValidOptionHstxBit3;
-    #[allow(missing_docs)]
-    type Bit4: ValidOptionHstxBit4;
-    #[allow(missing_docs)]
-    type Bit5: ValidOptionHstxBit5;
-    #[allow(missing_docs)]
-    type Bit6: ValidOptionHstxBit6;
-    #[allow(missing_docs)]
-    type Bit7: ValidOptionHstxBit7;
-}
-
-/// Set of valid HSTX pins
-pub struct HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
-where
-    Opt0: ValidOptionHstxBit0,
-    Opt1: ValidOptionHstxBit1,
-    Opt2: ValidOptionHstxBit2,
-    Opt3: ValidOptionHstxBit3,
-    Opt4: ValidOptionHstxBit4,
-    Opt5: ValidOptionHstxBit5,
-    Opt6: ValidOptionHstxBit6,
-    Opt7: ValidOptionHstxBit7,
-{
-    /// Optional bit 0 pin
-    pub bit0: Opt0,
-    /// Optional bit 1 pin
-    pub bit1: Opt1,
-    /// Optional bit 2 pin
-    pub bit2: Opt2,
-    /// Optional bit 3 pin
-    pub bit3: Opt3,
-    /// Optional bit 4 pin
-    pub bit4: Opt4,
-    /// Optional bit 5 pin
-    pub bit5: Opt5,
-    /// Optional bit 6 pin
-    pub bit6: Opt6,
-    /// Optional bit 7 pin
-    pub bit7: Opt7,
-}
-
-impl<
-        Opt0: ValidOptionHstxBit0,
-        Opt1: ValidOptionHstxBit1,
-        Opt2: ValidOptionHstxBit2,
-        Opt3: ValidOptionHstxBit3,
-        Opt4: ValidOptionHstxBit4,
-        Opt5: ValidOptionHstxBit5,
-        Opt6: ValidOptionHstxBit6,
-        Opt7: ValidOptionHstxBit7,
-    > Sealed for HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
-{
-}
-
-impl<
-        Opt0: ValidOptionHstxBit0,
-        Opt1: ValidOptionHstxBit1,
-        Opt2: ValidOptionHstxBit2,
-        Opt3: ValidOptionHstxBit3,
-        Opt4: ValidOptionHstxBit4,
-        Opt5: ValidOptionHstxBit5,
-        Opt6: ValidOptionHstxBit6,
-        Opt7: ValidOptionHstxBit7,
-    > ValidHstxPinout for HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
-{
-    type Bit0 = Opt0;
-    type Bit1 = Opt1;
-    type Bit2 = Opt2;
-    type Bit3 = Opt3;
-    type Bit4 = Opt4;
-    type Bit5 = Opt5;
-    type Bit6 = Opt6;
-    type Bit7 = Opt7;
-}
-
-impl HstxPins<OptionTNone,
-              OptionTNone,
-              OptionTNone,
-              OptionTNone,
-              OptionTNone,
-              OptionTNone,
-              OptionTNone,
-              OptionTNone> {
-    /// Create an empty set of HstxPins
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> HstxPins<OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone, OptionTNone,> {
-        HstxPins {bit0: OptionTNone{},
-                  bit1: OptionTNone{},
-                  bit2: OptionTNone{},
-                  bit3: OptionTNone{},
-                  bit4: OptionTNone{},
-                  bit5: OptionTNone{},
-                  bit6: OptionTNone{},
-                  bit7: OptionTNone{}}
-    }
-}
-
-impl<Opt1: ValidOptionHstxBit1,
-     Opt2: ValidOptionHstxBit2,
-     Opt3: ValidOptionHstxBit3,
-     Opt4: ValidOptionHstxBit4,
-     Opt5: ValidOptionHstxBit5,
-     Opt6: ValidOptionHstxBit6,
-     Opt7: ValidOptionHstxBit7> HstxPins<OptionTNone, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
-    /// Add bit0 pin to HSTX pin set
-    pub fn add_bit0_pin<Bit0: ValidHstxBit0Pin>(self, bit0: Bit0) -> HstxPins<OptionTSome<Bit0>, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
-        HstxPins {bit0: OptionTSome(bit0),
-                  bit1: self.bit1,
-                  bit2: self.bit2,
-                  bit3: self.bit3,
-                  bit4: self.bit4,
-                  bit5: self.bit5,
-                  bit6: self.bit6,
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt2: ValidOptionHstxBit2,
-     Opt3: ValidOptionHstxBit3,
-     Opt4: ValidOptionHstxBit4,
-     Opt5: ValidOptionHstxBit5,
-     Opt6: ValidOptionHstxBit6,
-     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, OptionTNone, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
-    /// Add bit1 pin to HSTX pin set
-    pub fn add_bit1_pin<Bit1: ValidHstxBit1Pin>(self, bit1: Bit1) -> HstxPins<Opt0, OptionTSome<Bit1>, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
-        HstxPins {bit0: self.bit0,
-                  bit1: OptionTSome(bit1),
-                  bit2: self.bit2,
-                  bit3: self.bit3,
-                  bit4: self.bit4,
-                  bit5: self.bit5,
-                  bit6: self.bit6,
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt1: ValidOptionHstxBit1,
-     Opt3: ValidOptionHstxBit3,
-     Opt4: ValidOptionHstxBit4,
-     Opt5: ValidOptionHstxBit5,
-     Opt6: ValidOptionHstxBit6,
-     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, OptionTNone, Opt3, Opt4, Opt5, Opt6, Opt7> {
-    /// Add bit2 pin to HSTX pin set
-    pub fn add_bit2_pin<Bit2: ValidHstxBit2Pin>(self, bit2: Bit2) -> HstxPins<Opt0, Opt1, OptionTSome<Bit2>, Opt3, Opt4, Opt5, Opt6, Opt7> {
-        HstxPins {bit0: self.bit0,
-                  bit1: self.bit1,
-                  bit2: OptionTSome(bit2),
-                  bit3: self.bit3,
-                  bit4: self.bit4,
-                  bit5: self.bit5,
-                  bit6: self.bit6,
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt1: ValidOptionHstxBit1,
-     Opt2: ValidOptionHstxBit2,
-     Opt4: ValidOptionHstxBit4,
-     Opt5: ValidOptionHstxBit5,
-     Opt6: ValidOptionHstxBit6,
-     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, OptionTNone, Opt4, Opt5, Opt6, Opt7> {
-    /// Add bit3 pin to HSTX pin set
-    pub fn add_bit3_pin<Bit3: ValidHstxBit3Pin>(self, bit3: Bit3) -> HstxPins<Opt0, Opt1, Opt2, OptionTSome<Bit3>, Opt4, Opt5, Opt6, Opt7> {
-        HstxPins {bit0: self.bit0,
-                  bit1: self.bit1,
-                  bit2: self.bit2,
-                  bit3: OptionTSome(bit3),
-                  bit4: self.bit4,
-                  bit5: self.bit5,
-                  bit6: self.bit6,
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt1: ValidOptionHstxBit1,
-     Opt2: ValidOptionHstxBit2,
-     Opt3: ValidOptionHstxBit3,
-     Opt5: ValidOptionHstxBit5,
-     Opt6: ValidOptionHstxBit6,
-     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, Opt3, OptionTNone, Opt5, Opt6, Opt7> {
-    /// Add bit4 pin to HSTX pin set
-    pub fn add_bit4_pin<Bit4: ValidHstxBit4Pin>(self, bit4: Bit4) -> HstxPins<Opt0, Opt1, Opt2, Opt3, OptionTSome<Bit4>, Opt5, Opt6, Opt7> {
-        HstxPins {bit0: self.bit0,
-                  bit1: self.bit1,
-                  bit2: self.bit2,
-                  bit3: self.bit3,
-                  bit4: OptionTSome(bit4),
-                  bit5: self.bit5,
-                  bit6: self.bit6,
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt1: ValidOptionHstxBit1,
-     Opt2: ValidOptionHstxBit2,
-     Opt3: ValidOptionHstxBit3,
-     Opt4: ValidOptionHstxBit4,
-     Opt6: ValidOptionHstxBit6,
-     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, OptionTNone, Opt6, Opt7> {
-    /// Add bit5 pin to HSTX pin set
-    pub fn add_bit5_pin<Bit5: ValidHstxBit5Pin>(self, bit5: Bit5) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, OptionTSome<Bit5>, Opt6, Opt7> {
-        HstxPins {bit0: self.bit0,
-                  bit1: self.bit1,
-                  bit2: self.bit2,
-                  bit3: self.bit3,
-                  bit4: self.bit4,
-                  bit5: OptionTSome(bit5),
-                  bit6: self.bit6,
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt1: ValidOptionHstxBit1,
-     Opt2: ValidOptionHstxBit2,
-     Opt3: ValidOptionHstxBit3,
-     Opt4: ValidOptionHstxBit4,
-     Opt5: ValidOptionHstxBit5,
-     Opt7: ValidOptionHstxBit7> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, OptionTNone, Opt7> {
-    /// Add bit6 pin to HSTX pin set
-    pub fn add_bit6_pin<Bit6: ValidHstxBit6Pin>(self, bit6: Bit6) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, OptionTSome<Bit6>, Opt7> {
-        HstxPins {bit0: self.bit0,
-                  bit1: self.bit1,
-                  bit2: self.bit2,
-                  bit3: self.bit3,
-                  bit4: self.bit4,
-                  bit5: self.bit5,
-                  bit6: OptionTSome(bit6),
-                  bit7: self.bit7,
-        }
-    }
-}
-
-impl<Opt0: ValidOptionHstxBit0,
-     Opt1: ValidOptionHstxBit1,
-     Opt2: ValidOptionHstxBit2,
-     Opt3: ValidOptionHstxBit3,
-     Opt4: ValidOptionHstxBit4,
-     Opt5: ValidOptionHstxBit5,
-     Opt6: ValidOptionHstxBit6> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, OptionTNone> {
-    /// Add bit7 pin to HSTX pin set
-    pub fn add_bit7_pin<Bit7: ValidHstxBit7Pin>(self, bit7: Bit7) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, OptionTSome<Bit7>> {
-        HstxPins {bit0: self.bit0,
-                  bit1: self.bit1,
-                  bit2: self.bit2,
-                  bit3: self.bit3,
-                  bit4: self.bit4,
-                  bit5: self.bit5,
-                  bit6: self.bit6,
-                  bit7: OptionTSome(bit7),
-        }
-    }
-}
 
 /// HSTX peripheral
 pub struct Hstx<S: State, P: ValidHstxPinout> {
@@ -501,8 +149,6 @@ impl<P: ValidHstxPinout> Hstx<Disabled, P> {
     }
 }
 
-hstx_pins!(0 => 12, 1 => 13, 2 => 14, 3 => 15, 4 => 16, 5 => 17, 6 => 18, 7 => 19);
-
 impl<P: ValidHstxPinout> Hstx<Enabled, P> {
     /// Disable the output, stop shifting data from the FIFO
     pub fn disable(self) -> Hstx<Disabled, P> {
@@ -563,3 +209,65 @@ unsafe impl<P: ValidHstxPinout> WriteTarget for Hstx<Enabled, P> {
 }
 
 impl<P: ValidHstxPinout> EndlessWriteTarget for Hstx<Enabled, P> {}
+
+/// Configuration of HSTX bit
+pub enum HstxBitConfig {
+    /// Configure a bit as a clock output
+    Clk {
+        /// Invert the output
+        inv: bool,
+    },
+
+    /// Configure a bit to output a bit from the output shifter
+    Shift {
+        /// Shift register bit for the first half of HSTX clock cycle
+        sel_p: u8,
+
+        /// Shift register bit for the second half of HSTX clock cycle
+        sel_n: u8,
+
+        /// Invert the output
+        inv: bool,
+    },
+}
+
+macro_rules! configure_bits_hstx {
+    ( $( $bit:expr ),* ) => {
+        paste::paste!{
+            $(
+                impl<P: ValidHstxPinout, B> Hstx<Disabled, P>
+                    where P::[<Bit $bit>]: Is<Type = OptionTSome<B>>,
+                          B: [<ValidHstxBit $bit Pin>] {
+                    #[doc = "Configure output bit " $bit]
+                    pub fn [<configure_bit$bit>](&mut self, config: HstxBitConfig) {
+                        match config {
+                            HstxBitConfig::Clk{inv: inv} => {
+                                self.ctrl.[<bit $bit>]().write(|w| {
+                                    w.clk().set_bit();
+                                    if inv {
+                                        w.inv().set_bit();
+                                    }
+                                    w
+                                })
+                            },
+                            HstxBitConfig::Shift{sel_p: sel_p, sel_n: sel_n, inv: inv} => {
+                                self.ctrl.[<bit $bit>]().write(|w| unsafe {
+                                    w.sel_p().bits(sel_p)
+                                    .sel_n().bits(sel_n);
+
+                                    if inv {
+                                        w.inv().set_bit();
+                                    }
+
+                                    w
+                                })
+                            }
+                        }
+                    }
+                }
+            )*
+        }
+    }
+}
+
+configure_bits_hstx!(0, 1, 2, 3, 4, 5, 6, 7);

--- a/rp235x-hal/src/hstx.rs
+++ b/rp235x-hal/src/hstx.rs
@@ -307,3 +307,18 @@ macro_rules! configure_bits_hstx {
 }
 
 configure_bits_hstx!(0, 1, 2, 3, 4, 5, 6, 7);
+
+/// "RAW" opcode for expander, OR with length argument to use
+pub const EXPANDER_CMD_RAW: u32 = 0;
+
+/// "RAW_REPEAT" opcode for expander shifted to appropriate position, OR with length argument to use
+pub const EXPANDER_CMD_RAW_REPEAT: u32 = 1 << 12;
+
+/// "TMDS" opcode for expander shifted to appropriate position, OR with length argument to use
+pub const EXPANDER_CMD_TMDS: u32 = 2 << 12;
+
+/// "TMDS_REPEAT" opcode for expander shifted to appropriate position, OR with length argument to use
+pub const EXPANDER_CMD_TMDS_REPEAT: u32 = 3 << 12;
+
+/// "NOP" opcode for expander
+pub const EXPANDER_CMD_NOP: u32 = 0xf << 12;

--- a/rp235x-hal/src/hstx/pins.rs
+++ b/rp235x-hal/src/hstx/pins.rs
@@ -1,0 +1,378 @@
+use crate::{
+    gpio::{bank0::*, AnyPin, FunctionHstx},
+    typelevel::{OptionT, OptionTNone, OptionTSome, Sealed},
+};
+
+macro_rules! hstx_pins {
+    ( $( $bit:expr => $pin:expr ),* ) => {
+        paste::paste!{
+            $(
+                #[doc = "Indicates a valid bit " $bit " pin for HSTX"]
+                pub trait [<ValidHstxBit $bit Pin>] : Sealed {}
+
+                impl<T> [<ValidHstxBit $bit Pin>] for T
+                where
+                    T: AnyPin<Function = FunctionHstx, Id = [<Gpio $pin>]>
+                {
+                }
+
+                #[doc = "Indicates a valid optional bit " $bit " pin for HSTX"]
+                pub trait [<ValidOptionHstxBit $bit>]: OptionT {}
+
+                impl [<ValidOptionHstxBit $bit>] for OptionTNone {}
+                impl<T> [<ValidOptionHstxBit $bit>] for OptionTSome<T>
+                where
+                    T: [<ValidHstxBit $bit Pin>],
+                {
+                }
+            )*
+        }
+    }
+}
+
+hstx_pins!(0 => 12, 1 => 13, 2 => 14, 3 => 15, 4 => 16, 5 => 17, 6 => 18, 7 => 19);
+
+/// Declares a valid HSTX pinout
+pub trait ValidHstxPinout: Sealed {
+    #[allow(missing_docs)]
+    type Bit0: ValidOptionHstxBit0;
+    #[allow(missing_docs)]
+    type Bit1: ValidOptionHstxBit1;
+    #[allow(missing_docs)]
+    type Bit2: ValidOptionHstxBit2;
+    #[allow(missing_docs)]
+    type Bit3: ValidOptionHstxBit3;
+    #[allow(missing_docs)]
+    type Bit4: ValidOptionHstxBit4;
+    #[allow(missing_docs)]
+    type Bit5: ValidOptionHstxBit5;
+    #[allow(missing_docs)]
+    type Bit6: ValidOptionHstxBit6;
+    #[allow(missing_docs)]
+    type Bit7: ValidOptionHstxBit7;
+}
+
+/// Set of valid HSTX pins
+pub struct HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+where
+    Opt0: ValidOptionHstxBit0,
+    Opt1: ValidOptionHstxBit1,
+    Opt2: ValidOptionHstxBit2,
+    Opt3: ValidOptionHstxBit3,
+    Opt4: ValidOptionHstxBit4,
+    Opt5: ValidOptionHstxBit5,
+    Opt6: ValidOptionHstxBit6,
+    Opt7: ValidOptionHstxBit7,
+{
+    /// Optional bit 0 pin
+    pub bit0: Opt0,
+    /// Optional bit 1 pin
+    pub bit1: Opt1,
+    /// Optional bit 2 pin
+    pub bit2: Opt2,
+    /// Optional bit 3 pin
+    pub bit3: Opt3,
+    /// Optional bit 4 pin
+    pub bit4: Opt4,
+    /// Optional bit 5 pin
+    pub bit5: Opt5,
+    /// Optional bit 6 pin
+    pub bit6: Opt6,
+    /// Optional bit 7 pin
+    pub bit7: Opt7,
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > Sealed for HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > ValidHstxPinout for HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+    type Bit0 = Opt0;
+    type Bit1 = Opt1;
+    type Bit2 = Opt2;
+    type Bit3 = Opt3;
+    type Bit4 = Opt4;
+    type Bit5 = Opt5;
+    type Bit6 = Opt6;
+    type Bit7 = Opt7;
+}
+
+impl
+    HstxPins<
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+    >
+{
+    /// Create an empty set of HstxPins
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> HstxPins<
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+        OptionTNone,
+    > {
+        HstxPins {
+            bit0: OptionTNone {},
+            bit1: OptionTNone {},
+            bit2: OptionTNone {},
+            bit3: OptionTNone {},
+            bit4: OptionTNone {},
+            bit5: OptionTNone {},
+            bit6: OptionTNone {},
+            bit7: OptionTNone {},
+        }
+    }
+}
+
+impl<
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<OptionTNone, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+    /// Add bit0 pin to HSTX pin set
+    pub fn add_bit0_pin<Bit0: ValidHstxBit0Pin>(
+        self,
+        bit0: Bit0,
+    ) -> HstxPins<OptionTSome<Bit0>, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {
+            bit0: OptionTSome(bit0),
+            bit1: self.bit1,
+            bit2: self.bit2,
+            bit3: self.bit3,
+            bit4: self.bit4,
+            bit5: self.bit5,
+            bit6: self.bit6,
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<Opt0, OptionTNone, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+    /// Add bit1 pin to HSTX pin set
+    pub fn add_bit1_pin<Bit1: ValidHstxBit1Pin>(
+        self,
+        bit1: Bit1,
+    ) -> HstxPins<Opt0, OptionTSome<Bit1>, Opt2, Opt3, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: OptionTSome(bit1),
+            bit2: self.bit2,
+            bit3: self.bit3,
+            bit4: self.bit4,
+            bit5: self.bit5,
+            bit6: self.bit6,
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<Opt0, Opt1, OptionTNone, Opt3, Opt4, Opt5, Opt6, Opt7>
+{
+    /// Add bit2 pin to HSTX pin set
+    pub fn add_bit2_pin<Bit2: ValidHstxBit2Pin>(
+        self,
+        bit2: Bit2,
+    ) -> HstxPins<Opt0, Opt1, OptionTSome<Bit2>, Opt3, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: self.bit1,
+            bit2: OptionTSome(bit2),
+            bit3: self.bit3,
+            bit4: self.bit4,
+            bit5: self.bit5,
+            bit6: self.bit6,
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<Opt0, Opt1, Opt2, OptionTNone, Opt4, Opt5, Opt6, Opt7>
+{
+    /// Add bit3 pin to HSTX pin set
+    pub fn add_bit3_pin<Bit3: ValidHstxBit3Pin>(
+        self,
+        bit3: Bit3,
+    ) -> HstxPins<Opt0, Opt1, Opt2, OptionTSome<Bit3>, Opt4, Opt5, Opt6, Opt7> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: self.bit1,
+            bit2: self.bit2,
+            bit3: OptionTSome(bit3),
+            bit4: self.bit4,
+            bit5: self.bit5,
+            bit6: self.bit6,
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<Opt0, Opt1, Opt2, Opt3, OptionTNone, Opt5, Opt6, Opt7>
+{
+    /// Add bit4 pin to HSTX pin set
+    pub fn add_bit4_pin<Bit4: ValidHstxBit4Pin>(
+        self,
+        bit4: Bit4,
+    ) -> HstxPins<Opt0, Opt1, Opt2, Opt3, OptionTSome<Bit4>, Opt5, Opt6, Opt7> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: self.bit1,
+            bit2: self.bit2,
+            bit3: self.bit3,
+            bit4: OptionTSome(bit4),
+            bit5: self.bit5,
+            bit6: self.bit6,
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt6: ValidOptionHstxBit6,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, OptionTNone, Opt6, Opt7>
+{
+    /// Add bit5 pin to HSTX pin set
+    pub fn add_bit5_pin<Bit5: ValidHstxBit5Pin>(
+        self,
+        bit5: Bit5,
+    ) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, OptionTSome<Bit5>, Opt6, Opt7> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: self.bit1,
+            bit2: self.bit2,
+            bit3: self.bit3,
+            bit4: self.bit4,
+            bit5: OptionTSome(bit5),
+            bit6: self.bit6,
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt7: ValidOptionHstxBit7,
+    > HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, OptionTNone, Opt7>
+{
+    /// Add bit6 pin to HSTX pin set
+    pub fn add_bit6_pin<Bit6: ValidHstxBit6Pin>(
+        self,
+        bit6: Bit6,
+    ) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, OptionTSome<Bit6>, Opt7> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: self.bit1,
+            bit2: self.bit2,
+            bit3: self.bit3,
+            bit4: self.bit4,
+            bit5: self.bit5,
+            bit6: OptionTSome(bit6),
+            bit7: self.bit7,
+        }
+    }
+}
+
+impl<
+        Opt0: ValidOptionHstxBit0,
+        Opt1: ValidOptionHstxBit1,
+        Opt2: ValidOptionHstxBit2,
+        Opt3: ValidOptionHstxBit3,
+        Opt4: ValidOptionHstxBit4,
+        Opt5: ValidOptionHstxBit5,
+        Opt6: ValidOptionHstxBit6,
+    > HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, OptionTNone>
+{
+    /// Add bit7 pin to HSTX pin set
+    pub fn add_bit7_pin<Bit7: ValidHstxBit7Pin>(
+        self,
+        bit7: Bit7,
+    ) -> HstxPins<Opt0, Opt1, Opt2, Opt3, Opt4, Opt5, Opt6, OptionTSome<Bit7>> {
+        HstxPins {
+            bit0: self.bit0,
+            bit1: self.bit1,
+            bit2: self.bit2,
+            bit3: self.bit3,
+            bit4: self.bit4,
+            bit5: self.bit5,
+            bit6: self.bit6,
+            bit7: OptionTSome(bit7),
+        }
+    }
+}

--- a/rp235x-hal/src/lib.rs
+++ b/rp235x-hal/src/lib.rs
@@ -48,6 +48,7 @@ mod critical_section_impl;
 pub mod dcp;
 pub mod dma;
 pub mod gpio;
+pub mod hstx;
 pub mod i2c;
 pub mod lposc;
 #[cfg(all(target_arch = "arm", target_os = "none"))]


### PR DESCRIPTION
There is not much to abstract in HSTX, but it still nice to have it in HAL for resets, pins etc. There are many questionable decisions made here for sure (including, but not limited to pinout), and I would be happy to hear your feedback.

I have an example using this module in [my repo](https://github.com/OYTIS/rp235x-hstx-example), but it's too bulky for rp235x-hal-examples - maybe a rework of [ST7789 example from pico-examples](https://github.com/raspberrypi/pico-examples/blob/master/hstx/spi_lcd/hstx_spi_lcd.c) will work?

PIO coupling is out of scope for this PR.