### PR TITLE
Updated embedded-io to 0.7.1

### DIFF
--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -23,7 +23,7 @@ embedded-alloc = "0.5.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-hal-bus = {version = "0.2.0", features = ["defmt-03"]}
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"]}
 fugit = "0.3.6"
 futures = {version = "0.3.30", default-features = false, features = ["async-await"]}

--- a/rp2040-hal/CHANGELOG.md
+++ b/rp2040-hal/CHANGELOG.md
@@ -13,10 +13,14 @@ The Minimum-Supported Rust Version (MSRV) for the next release is 1.81
 
 - Bump MSRV to 1.81 because the crate `home` (an indirect build-depencency) requires it.
 
+### Added
+- Implement core::fmt::Display and core::err:Error for ReadErrorType per the requirements of embedded-io 0.7.1
+
 ### Changed
 
 - Update to pio 0.3.0
 - Update rand\_core to 0.9.3
+- Update embedded-io to 0.7.1
 
 ## [0.11.0] - 2024-12-22
 

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -26,7 +26,7 @@ embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-hal-nb = "1.0.0"
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"]}
 frunk = {version = "0.4.1", default-features = false}
 fugit = "0.3.6"

--- a/rp2040-hal/src/uart/peripheral.rs
+++ b/rp2040-hal/src/uart/peripheral.rs
@@ -466,6 +466,14 @@ impl<D: UartDevice, P: ValidUartPinout<D>> fmt::Write for UartPeripheral<Enabled
     }
 }
 
+impl core::fmt::Display for ReadErrorType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl core::error::Error for ReadErrorType {}
+
 impl embedded_io::Error for ReadErrorType {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -22,7 +22,7 @@ dht-sensor = "0.2.1"
 embedded-alloc = "0.5.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"]}
 fugit = "0.3.6"
 futures = {version = "0.3.30", default-features = false, features = ["async-await"]}

--- a/rp235x-hal/CHANGELOG.md
+++ b/rp235x-hal/CHANGELOG.md
@@ -13,10 +13,14 @@ The Minimum-Supported Rust Version (MSRV) for the next release is 1.81
 
 - Bump MSRV to 1.81 because the crate `home` (an indirect build-depencency) requires it.
 
+### Added
+- Implement core::fmt::Display and core::err:Error for ReadErrorType per the requirements of embedded-io 0.7.1
+
 ### Changed
 
 - Update to pio 0.3.0
 - Update rand\_core to 0.9.3
+- Update embedded-io to 0.7.1
 - Fix handling of flags in `RebootKind::BootSel` reboot.
 
 ## [0.3.0] - 2025-03-02

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -25,7 +25,7 @@ embedded-dma = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
 embedded-hal-nb = "1.0.0"
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 embedded_hal_0_2 = {package = "embedded-hal", version = "0.2.5", features = ["unproven"]}
 frunk = {version = "0.4.1", default-features = false}
 fugit = "0.3.6"

--- a/rp235x-hal/src/uart/peripheral.rs
+++ b/rp235x-hal/src/uart/peripheral.rs
@@ -466,11 +466,20 @@ impl<D: UartDevice, P: ValidUartPinout<D>> fmt::Write for UartPeripheral<Enabled
     }
 }
 
+impl core::fmt::Display for ReadErrorType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl core::error::Error for ReadErrorType {}
+
 impl embedded_io::Error for ReadErrorType {
     fn kind(&self) -> embedded_io::ErrorKind {
         embedded_io::ErrorKind::Other
     }
 }
+
 impl<D: UartDevice, P: ValidUartPinout<D>> embedded_io::ErrorType
     for UartPeripheral<Enabled, D, P>
 {


### PR DESCRIPTION
This is a breaking change since it uses a breaking version of embedded-io, I think.