### PR TITLE
Don't emit binary info unless we are bare-metal.

### DIFF
--- a/rp-binary-info/src/lib.rs
+++ b/rp-binary-info/src/lib.rs
@@ -115,7 +115,7 @@ extern "C" {
 /// The data here tells picotool the start and end flash addresses of our
 /// metadata.
 #[link_section = ".boot_info"]
-#[cfg(feature = "binary-info")]
+#[cfg(all(feature = "binary-info", target_os = "none"))]
 #[used]
 #[allow(unused_unsafe)] // addr_of! is safe since rust 1.82.0
 pub static PICOTOOL_HEADER: Header = unsafe {


### PR DESCRIPTION
The change for `#[used]` in Rust 1.89 causes linker errors when compiling this library for a Linux target (and probably other OSes as well). So now only emit this global variable when target_os is none.