### PR TITLE
RP2350: Fix handling of flags in BOOTSEL reboot calls.

### DIFF
--- a/rp235x-hal/CHANGELOG.md
+++ b/rp235x-hal/CHANGELOG.md
@@ -17,6 +17,7 @@ The Minimum-Supported Rust Version (MSRV) for the next release is 1.81
 
 - Update to pio 0.3.0
 - Update rand\_core to 0.9.3
+- Fix handling of flags in `RebootKind::BootSel` reboot.
 
 ## [0.3.0] - 2025-03-02
 

--- a/rp235x-hal/src/reboot.rs
+++ b/rp235x-hal/src/reboot.rs
@@ -69,7 +69,7 @@ pub fn reboot(kind: RebootKind, arch: RebootArch) -> ! {
             if msd_disabled {
                 flags |= 1;
             }
-            crate::rom_data::reboot(0x0002 | options, 500, 0, flags);
+            crate::rom_data::reboot(0x0002 | options, 500, flags, 0);
         }
         RebootKind::Ram { start_addr, size } => {
             crate::rom_data::reboot(0x0003 | options, 500, start_addr as u32, size as u32);


### PR DESCRIPTION
I saw @thejpster 's avatar when filing a PR into defmt and realised I hadn't gotten around to filing this PR. This goes back to the errata I reported here: https://github.com/raspberrypi/pico-feedback/issues/466, which was subsequently incorporated into the [datasheet](https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf), page 397 in section `5.4.8.24`, `p0` is now flags, while `p1` is the gpio.

I use the embassy hal, which doesn't provide a wrapper, when I was setting up bootsel rebooting for picotool, I couldn't figure out how to disable that mass storage device and ultimately also tried the reboot from this HAL, which also didn't work. Only when I tried the pico-sdk reboot function did things start working, which led to the discovery of the above issue. Fixing it here hopefully prevents anyone else from running into this issue in the future.

I did confirm this change fixes it by modifying blinky [here](https://github.com/rp-rs/rp-hal/blob/01eed938623df65c016f81f8163df6801be21d93/rp235x-hal-examples/src/bin/blinky.rs#L71) and inserting;
```rust
    timer.delay_ms(5000);
    rp235x_hal::reboot::reboot(
        RebootKind::BootSel {
            picoboot_disabled: false,
            msd_disabled: true,
        },
        rp235x_hal::reboot::RebootArch::Arm,
    );
```
Without the fix, this results in a USB mass storage device, with the fix this inhibits the behaviour.