### PR TITLE
Don't install libxml2-utils in CI pipeline

### DIFF
--- a/.github/workflows/rp2040_hal_examples.yml
+++ b/.github/workflows/rp2040_hal_examples.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install -y debian-archive-keyring
           sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian unstable main contrib non-free' >/etc/apt/sources.list.d/debian.list"
           sudo apt-get update
-          sudo apt-get install -y libxml2-utils picotool
+          sudo apt-get install -y picotool
       - name: Test picotool
         run: picotool info ${PACKAGE}/target/${TARGET}/debug/binary_info_demo -t elf -a | tee /dev/stderr | grep -q "rp2040-hal Binary Info Example"
   udeps:

--- a/.github/workflows/rp235x_hal_examples_arm.yml
+++ b/.github/workflows/rp235x_hal_examples_arm.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install -y debian-archive-keyring
           sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian unstable main contrib non-free' >/etc/apt/sources.list.d/debian.list"
           sudo apt-get update
-          sudo apt-get install -y libxml2-utils picotool
+          sudo apt-get install -y picotool
       - name: Test picotool
         run: picotool info ${PACKAGE}/target/${TARGET}/debug/binary_info_demo -t elf -a | tee /dev/stderr | grep -q RP2350
   udeps:


### PR DESCRIPTION
I don't even remember why I added it in the first place. May have been a plain cut & paste error.