### PR TITLE
Derive Clone, Copy, PartialEq, Eq on ReadErrorType

### DIFF
--- a/rp2040-hal/src/uart/reader.rs
+++ b/rp2040-hal/src/uart/reader.rs
@@ -23,7 +23,7 @@ pub struct ReadError<'err> {
 
 /// Possible types of read errors. See Chapter 4, Section 2 §8 - Table 436: "UARTDR Register"
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReadErrorType {
     /// Triggered when the FIFO (or shift-register) is overflowed.
     Overrun,


### PR DESCRIPTION
This PR is purely to fix one of my painpoints in my project. It's possible that the same changes could be applied to more places throughout this repo.

TODO for myself: build this and test that it doesn't raise any more errors