### PR TITLE
Add ReadPinHList and WritePinHList to PinGroup export

### DIFF
--- a/rp2040-hal/src/gpio/mod.rs
+++ b/rp2040-hal/src/gpio/mod.rs
@@ -55,7 +55,7 @@ mod pull;
 
 pub use func::*;
 pub use pin::{DynBankId, DynPinId, PinId};
-pub use pin_group::PinGroup;
+pub use pin_group::{PinGroup, ReadPinHList, WritePinHList};
 pub use pull::*;
 
 /// The amount of current that a pin can drive when used as an output.


### PR DESCRIPTION
A tiny change that would allow users of the crate to define trait bounds using ``ReadPinHList`` and ``WritePinHList``, which **aren't publicly re-exported**.

For example, say a user wants to pass a ``PinGroup`` as a struct field, and use ``.set_u32()`` on the ``PinGroup``.

This is not possible, as the trait bounds aren't satisfied for ANY PinGroup. ``.set_u32()`` **only works on** ``PinGroup``s **with these bounds:**

```rs
impl<H, T> PinGroup<HCons<H, T>>
where
    HCons<H, T>: ReadPinHList + WritePinHList,
    H: AnyPin,
{
    ...
}
```

The issue is that, because both of those traits aren't public, **users cannot define trait bounds for their own code**:

```rs
use rp2040_hal::{self as hal, gpio::{PinGroup, ReadPinHList, WritePinHList}}; // <-- unresolved imports `rp2040_hal::gpio::ReadPinHList`, `rp2040_hal::gpio::WritePinHList`
use embedded_hal::digital::OutputPin;
use frunk::HCons;

pub struct DataBus<H, T, BDIR, BC1>
where
    HCons<H, T>: ReadPinHList + WritePinHList,
    BDIR: OutputPin,
    BC1: OutputPin,
{
    // ( code that involves .set_u32() )
    ...
}
```