### PR TITLE
rp235x: fix names of directly mapped SRAM banks

### DIFF
--- a/on-target-tests/memory_rp235x.x
+++ b/on-target-tests/memory_rp235x.x
@@ -17,8 +17,8 @@ MEMORY {
      * of access times.
      * Example: Separate stacks for core0 and core1.
      */
-    SRAM4 : ORIGIN = 0x20080000, LENGTH = 4K
-    SRAM5 : ORIGIN = 0x20081000, LENGTH = 4K
+    SRAM8 : ORIGIN = 0x20080000, LENGTH = 4K
+    SRAM9 : ORIGIN = 0x20081000, LENGTH = 4K
 }
 
 SECTIONS {

--- a/rp235x-hal-examples/memory.x
+++ b/rp235x-hal-examples/memory.x
@@ -17,8 +17,8 @@ MEMORY {
      * of access times.
      * Example: Separate stacks for core0 and core1.
      */
-    SRAM4 : ORIGIN = 0x20080000, LENGTH = 4K
-    SRAM5 : ORIGIN = 0x20081000, LENGTH = 4K
+    SRAM8 : ORIGIN = 0x20080000, LENGTH = 4K
+    SRAM9 : ORIGIN = 0x20081000, LENGTH = 4K
 }
 
 SECTIONS {

--- a/rp235x-hal-examples/rp235x_riscv.x
+++ b/rp235x-hal-examples/rp235x_riscv.x
@@ -17,8 +17,8 @@ MEMORY {
      * of access times.
      * Example: Separate stacks for core0 and core1.
      */
-    SRAM4 : ORIGIN = 0x20080000, LENGTH = 4K
-    SRAM5 : ORIGIN = 0x20081000, LENGTH = 4K
+    SRAM8 : ORIGIN = 0x20080000, LENGTH = 4K
+    SRAM9 : ORIGIN = 0x20081000, LENGTH = 4K
 }
 
 /* # Developer notes

--- a/rp235x-hal/src/multicore.rs
+++ b/rp235x-hal/src/multicore.rs
@@ -186,7 +186,7 @@ impl StackAllocation {
     /// Unsafely construct a stack allocation
     ///
     /// This is mainly useful to construct a stack allocation in some memory region
-    /// defined in a linker script, for example to place the stack in the SRAM4/5 regions.
+    /// defined in a linker script, for example to place the stack in the SRAM8/9 regions.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
This corrects the names of the directly mapped SRAM banks from 4/5 to 8/9, in line with section 2.2.3 of the RP2350 datasheet.

This affects three memory.x files; the change in the RP235x HAL itself is to a doc comment.

The incorrect names appear to just have been carried over from the RP2040, where 4/5 are the directly mapped banks. Originally spotted in [this Embassy PR](https://github.com/embassy-rs/embassy/pull/4404).