### PR TITLE
Depend on `pio-core` to avoid pulling in `pio-proc`

### DIFF
--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -33,7 +33,7 @@ fugit = "0.3.6"
 itertools = {version = "0.10.1", default-features = false}
 nb = "1.0"
 paste = "1.0"
-pio = "0.3.0"
+pio-core = "0.3.0"
 rand_core = "0.9.3"
 rp-binary-info = { version = "0.1.2", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
@@ -51,6 +51,7 @@ rtic-monotonic = {version = "1.0.0", optional = true}
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
+pio = "0.3"
 rand = {version = "0.9.1", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -3,7 +3,7 @@
 //! See [Chapter 3 of the datasheet](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf#section_pio) for more details.
 
 use core::ops::Deref;
-use pio::{Instruction, InstructionOperands, Program, SideSet, Wrap};
+use pio_core::{self as pio, Instruction, InstructionOperands, Program, SideSet, Wrap};
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -33,7 +33,7 @@ gcd = ">=2.1,<3.0"
 itertools = {version = "0.13.0", default-features = false}
 nb = "1.0"
 paste = "1.0"
-pio = "0.3.0"
+pio-core = "0.3.0"
 rand_core = "0.9.3"
 rp-binary-info = {version = "0.1.2", path = "../rp-binary-info"}
 rp-hal-common = {version = "0.1.0", path = "../rp-hal-common"}
@@ -59,6 +59,7 @@ riscv-rt = "0.12"
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
+pio = "0.3"
 rand = {version = "0.9.1", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.

--- a/rp235x-hal/src/pio.rs
+++ b/rp235x-hal/src/pio.rs
@@ -4,7 +4,7 @@
 //! datasheet for more details.
 
 use core::ops::Deref;
-use pio::{Instruction, InstructionOperands, Program, SideSet, Wrap};
+use pio_core::{self as pio, Instruction, InstructionOperands, Program, SideSet, Wrap};
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},


### PR DESCRIPTION
This avoids pulling in pio macro support, which is not used in the implementation.

`pio` is kept as a dev-dependency since `pio::pio_asm!` is used in some documentation.