### PR TITLE
Avoid direct casts from function to integer

### DIFF
--- a/rp2040-hal/src/multicore.rs
+++ b/rp2040-hal/src/multicore.rs
@@ -348,7 +348,7 @@ impl Core<'_> {
                 1,
                 vector_table as usize,
                 stack_ptr as usize,
-                core1_startup::<F> as usize,
+                core1_startup::<F> as *const () as usize,
             ];
 
             let mut seq = 0;

--- a/rp235x-hal/src/multicore.rs
+++ b/rp235x-hal/src/multicore.rs
@@ -368,7 +368,7 @@ impl Core<'_> {
                 1,
                 vector_table as usize,
                 stack_ptr as usize,
-                core1_startup::<F> as usize,
+                core1_startup::<F> as *const () as usize,
             ];
 
             let mut seq = 0;


### PR DESCRIPTION
Current nightly warns about direct casts from function to integer:
```
warning: direct cast of function item into an integer
   --> .../rp235x-hal/src/multicore.rs:371:36
    |
371 |                 core1_startup::<F> as usize,
    |                                    ^^^^^^^^
    |
    = note: `#[warn(function_casts_as_integer)]` on by default
help: first cast to a pointer `as *const ()`
    |
371 |                 core1_startup::<F> as *const () as usize,
    |                                    ++++++++++++
```

In our case the cast is intended, so apply the suggested fix.

As an alternative to `*const ()` for the intermediate step, one could also use the actual fn type. However, in this case, that would be a rather long signature:
`core1_startup::<F> as extern "C" fn(u64, u64, *mut core::mem::ManuallyDrop<F>, *mut usize) -> ! as usize`

So I think here it's better to use the `*const ()` shortcut.