### PR TITLE
Add SHA256 hashing to rp235x-hal and rp235x-hal-examples.

### DIFF
--- a/rp235x-hal-examples/src/bin/sha256_test.rs
+++ b/rp235x-hal-examples/src/bin/sha256_test.rs
@@ -1,0 +1,168 @@
+//! SHA-256 Hardware Accelerator Test
+//!
+//! This example tests the SHA256 hardware accelerator against NIST test vectors.
+
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+use rp235x_hal as hal;
+
+use hal::{
+    clocks::init_clocks_and_plls,
+    gpio, pac,
+    prelude::*,
+    sha256::{Endianness, Sha256, Sha256State},
+    Watchdog,
+};
+
+use core::fmt::Write;
+use embedded_hal::delay::DelayNs;
+use hal::clocks::Clock;
+use hal::fugit::RateExtU32;
+use hal::uart::{DataBits, StopBits, UartConfig};
+
+const XTAL_FREQ_HZ: u32 = 12_000_000u32;
+
+// NIST test vectors
+const EMPTY_HASH: [u8; 32] = [
+    0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+    0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+];
+
+const ABC_HASH: [u8; 32] = [
+    0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+    0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+];
+
+#[link_section = ".start_block"]
+#[used]
+pub static IMAGE_DEF: hal::block::ImageDef = hal::block::ImageDef::secure_exe();
+
+#[hal::entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let mut watchdog = Watchdog::new(pac.WATCHDOG);
+
+    let clocks = init_clocks_and_plls(
+        XTAL_FREQ_HZ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .unwrap();
+
+    let mut delay = hal::Timer::new_timer0(pac.TIMER0, &mut pac.RESETS, &clocks);
+
+    // The single-cycle I/O block controls our GPIO pins
+    let sio = hal::Sio::new(pac.SIO);
+
+    // Set the pins to their default state
+    let pins = hal::gpio::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    let uart0_pins = (
+        // UART TX (characters sent from rp235x) on GPIO0
+        pins.gpio0.into_function(),
+        // UART RX (characters received by rp235x) on GPIO1
+        pins.gpio1.into_function(),
+    );
+
+    let mut uart0 = hal::uart::UartPeripheral::new(pac.UART0, uart0_pins, &mut pac.RESETS)
+        .enable(
+            UartConfig::new(115200.Hz(), DataBits::Eight, None, StopBits::One),
+            clocks.peripheral_clock.freq(),
+        )
+        .unwrap();
+
+    uart0.write_full_blocking(b"Starting SHA256 example on UART0\r\n");
+
+    let mut sha256 = Sha256::new(pac.SHA256);
+
+    // Test 1: Empty string
+    let mut state = Sha256State::new();
+    state.start(&mut sha256, Endianness::Big);
+    let result_empty = state.finish(&mut sha256);
+    assert!(result_empty == EMPTY_HASH, "Empty string hash mismatch");
+    uart0.write_full_blocking(b"Test 1 (empty): PASS\r\n");
+
+    // Test 2: "abc"
+    let mut state = Sha256State::new();
+    state.start(&mut sha256, Endianness::Big);
+    state.update_blocking(&mut sha256, b"abc");
+    let result_abc = state.finish(&mut sha256);
+    assert!(result_abc == ABC_HASH, "abc hash mismatch");
+    uart0.write_full_blocking(b"Test 2 (abc): PASS\r\n");
+
+    // Test 3: Longer message
+    let data = b"abcdefghijklmnopqrstuvwxyz";
+    let mut state = Sha256State::new();
+    state.start(&mut sha256, Endianness::Big);
+    state.update_blocking(&mut sha256, data);
+    let result_long = state.finish(&mut sha256);
+    let expected_long: [u8; 32] = [
+        0x71, 0xc4, 0x80, 0xdf, 0x93, 0xd6, 0xae, 0x2f, 0x1e, 0xfA, 0xd1, 0x44, 0x7c, 0x66, 0xc9,
+        0x52, 0x5e, 0x31, 0x62, 0x18, 0xcf, 0x51, 0xfc, 0x8d, 0x9e, 0xd8, 0x32, 0xf2, 0xda, 0xf1,
+        0x8b, 0x73,
+    ];
+    assert!(result_long == expected_long, "Long string hash mismatch");
+    uart0.write_full_blocking(b"Test 3 (long): PASS\r\n");
+
+    // Test 4: Multi-block hash (65 bytes)
+    let multi_block_data: [u8; 65] = [b'A'; 65];
+    let mut state = Sha256State::new();
+    state.start(&mut sha256, Endianness::Big);
+    state.update_blocking(&mut sha256, &multi_block_data);
+    let result_multi = state.finish(&mut sha256);
+    let expected_multi_block: [u8; 32] = [
+        0x83, 0x62, 0x03, 0x94, 0x4f, 0x4c, 0x02, 0x80, 0x46, 0x1a, 0xd7, 0x3d, 0x31, 0x45, 0x7c,
+        0x22, 0xba, 0x19, 0xd1, 0xd9, 0x9e, 0x23, 0x2d, 0xc2, 0x31, 0x00, 0x00, 0x85, 0x89, 0x9e,
+        0x00, 0xa2,
+    ];
+    assert!(
+        result_multi == expected_multi_block,
+        "Multi block hash mismatch"
+    );
+
+    uart0.write_full_blocking(b"Test 4 (multi-block): PASS\r\n");
+
+    // Test 5: Incremental update
+    let mut state = Sha256State::new();
+    state.start(&mut sha256, Endianness::Big);
+    state.update_blocking(&mut sha256, b"hello");
+    state.update_blocking(&mut sha256, b" ");
+    state.update_blocking(&mut sha256, b"world");
+    let result_incremental = state.finish(&mut sha256);
+
+    // SHA256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    let expected_hello_world: [u8; 32] = [
+        0xb9, 0x4d, 0x27, 0xb9, 0x93, 0x4d, 0x3e, 0x08, 0xa5, 0x2e, 0x52, 0xd7, 0xda, 0x7d, 0xab,
+        0xfa, 0xc4, 0x84, 0xef, 0xe3, 0x7a, 0x53, 0x80, 0xee, 0x90, 0x88, 0xf7, 0xac, 0xe2, 0xef,
+        0xcd, 0xe9,
+    ];
+    assert!(
+        result_incremental == expected_hello_world,
+        "Incremental hash mismatch"
+    );
+    uart0.write_full_blocking(b"Test 5 (incremental): PASS\r\n");
+
+    uart0.write_full_blocking(b"All tests passed.\r\n");
+
+    loop {
+        cortex_m::asm::wfi();
+    }
+}
+
+/// Required by panic_halt
+#[cfg(feature = "rt")]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/rp235x-hal-examples/src/bin/sha256_test.rs
+++ b/rp235x-hal-examples/src/bin/sha256_test.rs
@@ -10,14 +10,11 @@ use rp235x_hal as hal;
 
 use hal::{
     clocks::init_clocks_and_plls,
-    gpio, pac,
-    prelude::*,
+    pac,
     sha256::{Endianness, Sha256, Sha256State},
     Watchdog,
 };
 
-use core::fmt::Write;
-use embedded_hal::delay::DelayNs;
 use hal::clocks::Clock;
 use hal::fugit::RateExtU32;
 use hal::uart::{DataBits, StopBits, UartConfig};
@@ -25,14 +22,42 @@ use hal::uart::{DataBits, StopBits, UartConfig};
 const XTAL_FREQ_HZ: u32 = 12_000_000u32;
 
 // NIST test vectors
+
+// hash of b"" (empty string)
 const EMPTY_HASH: [u8; 32] = [
     0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
     0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
 ];
 
+// hash of b"abc"
 const ABC_HASH: [u8; 32] = [
     0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
     0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+];
+
+// hash of b"abcdefghijklmnopqrstuvwxyz"
+const EXPECTED_LONG: [u8; 32] = [
+    0x71, 0xc4, 0x80, 0xdf, 0x93, 0xd6, 0xae, 0x2f, 0x1e, 0xfa, 0xd1, 0x44, 0x7c, 0x66, 0xc9, 0x52,
+    0x5e, 0x31, 0x62, 0x18, 0xcf, 0x51, 0xfc, 0x8d, 0x9e, 0xd8, 0x32, 0xf2, 0xda, 0xf1, 0x8b, 0x73,
+];
+
+// hash of b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+const EXPECTED_MULTI_BLOCK: [u8; 32] = [
+    0x83, 0x62, 0x03, 0x94, 0x4f, 0x4c, 0x02, 0x80, 0x46, 0x1a, 0xd7, 0x3d, 0x31, 0x45, 0x7c, 0x22,
+    0xba, 0x19, 0xd1, 0xd9, 0x9e, 0x23, 0x2d, 0xc2, 0x31, 0x00, 0x00, 0x85, 0x89, 0x9e, 0x00, 0xa2,
+];
+
+// hash of b"hello world"
+const EXPECTED_HELLO_WORLD: [u8; 32] = [
+    0xb9, 0x4d, 0x27, 0xb9, 0x93, 0x4d, 0x3e, 0x08, 0xa5, 0x2e, 0x52, 0xd7, 0xda, 0x7d, 0xab, 0xfa,
+    0xc4, 0x84, 0xef, 0xe3, 0x7a, 0x53, 0x80, 0xee, 0x90, 0x88, 0xf7, 0xac, 0xe2, 0xef, 0xcd, 0xe9,
+];
+
+// hash of b"PUCELLE. First, let me tell you whom you have condemn'd: Not one begotten of a shepherd swain, But issued from the progeny of kings; Virtuous and holy, chosen from above, By inspiration of celestial grace, To work exceeding miracles on earth. I never had to do with wicked spirits. But you, that are polluted with your lusts, Stain'd with the guiltless blood of innocents, Corrupt and tainted with a thousand vices, Because you want the grace that others have, You judge it straight a thing impossible To compass wonders but by help of devils. No, misconceived! Joan of Arc hath been A virgin from her tender infancy, Chaste and immaculate in very thought; Whose maiden blood, thus rigorously effused, Will cry for vengeance at the gates of heaven."
+// source: https://www.gutenberg.org/cache/epub/100/pg100.txt with apostrophe substitution
+const EXPECTED_SHAKESPEARE: [u8; 32] = [
+    0x19, 0x42, 0x5f, 0xcc, 0x0a, 0xf2, 0xde, 0x8f, 0x27, 0xd5, 0x60, 0xb9, 0xb3, 0x02, 0x53, 0x08,
+    0x30, 0x50, 0x92, 0x0f, 0x6b, 0x82, 0x9a, 0xda, 0x80, 0x40, 0x02, 0xa9, 0x2b, 0xba, 0xf4, 0x90,
 ];
 
 #[link_section = ".start_block"]
@@ -55,8 +80,6 @@ fn main() -> ! {
     )
     .unwrap();
 
-    let mut delay = hal::Timer::new_timer0(pac.TIMER0, &mut pac.RESETS, &clocks);
-
     // The single-cycle I/O block controls our GPIO pins
     let sio = hal::Sio::new(pac.SIO);
 
@@ -75,7 +98,7 @@ fn main() -> ! {
         pins.gpio1.into_function(),
     );
 
-    let mut uart0 = hal::uart::UartPeripheral::new(pac.UART0, uart0_pins, &mut pac.RESETS)
+    let uart0 = hal::uart::UartPeripheral::new(pac.UART0, uart0_pins, &mut pac.RESETS)
         .enable(
             UartConfig::new(115200.Hz(), DataBits::Eight, None, StopBits::One),
             clocks.peripheral_clock.freq(),
@@ -96,7 +119,7 @@ fn main() -> ! {
     // Test 2: "abc"
     let mut state = Sha256State::new();
     state.start(&mut sha256, Endianness::Big);
-    state.update_blocking(&mut sha256, b"abc");
+    state.update(&mut sha256, b"abc");
     let result_abc = state.finish(&mut sha256);
     assert!(result_abc == ABC_HASH, "abc hash mismatch");
     uart0.write_full_blocking(b"Test 2 (abc): PASS\r\n");
@@ -105,29 +128,20 @@ fn main() -> ! {
     let data = b"abcdefghijklmnopqrstuvwxyz";
     let mut state = Sha256State::new();
     state.start(&mut sha256, Endianness::Big);
-    state.update_blocking(&mut sha256, data);
+    state.update(&mut sha256, data);
     let result_long = state.finish(&mut sha256);
-    let expected_long: [u8; 32] = [
-        0x71, 0xc4, 0x80, 0xdf, 0x93, 0xd6, 0xae, 0x2f, 0x1e, 0xfA, 0xd1, 0x44, 0x7c, 0x66, 0xc9,
-        0x52, 0x5e, 0x31, 0x62, 0x18, 0xcf, 0x51, 0xfc, 0x8d, 0x9e, 0xd8, 0x32, 0xf2, 0xda, 0xf1,
-        0x8b, 0x73,
-    ];
-    assert!(result_long == expected_long, "Long string hash mismatch");
+
+    assert!(result_long == EXPECTED_LONG, "Long string hash mismatch");
     uart0.write_full_blocking(b"Test 3 (long): PASS\r\n");
 
     // Test 4: Multi-block hash (65 bytes)
     let multi_block_data: [u8; 65] = [b'A'; 65];
     let mut state = Sha256State::new();
     state.start(&mut sha256, Endianness::Big);
-    state.update_blocking(&mut sha256, &multi_block_data);
+    state.update(&mut sha256, &multi_block_data);
     let result_multi = state.finish(&mut sha256);
-    let expected_multi_block: [u8; 32] = [
-        0x83, 0x62, 0x03, 0x94, 0x4f, 0x4c, 0x02, 0x80, 0x46, 0x1a, 0xd7, 0x3d, 0x31, 0x45, 0x7c,
-        0x22, 0xba, 0x19, 0xd1, 0xd9, 0x9e, 0x23, 0x2d, 0xc2, 0x31, 0x00, 0x00, 0x85, 0x89, 0x9e,
-        0x00, 0xa2,
-    ];
     assert!(
-        result_multi == expected_multi_block,
+        result_multi == EXPECTED_MULTI_BLOCK,
         "Multi block hash mismatch"
     );
 
@@ -136,33 +150,31 @@ fn main() -> ! {
     // Test 5: Incremental update
     let mut state = Sha256State::new();
     state.start(&mut sha256, Endianness::Big);
-    state.update_blocking(&mut sha256, b"hello");
-    state.update_blocking(&mut sha256, b" ");
-    state.update_blocking(&mut sha256, b"world");
+    state.update(&mut sha256, b"hello");
+    state.update(&mut sha256, b" ");
+    state.update(&mut sha256, b"world");
     let result_incremental = state.finish(&mut sha256);
 
-    // SHA256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-    let expected_hello_world: [u8; 32] = [
-        0xb9, 0x4d, 0x27, 0xb9, 0x93, 0x4d, 0x3e, 0x08, 0xa5, 0x2e, 0x52, 0xd7, 0xda, 0x7d, 0xab,
-        0xfa, 0xc4, 0x84, 0xef, 0xe3, 0x7a, 0x53, 0x80, 0xee, 0x90, 0x88, 0xf7, 0xac, 0xe2, 0xef,
-        0xcd, 0xe9,
-    ];
     assert!(
-        result_incremental == expected_hello_world,
+        result_incremental == EXPECTED_HELLO_WORLD,
         "Incremental hash mismatch"
     );
     uart0.write_full_blocking(b"Test 5 (incremental): PASS\r\n");
+
+    let mut state = Sha256State::new();
+    state.start(&mut sha256, Endianness::Big);
+    state.update(&mut sha256, b"PUCELLE. First, let me tell you whom you have condemn'd: Not one begotten of a shepherd swain, But issued from the progeny of kings; Virtuous and holy, chosen from above, By inspiration of celestial grace, To work exceeding miracles on earth. I never had to do with wicked spirits. But you, that are polluted with your lusts, Stain'd with the guiltless blood of innocents, Corrupt and tainted with a thousand vices, Because you want the grace that others have, You judge it straight a thing impossible To compass wonders but by help of devils. No, misconceived! Joan of Arc hath been A virgin from her tender infancy, Chaste and immaculate in very thought; Whose maiden blood, thus rigorously effused, Will cry for vengeance at the gates of heaven.");
+    let result_shakespeare = state.finish(&mut sha256);
+
+    assert!(
+        result_shakespeare == EXPECTED_SHAKESPEARE,
+        "Long text entry mismatch!"
+    );
+    uart0.write_full_blocking(b"Test 6 (long text entry): PASS\r\n");
 
     uart0.write_full_blocking(b"All tests passed.\r\n");
 
     loop {
         cortex_m::asm::wfi();
     }
-}
-
-/// Required by panic_halt
-#[cfg(feature = "rt")]
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
 }

--- a/rp235x-hal/src/lib.rs
+++ b/rp235x-hal/src/lib.rs
@@ -63,6 +63,7 @@ pub mod reboot;
 pub mod resets;
 pub mod rom_data;
 pub mod rosc;
+pub mod sha256;
 pub mod sio;
 pub mod spi;
 pub mod timer;

--- a/rp235x-hal/src/sha256.rs
+++ b/rp235x-hal/src/sha256.rs
@@ -1,0 +1,415 @@
+//! SHA-256 Hardware Accelerator
+//!
+//! The RP2350 features a hardware SHA-256 accelerator that can compute
+//! cryptographic hash functions much faster than software implementation.
+//!
+//! See [Section 4.6](https://rptl.io/rp2350-datasheet#section_sha256) of the
+//! RP2350 datasheet for more details.
+//!
+//! ## Features
+//!
+//! - Hardware-accelerated SHA-256 hashing
+//! - Supports both big-endian and little-endian data
+//! - Byte swapping for proper SHA-256 format
+//! - DMA support for large data transfers (via DREQ_SHA256)
+//! - Error detection and recovery
+//!
+//! ## Basic Usage
+//!
+//! ```no_run
+//! use rp235x_hal::{pac, sha256::{Sha256, Sha256State, Endianness}};
+//!
+//! let mut peripherals = pac::Peripherals::take().unwrap();
+//!
+//! // Initialize SHA256 peripheral (no reset needed)
+//! let mut sha256 = Sha256::new(peripherals.SHA256);
+//!
+//! // Create hasher state
+//! let mut state = Sha256State::new();
+//!
+//! // Compute hash
+//! let data = b"Hello, World!";
+//! state.start(&mut sha256, Endianness::Big);
+//! state.update_blocking(&mut sha256, data);
+//! let result = state.finish(&mut sha256);
+//!
+//! // result is a 32-byte SHA-256 hash
+//! ```
+//!
+//! ## NIST Test Vectors
+//!
+//! - SHA256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+//! - SHA256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+use core::marker::PhantomData;
+
+use crate::pac::sha256;
+use crate::pac::SHA256;
+
+/// SHA-256 hash result (32 bytes)
+pub type Sha256Result = [u8; 32];
+
+/// Endianness for input/output data
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endianness {
+    /// Little-endian byte order
+    Little,
+    /// Big-endian byte order (network order, SHA-256 standard)
+    Big,
+}
+
+/// DMA transfer size for hardware acceleration
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DmaSize {
+    /// 8-bit transfers (1 byte)
+    Bits8 = 0,
+    /// 16-bit transfers (2 bytes)
+    Bits16 = 1,
+    /// 32-bit transfers (4 bytes)
+    Bits32 = 2,
+}
+
+impl DmaSize {
+    /// Convert byte size to DmaSize
+    pub fn from_bytes(size: u8) -> Self {
+        match size {
+            1 => DmaSize::Bits8,
+            2 => DmaSize::Bits16,
+            4 => DmaSize::Bits32,
+            _ => panic!("DMA size must be 1, 2, or 4 bytes"),
+        }
+    }
+}
+
+/// SHA-256 peripheral wrapper
+///
+/// This provides direct register access to the SHA-256 hardware accelerator.
+/// For higher-level functionality, use `Sha256State` which handles padding
+/// and multi-block hashing.
+pub struct Sha256 {
+    register_block: *const sha256::RegisterBlock,
+}
+
+unsafe impl Send for Sha256 {}
+
+impl Sha256 {
+    /// Take ownership of the SHA256 peripheral
+    ///
+    /// Note: Unlike other peripherals, SHA256 does not require explicit reset handling.
+    /// The hardware is ready to use immediately.
+    pub fn new(peripheral: SHA256) -> Self {
+        let _ = peripheral; // Consume the peripheral to ensure uniqueness
+        Self {
+            register_block: SHA256::PTR,
+        }
+    }
+
+    /// Get the CSR register
+    #[inline]
+    fn csr(&self) -> &sha256::CSR {
+        unsafe { (*self.register_block).csr() }
+    }
+
+    /// Get the WDATA register
+    #[inline]
+    fn wdata(&self) -> &sha256::WDATA {
+        unsafe { (*self.register_block).wdata() }
+    }
+
+    /// Get the SUM registers as a pointer
+    #[inline]
+    fn sum_ptr(&self) -> *const u32 {
+        unsafe { (*self.register_block).sum0() as *const _ as *const u32 }
+    }
+
+    /// Enable or disable byte swapping
+    ///
+    /// SHA-256 expects bytes in big-endian order, but the system bus is little-endian.
+    /// When enabled (default), the hardware will swap bytes automatically.
+    ///
+    /// # Arguments
+    /// * `enable` - `true` to enable byte swapping (recommended for SHA-256),
+    ///   `false` to disable
+    pub fn set_bswap(&mut self, enable: bool) {
+        self.csr().modify(|_, w| w.bswap().bit(enable));
+    }
+
+    /// Start a new hash calculation
+    ///
+    /// This initializes the hardware with the SHA-256 initial hash values
+    /// and clears all internal counters.
+    pub fn start(&mut self) {
+        self.wait_ready_blocking();
+        self.clear_err_not_ready();
+        self.csr().modify(|_, w| w.start().set_bit());
+    }
+
+    /// Check if hardware is ready to accept data
+    ///
+    /// Returns `true` if the hardware has processed the previous 64-byte block
+    /// and is ready to accept more data.
+    pub fn is_ready(&self) -> bool {
+        self.csr().read().wdata_rdy().bit()
+    }
+
+    /// Wait until hardware is ready to accept data.
+    pub fn wait_ready_blocking(&self) {
+        while !self.is_ready() {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Check if hash result is valid
+    ///
+    /// Returns `true` if a complete 64-byte block has been processed
+    /// and the result in SUM registers is valid.
+    pub fn is_sum_valid(&self) -> bool {
+        self.csr().read().sum_vld().bit()
+    }
+
+    /// Wait until hash result is valid.
+    pub fn wait_valid_blocking(&self) {
+        while !self.is_sum_valid() {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Write one 32-bit word to the hardware
+    ///
+    /// # Safety
+    /// The caller must ensure the hardware is ready
+    pub unsafe fn put_word(&self, word: u32) {
+        let wdata = self.wdata();
+        wdata.write(|w| w.bits(word));
+    }
+
+    /// Write one byte to the hardware
+    ///
+    /// # Safety
+    /// The caller must ensure the hardware is ready
+    pub unsafe fn put_byte(&self, byte: u8) {
+        let wdata_ptr = self.wdata() as *const _ as *mut u8;
+        wdata_ptr.write_volatile(byte);
+    }
+
+    /// Check for "not ready" error
+    ///
+    /// Returns `true` if data was written when the hardware was not ready.
+    pub fn err_not_ready(&self) -> bool {
+        self.csr().read().err_wdata_not_rdy().bit()
+    }
+
+    /// Clear "not ready" error.
+    pub fn clear_err_not_ready(&mut self) {
+        self.csr()
+            .modify(|_, w| w.err_wdata_not_rdy().clear_bit_by_one());
+    }
+
+    /// Read the CSR register value for debugging.
+    #[allow(dead_code)]
+    fn read_csr(&self) -> u32 {
+        self.csr().read().bits()
+    }
+
+    /// Read the 256-bit hash result
+    ///
+    /// # Safety
+    /// The caller must ensure the result is valid.
+    pub unsafe fn get_result(&self) -> [u32; 8] {
+        let sum_ptr = self.sum_ptr();
+        core::ptr::read_unaligned(sum_ptr as *const [u32; 8])
+    }
+}
+
+/// SHA-256 hashing state
+///
+/// This maintains the state for incremental hashing, including:
+/// - Total data size processed
+/// - Cached partial words for unaligned data
+/// - Endianness configuration
+///
+/// ## Example
+/// ```no_run
+/// use rp235x_hal::{pac, sha256::{Sha256, Sha256State, Endianness}};
+///
+/// let mut peripherals = pac::Peripherals::take().unwrap();
+/// let mut sha256 = Sha256::new(peripherals.SHA256);
+///
+/// let mut state = Sha256State::new();
+/// state.start(&mut sha256, Endianness::Big);
+///
+/// // Hash data in chunks
+/// state.update_blocking(&mut sha256, b"Hello, ");
+/// state.update_blocking(&mut sha256, b"World!");
+///
+/// let result = state.finish(&mut sha256);
+/// ```
+pub struct Sha256State {
+    endianness: Endianness,
+    total_data_size: usize,
+    cache: [u8; 4],
+    cache_used: u8,
+    _marker: PhantomData<()>,
+}
+
+impl Default for Sha256State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sha256State {
+    /// Create a new SHA-256 state
+    pub fn new() -> Self {
+        Self {
+            endianness: Endianness::Big,
+            total_data_size: 0,
+            cache: [0; 4],
+            cache_used: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Start a new SHA-256 calculation
+    ///
+    /// # Arguments
+    /// * `sha256` - The SHA-256 peripheral instance
+    /// * `endianness` - The endianness of the input data
+    pub fn start(&mut self, sha256: &mut Sha256, endianness: Endianness) {
+        self.endianness = endianness;
+        self.total_data_size = 0;
+        self.cache_used = 0;
+
+        sha256.set_bswap(endianness == Endianness::Big);
+        sha256.start();
+    }
+
+    /// Update hash with data (non-blocking)
+    ///
+    /// This method writes data to the hardware as quickly as possible.
+    /// Any unaligned bytes are cached for the next update call.
+    ///
+    /// # Note
+    /// This does not wait for the hardware to be ready between writes.
+    /// Use `update_blocking()` for simpler code that handles readiness automatically.
+    pub fn update(&mut self, sha256: &mut Sha256, data: &[u8]) {
+        let mut pos = 0;
+
+        if self.cache_used > 0 {
+            while self.cache_used < 4 && pos < data.len() {
+                self.cache[self.cache_used as usize] = data[pos];
+                self.cache_used += 1;
+                pos += 1;
+            }
+
+            // If we now have a complete word, write it
+            if self.cache_used == 4 {
+                let word = u32::from_le_bytes(self.cache);
+                sha256.wait_ready_blocking();
+                unsafe { sha256.put_word(word) };
+                self.cache_used = 0;
+            }
+        }
+
+        while pos + 4 <= data.len() {
+            sha256.wait_ready_blocking();
+
+            let word = u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+            unsafe { sha256.put_word(word) };
+            pos += 4;
+        }
+
+        while pos < data.len() {
+            self.cache[self.cache_used as usize] = data[pos];
+            self.cache_used += 1;
+            pos += 1;
+        }
+
+        self.total_data_size += data.len();
+    }
+
+    /// Update hash with data (blocking)
+    ///
+    /// This method waits for the hardware to be ready before each write,
+    /// ensuring no data is lost.
+    pub fn update_blocking(&mut self, sha256: &mut Sha256, data: &[u8]) {
+        self.update(sha256, data);
+    }
+
+    /// Finalize the hash and return the result
+    ///
+    /// This appends the required padding:
+    /// 1. A single 0x80 byte
+    /// 2. Zero bytes until the length is congruent to 56 mod 64
+    /// 3. The original message length as a 64-bit big-endian integer
+    ///
+    /// Then waits for the hash to complete and returns the 32-byte result.
+    pub fn finish(&mut self, sha256: &mut Sha256) -> Sha256Result {
+        if self.total_data_size == 0 && self.cache_used == 0 {
+            sha256.wait_ready_blocking();
+            unsafe { sha256.put_word(0x00000080) };
+
+            for _ in 0..13 {
+                sha256.wait_ready_blocking();
+                unsafe { sha256.put_word(0) };
+            }
+
+            sha256.wait_ready_blocking();
+            unsafe { sha256.put_word(0) };
+            sha256.wait_ready_blocking();
+            unsafe { sha256.put_word(0) };
+
+            sha256.wait_valid_blocking();
+
+            let result_words = unsafe { sha256.get_result() };
+            let mut result = [0u8; 32];
+            for i in 0..8 {
+                let bytes = result_words[i].to_be_bytes();
+                result[i * 4] = bytes[0];
+                result[i * 4 + 1] = bytes[1];
+                result[i * 4 + 2] = bytes[2];
+                result[i * 4 + 3] = bytes[3];
+            }
+
+            return result;
+        }
+
+        for i in 0..self.cache_used {
+            sha256.wait_ready_blocking();
+            unsafe { sha256.put_byte(self.cache[i as usize]) };
+        }
+        self.cache_used = 0;
+
+        sha256.wait_ready_blocking();
+        unsafe { sha256.put_byte(0x80) };
+
+        let msg_len_bits = (self.total_data_size * 8) as u64;
+        let bytes_written = self.total_data_size + 1;
+        let zero_bytes = if bytes_written % 64 <= 56 {
+            56 - (bytes_written % 64)
+        } else {
+            64 + 56 - (bytes_written % 64)
+        };
+
+        for _ in 0..zero_bytes {
+            sha256.wait_ready_blocking();
+            unsafe { sha256.put_byte(0) };
+        }
+
+        let len_bytes = msg_len_bits.to_be_bytes();
+        for b in &len_bytes {
+            sha256.wait_ready_blocking();
+            unsafe { sha256.put_byte(*b) };
+        }
+
+        sha256.wait_valid_blocking();
+
+        let result_words = unsafe { sha256.get_result() };
+        let mut result = [0u8; 32];
+        for i in 0..8 {
+            let bytes = result_words[i].to_be_bytes();
+            result[i * 4..i * 4 + 4].copy_from_slice(&bytes);
+        }
+        result
+    }
+}

--- a/rp235x-hal/src/sha256.rs
+++ b/rp235x-hal/src/sha256.rs
@@ -28,9 +28,10 @@
 //! let mut state = Sha256State::new();
 //!
 //! // Compute hash
-//! let data = b"Hello, World!";
+//! let data = b"Hello, World!"; // must be bytes
 //! state.start(&mut sha256, Endianness::Big);
-//! state.update_blocking(&mut sha256, data);
+//! state.update(&mut sha256, data);
+//! state.update(&mut sha256, data); // more data can be appended
 //! let result = state.finish(&mut sha256);
 //!
 //! // result is a 32-byte SHA-256 hash
@@ -40,8 +41,6 @@
 //!
 //! - SHA256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 //! - SHA256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-
-use core::marker::PhantomData;
 
 use crate::pac::sha256;
 use crate::pac::SHA256;
@@ -58,36 +57,13 @@ pub enum Endianness {
     Big,
 }
 
-/// DMA transfer size for hardware acceleration
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DmaSize {
-    /// 8-bit transfers (1 byte)
-    Bits8 = 0,
-    /// 16-bit transfers (2 bytes)
-    Bits16 = 1,
-    /// 32-bit transfers (4 bytes)
-    Bits32 = 2,
-}
-
-impl DmaSize {
-    /// Convert byte size to DmaSize
-    pub fn from_bytes(size: u8) -> Self {
-        match size {
-            1 => DmaSize::Bits8,
-            2 => DmaSize::Bits16,
-            4 => DmaSize::Bits32,
-            _ => panic!("DMA size must be 1, 2, or 4 bytes"),
-        }
-    }
-}
-
 /// SHA-256 peripheral wrapper
 ///
 /// This provides direct register access to the SHA-256 hardware accelerator.
 /// For higher-level functionality, use `Sha256State` which handles padding
 /// and multi-block hashing.
 pub struct Sha256 {
-    register_block: *const sha256::RegisterBlock,
+    device: SHA256,
 }
 
 unsafe impl Send for Sha256 {}
@@ -97,29 +73,18 @@ impl Sha256 {
     ///
     /// Note: Unlike other peripherals, SHA256 does not require explicit reset handling.
     /// The hardware is ready to use immediately.
-    pub fn new(peripheral: SHA256) -> Self {
-        let _ = peripheral; // Consume the peripheral to ensure uniqueness
-        Self {
-            register_block: SHA256::PTR,
-        }
+    pub fn new(device: SHA256) -> Self {
+        Self { device }
     }
 
     /// Get the CSR register
-    #[inline]
     fn csr(&self) -> &sha256::CSR {
-        unsafe { (*self.register_block).csr() }
+        self.device.csr()
     }
 
     /// Get the WDATA register
-    #[inline]
     fn wdata(&self) -> &sha256::WDATA {
-        unsafe { (*self.register_block).wdata() }
-    }
-
-    /// Get the SUM registers as a pointer
-    #[inline]
-    fn sum_ptr(&self) -> *const u32 {
-        unsafe { (*self.register_block).sum0() as *const _ as *const u32 }
+        self.device.wdata()
     }
 
     /// Enable or disable byte swapping
@@ -179,8 +144,7 @@ impl Sha256 {
     /// # Safety
     /// The caller must ensure the hardware is ready
     pub unsafe fn put_word(&self, word: u32) {
-        let wdata = self.wdata();
-        wdata.write(|w| w.bits(word));
+        (self.wdata() as *const _ as *mut u32).write_volatile(word);
     }
 
     /// Write one byte to the hardware
@@ -188,15 +152,7 @@ impl Sha256 {
     /// # Safety
     /// The caller must ensure the hardware is ready
     pub unsafe fn put_byte(&self, byte: u8) {
-        let wdata_ptr = self.wdata() as *const _ as *mut u8;
-        wdata_ptr.write_volatile(byte);
-    }
-
-    /// Check for "not ready" error
-    ///
-    /// Returns `true` if data was written when the hardware was not ready.
-    pub fn err_not_ready(&self) -> bool {
-        self.csr().read().err_wdata_not_rdy().bit()
+        (self.wdata() as *const _ as *mut u8).write_volatile(byte);
     }
 
     /// Clear "not ready" error.
@@ -205,19 +161,12 @@ impl Sha256 {
             .modify(|_, w| w.err_wdata_not_rdy().clear_bit_by_one());
     }
 
-    /// Read the CSR register value for debugging.
-    #[allow(dead_code)]
-    fn read_csr(&self) -> u32 {
-        self.csr().read().bits()
-    }
-
     /// Read the 256-bit hash result
     ///
     /// # Safety
     /// The caller must ensure the result is valid.
     pub unsafe fn get_result(&self) -> [u32; 8] {
-        let sum_ptr = self.sum_ptr();
-        core::ptr::read_unaligned(sum_ptr as *const [u32; 8])
+        (self.device.sum0() as *const _ as *const [u32; 8]).read_volatile()
     }
 }
 
@@ -239,8 +188,8 @@ impl Sha256 {
 /// state.start(&mut sha256, Endianness::Big);
 ///
 /// // Hash data in chunks
-/// state.update_blocking(&mut sha256, b"Hello, ");
-/// state.update_blocking(&mut sha256, b"World!");
+/// state.update(&mut sha256, b"Hello, ");
+/// state.update(&mut sha256, b"World!");
 ///
 /// let result = state.finish(&mut sha256);
 /// ```
@@ -249,7 +198,6 @@ pub struct Sha256State {
     total_data_size: usize,
     cache: [u8; 4],
     cache_used: u8,
-    _marker: PhantomData<()>,
 }
 
 impl Default for Sha256State {
@@ -266,7 +214,6 @@ impl Sha256State {
             total_data_size: 0,
             cache: [0; 4],
             cache_used: 0,
-            _marker: PhantomData,
         }
     }
 
@@ -279,6 +226,7 @@ impl Sha256State {
         self.endianness = endianness;
         self.total_data_size = 0;
         self.cache_used = 0;
+        self.cache = [0; 4];
 
         sha256.set_bswap(endianness == Endianness::Big);
         sha256.start();
@@ -286,12 +234,13 @@ impl Sha256State {
 
     /// Update hash with data (non-blocking)
     ///
-    /// This method writes data to the hardware as quickly as possible.
-    /// Any unaligned bytes are cached for the next update call.
+    /// It only uses 32-bit writes; if the data passed to it is not a
+    /// multiple of 4 bytes, left over (unaligned) bytes will be cached
+    /// for the next update() or will be flushed during finish().
     ///
     /// # Note
-    /// This does not wait for the hardware to be ready between writes.
-    /// Use `update_blocking()` for simpler code that handles readiness automatically.
+    /// This function will block until the SHA256 peripheral is ready
+    /// to have data written to it.
     pub fn update(&mut self, sha256: &mut Sha256, data: &[u8]) {
         let mut pos = 0;
 
@@ -312,28 +261,20 @@ impl Sha256State {
         }
 
         while pos + 4 <= data.len() {
-            sha256.wait_ready_blocking();
-
             let word = u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+            sha256.wait_ready_blocking();
             unsafe { sha256.put_word(word) };
             pos += 4;
         }
 
         while pos < data.len() {
+            // copy any unaligned bytes to cache
             self.cache[self.cache_used as usize] = data[pos];
             self.cache_used += 1;
             pos += 1;
         }
 
         self.total_data_size += data.len();
-    }
-
-    /// Update hash with data (blocking)
-    ///
-    /// This method waits for the hardware to be ready before each write,
-    /// ensuring no data is lost.
-    pub fn update_blocking(&mut self, sha256: &mut Sha256, data: &[u8]) {
-        self.update(sha256, data);
     }
 
     /// Finalize the hash and return the result
@@ -345,35 +286,7 @@ impl Sha256State {
     ///
     /// Then waits for the hash to complete and returns the 32-byte result.
     pub fn finish(&mut self, sha256: &mut Sha256) -> Sha256Result {
-        if self.total_data_size == 0 && self.cache_used == 0 {
-            sha256.wait_ready_blocking();
-            unsafe { sha256.put_word(0x00000080) };
-
-            for _ in 0..13 {
-                sha256.wait_ready_blocking();
-                unsafe { sha256.put_word(0) };
-            }
-
-            sha256.wait_ready_blocking();
-            unsafe { sha256.put_word(0) };
-            sha256.wait_ready_blocking();
-            unsafe { sha256.put_word(0) };
-
-            sha256.wait_valid_blocking();
-
-            let result_words = unsafe { sha256.get_result() };
-            let mut result = [0u8; 32];
-            for i in 0..8 {
-                let bytes = result_words[i].to_be_bytes();
-                result[i * 4] = bytes[0];
-                result[i * 4 + 1] = bytes[1];
-                result[i * 4 + 2] = bytes[2];
-                result[i * 4 + 3] = bytes[3];
-            }
-
-            return result;
-        }
-
+        // flush remaining bytes in cache
         for i in 0..self.cache_used {
             sha256.wait_ready_blocking();
             unsafe { sha256.put_byte(self.cache[i as usize]) };

--- a/rp235x-hal/src/sha256.rs
+++ b/rp235x-hal/src/sha256.rs
@@ -10,9 +10,6 @@
 //!
 //! - Hardware-accelerated SHA-256 hashing
 //! - Supports both big-endian and little-endian data
-//! - Byte swapping for proper SHA-256 format
-//! - DMA support for large data transfers (via DREQ_SHA256)
-//! - Error detection and recovery
 //!
 //! ## Basic Usage
 //!
@@ -36,11 +33,6 @@
 //!
 //! // result is a 32-byte SHA-256 hash
 //! ```
-//!
-//! ## NIST Test Vectors
-//!
-//! - SHA256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-//! - SHA256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
 
 use crate::pac::sha256;
 use crate::pac::SHA256;


### PR DESCRIPTION
Hello rp-rs! 👋

We added an implementation of the SHA256 hasher peripheral.

## Basic Usage
```no_run
use rp235x_hal::{pac, sha256::{Sha256, Sha256State, Endianness}};

let mut peripherals = pac::Peripherals::take().unwrap();

// Initialize SHA256 peripheral (no reset needed)
let mut sha256 = Sha256::new(peripherals.SHA256);

// Create hasher state
let mut state = Sha256State::new();

 // Compute hash
let data = b"Hello, World!";
state.start(&mut sha256, Endianness::Big);
state.update_blocking(&mut sha256, data);
let result = state.finish(&mut sha256);

// result is a 32-byte SHA-256 hash
```

Validated against x86_64 `sha256sum` on test vectors: empty string, "abc", "abcdef...", "A" x65, "hello world".

Output from `cargo flash --bin sha256_test` as of  e56c3b9:
```
Starting SHA256 example on UART0
Test 1 (empty): PASS
Test 2 (abc): PASS
Test 3 (long): PASS
Test 4 (multi-block): PASS
Test 5 (incremental): PASS
All tests passed.
```

DMA of blocks to the hasher is not yet implemented.

pico-sdk reference:
https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_sha256/include/hardware/sha256.h

