### PR TITLE
Fix MSRV check on CI

### DIFF
--- a/.github/workflows/on_target_tests.yml
+++ b/.github/workflows/on_target_tests.yml
@@ -38,6 +38,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: thumbv6m-none-eabi
       - name: Install cargo-hack

--- a/.github/workflows/rp2040_hal.yml
+++ b/.github/workflows/rp2040_hal.yml
@@ -61,13 +61,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: ${{ env.TARGET }}
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
-      - name: Use older version of regex
-        run: cd ${PACKAGE}-examples && cargo update -p regex --precise 1.9.3
       - name: Build rp2040-hal (on MSRV)
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature --target=${TARGET}
       - name: Build rp2040-hal-macros (on MSRV)

--- a/.github/workflows/rp2040_hal_examples.yml
+++ b/.github/workflows/rp2040_hal_examples.yml
@@ -41,10 +41,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: ${{ env.TARGET }}
-      - name: Use older version of regex
-        run: cd ${PACKAGE} && cargo update -p regex --precise 1.9.3
       - name: Build on MSRV
         run: cd ${PACKAGE} && cargo build 
   fmt:

--- a/.github/workflows/rp235x_hal_arm.yml
+++ b/.github/workflows/rp235x_hal_arm.yml
@@ -61,13 +61,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: ${{ env.TARGET }}
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
-      - name: Use older version of regex
-        run: cd ${PACKAGE}-examples && cargo update -p regex --precise 1.9.3
       - name: Build rp235x-hal (on MSRV)
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature --target=${TARGET}
       - name: Build rp235x-hal-macros (on MSRV)

--- a/.github/workflows/rp235x_hal_examples_arm.yml
+++ b/.github/workflows/rp235x_hal_examples_arm.yml
@@ -41,10 +41,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: ${{ env.TARGET }}
-      - name: Use older version of regex
-        run: cd ${PACKAGE} && cargo update -p regex --precise 1.9.3
       - name: Build on MSRV
         run: cd ${PACKAGE} && cargo build --target=${TARGET}
   fmt:

--- a/.github/workflows/rp235x_hal_examples_riscv.yml
+++ b/.github/workflows/rp235x_hal_examples_riscv.yml
@@ -25,10 +25,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: ${{ env.TARGET }}
-      - name: Use older version of regex
-        run: cd ${PACKAGE} && cargo update -p regex --precise 1.9.3
       - name: Build on MSRV
         run: |
           cd ${PACKAGE}

--- a/.github/workflows/rp235x_hal_riscv.yml
+++ b/.github/workflows/rp235x_hal_riscv.yml
@@ -61,13 +61,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
           target: ${{ env.TARGET }}
       - name: Install cargo-hack
         run: |
           curl -sSL https://github.com/taiki-e/cargo-hack/releases/download/v0.6.17/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xvzf - -C ~/.cargo/bin
-      - name: Use older version of regex
-        run: cd ${PACKAGE}-examples && cargo update -p regex --precise 1.9.3
       - name: Build rp235x-hal (on MSRV)
         run: cd ${PACKAGE} && cargo hack build --optional-deps --each-feature --target=${TARGET}
       - name: Build rp235x-hal-macros (on MSRV)

--- a/.github/workflows/rp_binary_info.yml
+++ b/.github/workflows/rp_binary_info.yml
@@ -47,6 +47,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
       - name: Install cargo-hack
         run: |

--- a/.github/workflows/rp_hal_common.yml
+++ b/.github/workflows/rp_hal_common.yml
@@ -47,6 +47,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Prepare Cargo.lock compatible with MSRV
+        run: cd ${PACKAGE} && CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+      - uses: dtolnay/rust-toolchain@master
+        with:
           toolchain: 1.82
       - name: Install cargo-hack
         run: |

--- a/on-target-tests/Cargo.toml
+++ b/on-target-tests/Cargo.toml
@@ -7,6 +7,7 @@ name = "on-target-tests"
 publish = false
 readme = "README.md"
 repository = "https://github.com/rp-rs/rp-hal"
+rust-version = "1.82"
 version = "0.1.0"
 
 [[test]]


### PR DESCRIPTION
Approach:
- First, create a Cargo.lock using the stable version of cargo, using the `resolver.incompatible-rust-versions=fallback` setting. That ensures that, if possible, only dependencies compatible with the declared rust-version (currently: 1.82) are installed
- Then, run the actual checks using version 1.82

This way, we can leverage the new resolver (available since cargo 1.84) without bumping our MSRV.