### PR TITLE
Added wrappers for slices to allow for use of non-static memory for DMA

### DIFF
--- a/rp-hal-common/Cargo.toml
+++ b/rp-hal-common/Cargo.toml
@@ -11,4 +11,6 @@ version = "0.1.0"
 
 # DO NOT LIST ANY PAC CRATES OR ARCHITECTURE CRATES HERE
 [dependencies]
+const-random = "0.1.18"
+embedded-dma = "0.2.0"
 fugit = "0.3.7"

--- a/rp-hal-common/src/dma.rs
+++ b/rp-hal-common/src/dma.rs
@@ -1,0 +1,127 @@
+use const_random::const_random;
+use embedded_dma::{ReadBuffer, WriteBuffer};
+
+pub struct SliceWrapperPointer<T> {
+    pointer: *const T,
+    length: usize,
+    id: u32,
+}
+
+unsafe impl<T> ReadBuffer for SliceWrapperPointer<T> {
+    type Word = T;
+    unsafe fn read_buffer(&self) -> (*const Self::Word, usize) {
+        (self.pointer, self.length)
+    }
+}
+
+#[derive(Debug)]
+pub struct SliceWrapper<'a, T> {
+    inner: &'a [T],
+    pointer_alive: bool,
+    id: u32,
+}
+
+impl<'a, T> SliceWrapper<'a, T> {
+    pub fn new(inner: &'a [T]) -> Self {
+        Self {
+            inner,
+            pointer_alive: false,
+            id: const_random!(u32),
+        }
+    }
+
+    pub fn get_pointer(&mut self) -> SliceWrapperPointer<T> {
+        if self.pointer_alive {
+            panic!("SliceWrapperPointer already referenced in scope");
+        }
+        self.pointer_alive = true;
+
+        SliceWrapperPointer {
+            pointer: self.inner.as_ptr(),
+            length: self.inner.len(),
+            id: self.id
+        }
+    }
+
+    pub fn feed_pointer(&mut self, pointer: SliceWrapperPointer<T>) {
+        if pointer.id != self.id {
+            panic!("Attempted to feed SliceWrapper a pointer with an invalid ID");
+        }
+
+        self.pointer_alive = false;
+    }
+}
+
+impl<'a, T> Drop for SliceWrapper<'a, T> {
+    fn drop(&mut self) {
+        if self.pointer_alive {
+            panic!("SliceWrapper has not been fed it's pointer");
+        }
+    }
+}
+
+pub struct SliceWrapperPointerMut<T> {
+    pointer: *mut T,
+    length: usize,
+    id: u32,
+}
+
+unsafe impl<T> ReadBuffer for SliceWrapperPointerMut<T> {
+    type Word = T;
+    unsafe fn read_buffer(&self) -> (*const Self::Word, usize) {
+        (self.pointer, self.length)
+    }
+}
+
+unsafe impl<T> WriteBuffer for SliceWrapperPointerMut<T> {
+    type Word = T;
+    unsafe fn write_buffer(&mut self) -> (*mut Self::Word, usize) {
+        (self.pointer, self.length)
+    }
+}
+
+#[derive(Debug)]
+pub struct SliceWrapperMut<'a, T> {
+    inner: &'a mut [T],
+    pointer_alive: bool,
+    id: u32,
+}
+
+impl<'a, T> SliceWrapperMut<'a, T> {
+    pub fn new(inner: &'a mut [T]) -> Self {
+        Self {
+            inner,
+            pointer_alive: false,
+            id: const_random!(u32),
+        }
+    }
+
+    pub fn get_pointer(&mut self) -> SliceWrapperPointerMut<T> {
+        if self.pointer_alive {
+            panic!("SliceWrapperPointer already referenced in scope");
+        }
+        self.pointer_alive = true;
+
+        SliceWrapperPointerMut {
+            pointer: self.inner.as_mut_ptr(),
+            length: self.inner.len(),
+            id: self.id
+        }
+    }
+
+    pub fn feed_pointer(&mut self, pointer: SliceWrapperPointerMut<T>) {
+        if pointer.id != self.id {
+            panic!("Attempted to feed SliceWrapper a pointer with an invalid ID");
+        }
+
+        self.pointer_alive = false;
+    }
+}
+
+impl<'a, T> Drop for SliceWrapperMut<'a, T> {
+    fn drop(&mut self) {
+        if self.pointer_alive {
+            panic!("SliceWrapper has not been fed it's pointer");
+        }
+    }
+}

--- a/rp-hal-common/src/lib.rs
+++ b/rp-hal-common/src/lib.rs
@@ -9,3 +9,4 @@
 #![no_std]
 
 pub mod uart;
+pub mod dma;


### PR DESCRIPTION
Recently needed to use DMA to ensure safe transmission of data in the off event that an interrupt triggers mid-data transfer(can cause substantial packet loss in my use case). This type ensures that the DMA transfer is complete before it is dropped by producing a pointer that needs to be fed back into the wrapper.

I haven't documented but if the feedback is good I can work on that later.