### PR TITLE
Remove elf2uf2-rs in favour of picotool

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ RPI-RP2 mass storage device, use the `picotool uf2 convert` command on your
 compiled program with the `-t elf` argument.
 
 ```console
-$ picotool uf2 convert target/thumbv6m-none-eabi/release/pwm_blink -t elf
+$ picotool uf2 convert -t elf target/thumbv6m-none-eabi/release/pwm_blink
 pwm_blink.uf2
 ```
 

--- a/on-target-tests/.cargo/config.toml
+++ b/on-target-tests/.cargo/config.toml
@@ -18,7 +18,7 @@ target = "thumbv6m-none-eabi"
 # * linker argument -Tlink.x tells the linker to use link.x as the linker
 #   script. This is usually provided by the cortex-m-rt crate, and by default
 #   the version in that crate will include a file called `memory.x` which
-#   describes the particular memory layout for your specific chip. 
+#   describes the particular memory layout for your specific chip.
 # * no-vectorize-loops turns off the loop vectorizer (seeing as the M0+ doesn't
 #   have SIMD)
 rustflags = [
@@ -28,9 +28,8 @@ rustflags = [
     "-C", "no-vectorize-loops",
 ]
 
-# This runner will make a UF2 file and then copy it to a mounted RP2040 in USB
-# Bootloader mode:
-runner = "elf2uf2-rs -d"
+# This runner will flash a mounted RP2040 in USB Bootloader mode:
+runner = "picotool load --update --verify --execute -t elf"
 
 # This runner will find a supported SWD debug probe and flash your RP2040 over
 # SWD:

--- a/rp2040-hal-examples/.cargo/config.toml
+++ b/rp2040-hal-examples/.cargo/config.toml
@@ -18,7 +18,7 @@ target = "thumbv6m-none-eabi"
 # * linker argument -Tlink.x tells the linker to use link.x as the linker
 #   script. This is usually provided by the cortex-m-rt crate, and by default
 #   the version in that crate will include a file called `memory.x` which
-#   describes the particular memory layout for your specific chip. 
+#   describes the particular memory layout for your specific chip.
 # * no-vectorize-loops turns off the loop vectorizer (seeing as the M0+ doesn't
 #   have SIMD)
 rustflags = [
@@ -28,9 +28,8 @@ rustflags = [
     "-C", "no-vectorize-loops",
 ]
 
-# This runner will make a UF2 file and then copy it to a mounted RP2040 in USB
-# Bootloader mode:
-runner = "elf2uf2-rs -d"
+# This runner will flash a mounted RP2040 in USB Bootloader mode:
+runner = "picotool load --update --verify --execute -t elf"
 
 # This runner will find a supported SWD debug probe and flash your RP2040 over
 # SWD:

--- a/rp2040-hal-examples/README.md
+++ b/rp2040-hal-examples/README.md
@@ -78,28 +78,30 @@ $ cargo build
 $ cargo build --bin dormant_sleep
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
 $ file ./target/thumbv6m-none-eabi/debug/dormant_sleep
-./target/thumbv6m-none-eabi/debug/dormant_sleep: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
+./target/thumbv6m-none-eabi/debug/dormant_sleep: ELF 32-bit LSB executable, ARM, EABI5 version 1 (GNU/Linux), statically linked, with debug_info, not stripped
 ```
 
-You can also 'run' an example, which will invoke [`elf2uf2-rs`] to copy it to an
-RP2040's virtual USB Mass Storage Device (which it puts over the USB port when
-in its ROM bootloader). You should install that if you don't have it already:
+You can also 'run' an example, which will invoke [picotool] to flash the RP2040
+over USB. You should install that if you don't have it already; [pre-built
+binaries][picotool-releases] are available for Windows, Linux, and macOS.
 
 ```console
-$ cargo install elf2uf2-rs --locked
 $ cd rp2040-hal-examples
 $ cargo run --bin dormant_sleep
-   Compiling rp2040-hal v0.10.0 (/home/user/rp-hal/rp2040-hal)
+   Compiling rp2040-hal v0.11.0 (/home/user/rp-hal/rp2040-hal)
    Compiling rp2040-hal-examples v0.1.0 (/home/user/rp-hal/rp2040-hal-examples)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.62s
-     Running `elf2uf2-rs -d target/thumbv6m-none-eabi/debug/dormant_sleep`
-Found pico uf2 disk /media/user/RP2040
-Transfering program to pico
-88.50 KB / 88.50 KB [=====================================] 100.00 % 430.77 KB/s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.47s
+     Running `picotool load --update --verify --execute -t elf target/thumbv6m-none-eabi/debug/dormant_sleep`
+Loading into Flash:   [==============================]  100%
+Verifying Flash:      [==============================]  100%
+  OK
+
+The device was rebooted to start the application.
 $
 ```
 
-[`elf2uf2-rs`]: https://github.com/JoNil/elf2uf2-rs
+[picotool]: https://github.com/raspberrypi/picotool
+[picotool-releases]: https://github.com/raspberrypi/pico-sdk-tools/releases
 
 <!-- ROADMAP -->
 ## Roadmap


### PR DESCRIPTION
elf2uf2-rs seems to be unmaintained, and as of Rust 1.89 [rejects valid ELF files](https://github.com/JoNil/elf2uf2-rs/issues/40) due to an overly strict check of the ELF header. Picotool is maintained by Raspberry Pi and does not have this problem.

This commit changes guide-level explanation in the root and RP2040 examples READMEs, and the runner in .cargo/config.toml files, to picotool.

Some wording around the flashing process as "creating a UF2 file" was changed as picotool can flash directly from an ELF file with the appropriate command-line flag. Information about deliberately creating a UF2 file has been kept.

In addition, the root README now directs people to rp-binary-info rather than stating that picotool compatible "binary info" is unsupported.

---

**A question**: Previously the root README said:

> For boards with USB Device support like the Raspberry Pi Pico, we recommend you use the UF2 process.

I have removed this explicit recommendation as the paragraph above it directs people to use picotool if they are not using a debug probe (or otherwise wish to flash over USB). Is this acceptable, or should an explicit recommendation (to use picotool over USB) be included?