### PR TITLE
unpredictable_function_pointer_comparisons lint is not known on MSRV

### DIFF
--- a/rp235x-hal/src/reboot.rs
+++ b/rp235x-hal/src/reboot.rs
@@ -1,6 +1,7 @@
 //! Functions for rebooting the chip using the ROM.
 
 /// Types of reboot we support
+#[allow(unknown_lints)]
 #[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RebootKind {


### PR DESCRIPTION
Add #[allow(unknown_lints)] to fix the issue.

(I'd also be fine with ignoring this. It is only a warning, and our CI doesn't forbid warnings on MSRV, so nothing breaks if we keep it as it is.)