### PR TITLE
Added support for pins_with_function!() and pin_with_name!()

### DIFF
--- a/rp-binary-info/src/macros.rs
+++ b/rp-binary-info/src/macros.rs
@@ -43,6 +43,25 @@ macro_rules! int {
     }};
 }
 
+/// Equivalent to the pico-sdk bi_2pins_with_func(p0, p1, func)
+#[macro_export]
+macro_rules! pins_with_function {
+    ($pin_0:expr, $pin_1:expr, $func:expr) => {{
+        static ENTRY: $crate::PinsWithFunctionEntry = $crate::PinsWithFunctionEntry::new($pin_0, $pin_1, $func);
+        ENTRY.addr()
+    }};
+}
+
+/// Equivalent to the pico-sdk bi_1pin_with_name(p0, name)
+#[macro_export]
+macro_rules! pin_with_name {
+    ($pin:expr, $name:expr) => {{
+        static ENTRY: $crate::PinWithNameEntry = $crate::PinWithNameEntry::new($pin, $name);
+        ENTRY.addr()
+    }};
+}
+
+
 /// Generate a static item containing the given pointer, and return its
 /// [`EntryAddr`](super::EntryAddr).
 ///


### PR DESCRIPTION
I submitted this to be used as a reference to save someone some time for when they decide to do a full implementation.

pub static PICOTOOL_ENTRIES: [rp_binary_info::EntryAddr; 2] = [
    rp_binary_info::pins_with_function!(
            PICO_DEFAULT_I2C_SDA_PIN,
            PICO_DEFAULT_I2C_SCL_PIN,
            GPIO_FUNC_I2C),

    rp_binary_info::pin_with_name!(
        25, // pin 25 is the LED
        c"The LED"
    ),
];

$ picotool info -a m.bin
Fixed Pin Information
 4:                   I2C0 SDA
 5:                   I2C0 SCL
 25:                  The LED

I found constants in these places:
pico-sdk/src/boards/include/boards/pico2_w.h
pico-sdk/src/common/pico_binary_info/include/pico/binary_info/structure.h pico-sdk/src/rp2350/hardware_structs/include/hardware/structs/io_bank0.h
