### PR TITLE
powman: add set_vreg_voltage, get_vreg_voltage, VRegVoltage enum

### DIFF
--- a/rp235x-hal/src/lib.rs
+++ b/rp235x-hal/src/lib.rs
@@ -70,6 +70,7 @@ pub mod typelevel;
 pub mod uart;
 pub mod usb;
 pub mod vector_table;
+pub mod vreg;
 pub mod watchdog;
 pub mod xh3irq;
 pub mod xosc;

--- a/rp235x-hal/src/powman.rs
+++ b/rp235x-hal/src/powman.rs
@@ -206,6 +206,14 @@ pub enum ClockPin {
     Pin22(Pin<Gpio22, FunctionSioInput, DynPullType>),
 }
 
+/// The ways in which setting the regulator voltage can fail
+pub enum VRegError {
+    /// The voltage value read back from POWMAN did not match the value written
+    VRegReadbackMismatchError,
+    /// The voltage value read back from POWMAN could not be converted to a VRegVoltage
+    VRegVoltageConversionError,
+}
+
 /// The Power Management device
 pub struct Powman {
     device: pac::POWMAN,
@@ -608,7 +616,7 @@ impl Powman {
     }
 
     /// Set the VREG voltage.
-    pub fn set_vreg_voltage(&mut self, voltage: VRegVoltage) {
+    pub fn set_vreg_voltage(&mut self, voltage: VRegVoltage) -> Result<(), VRegError> {
         // Unlock VREG_CTRL and release reset
         self.device.vreg_ctrl().modify(|_r, w| {
             unsafe {
@@ -641,6 +649,19 @@ impl Powman {
         // Wait for voltage to stabilize
         while self.device.vreg_sts().read().vout_ok().bit_is_clear() {
             core::hint::spin_loop();
+        }
+
+        // Read back the voltage and return an Err if the requested voltage
+        // was not successfully read back as having been properly set.
+        match VRegVoltage::try_from(self.device.vreg().read().vsel().bits()) {
+            Ok(set_voltage) => {
+                if set_voltage != voltage {
+                    Err(VRegError::VRegReadbackMismatchError)
+                } else {
+                    Ok(())
+                }
+            }
+            Err(InvalidVRegVoltageError) => Err(VRegError::VRegVoltageConversionError),
         }
     }
 

--- a/rp235x-hal/src/powman.rs
+++ b/rp235x-hal/src/powman.rs
@@ -18,7 +18,7 @@ use crate::{
         DynPullType, FunctionSioInput, Pin,
     },
     pac,
-    vreg::VRegVoltage,
+    vreg::{InvalidVRegVoltageError, VRegVoltage},
 };
 
 /// A frequency in kHz, represented as a fixed point 16.16 value
@@ -645,8 +645,8 @@ impl Powman {
     }
 
     /// Get the current VREG voltage.
-    pub fn get_vreg_voltage(&self) -> Option<VRegVoltage> {
-        VRegVoltage::from_vsel_bits(self.device.vreg().read().vsel().bits())
+    pub fn get_vreg_voltage(&self) -> Result<VRegVoltage, InvalidVRegVoltageError> {
+        VRegVoltage::try_from(self.device.vreg().read().vsel().bits())
     }
 
     /// Write to a POWMAN protected register, using the key

--- a/rp235x-hal/src/powman.rs
+++ b/rp235x-hal/src/powman.rs
@@ -3,7 +3,7 @@
 //! The POWMAN peripheral contains a mixture of functionality, including:
 //!
 //! * [x] An always-on timer (AOT) with alarm
-//! * [ ] Voltage Regulator Control
+//! * [x] Voltage Regulator Control
 //! * [ ] Brown-out detection
 //! * [ ] Low-power oscillator control
 //! * [ ] Using as GPIO as a time reference or wake-up signal
@@ -18,6 +18,7 @@ use crate::{
         DynPullType, FunctionSioInput, Pin,
     },
     pac,
+    vreg::VRegVoltage,
 };
 
 /// A frequency in kHz, represented as a fixed point 16.16 value
@@ -604,6 +605,48 @@ impl Powman {
         unsafe {
             Self::powman_set_bits(reg, bit as u16);
         }
+    }
+
+    /// Set the VREG voltage.
+    pub fn set_vreg_voltage(&mut self, voltage: VRegVoltage) {
+        // Unlock VREG_CTRL and release reset
+        self.device.vreg_ctrl().modify(|_r, w| {
+            unsafe {
+                w.bits(Self::KEY_VALUE);
+                w.unlock().set_bit();
+                w.rst_n().set_bit();
+            }
+            w
+        });
+
+        // Wait for update to complete
+        while self.device.vreg().read().update_in_progress().bit_is_set() {
+            core::hint::spin_loop();
+        }
+
+        // Set the voltage
+        self.device.vreg().modify(|_r, w| {
+            unsafe {
+                w.bits(Self::KEY_VALUE);
+                w.vsel().bits(voltage as u8);
+            }
+            w
+        });
+
+        // Wait for update to complete
+        while self.device.vreg().read().update_in_progress().bit_is_set() {
+            core::hint::spin_loop();
+        }
+
+        // Wait for voltage to stabilize
+        while self.device.vreg_sts().read().vout_ok().bit_is_clear() {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Get the current VREG voltage.
+    pub fn get_vreg_voltage(&self) -> Option<VRegVoltage> {
+        VRegVoltage::from_vsel_bits(self.device.vreg().read().vsel().bits())
     }
 
     /// Write to a POWMAN protected register, using the key

--- a/rp235x-hal/src/vreg.rs
+++ b/rp235x-hal/src/vreg.rs
@@ -1,0 +1,111 @@
+//! VREG voltage control types.
+
+/// Voltage selection for the on-chip VREG.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VRegVoltage {
+    /// 0.55V
+    V550mV = 0b00000,
+    /// 0.60V
+    V600mV = 0b00001,
+    /// 0.65V
+    V650mV = 0b00010,
+    /// 0.70V
+    V700mV = 0b00011,
+    /// 0.75V
+    V750mV = 0b00100,
+    /// 0.80V
+    V800mV = 0b00101,
+    /// 0.85V
+    V850mV = 0b00110,
+    /// 0.90V
+    V900mV = 0b00111,
+    /// 0.95V
+    V950mV = 0b01000,
+    /// 1.00V
+    V1000mV = 0b01001,
+    /// 1.05V
+    V1050mV = 0b01010,
+    /// 1.10V (default)
+    V1100mV = 0b01011,
+    /// 1.15V
+    V1150mV = 0b01100,
+    /// 1.20V
+    V1200mV = 0b01101,
+    /// 1.25V
+    V1250mV = 0b01110,
+    /// 1.30V
+    V1300mV = 0b01111,
+    /// 1.35V
+    V1350mV = 0b10000,
+    /// 1.40V
+    V1400mV = 0b10001,
+    /// 1.50V
+    V1500mV = 0b10010,
+    /// 1.60V
+    V1600mV = 0b10011,
+    /// 1.65V
+    V1650mV = 0b10100,
+    /// 1.70V
+    V1700mV = 0b10101,
+    /// 1.80V
+    V1800mV = 0b10110,
+    /// 1.90V
+    V1900mV = 0b10111,
+    /// 2.00V
+    V2000mV = 0b11000,
+    /// 2.35V
+    V2350mV = 0b11001,
+    /// 2.50V
+    V2500mV = 0b11010,
+    /// 2.65V
+    V2650mV = 0b11011,
+    /// 2.80V
+    V2800mV = 0b11100,
+    /// 3.00V
+    V3000mV = 0b11101,
+    /// 3.15V
+    V3150mV = 0b11110,
+    /// 3.30V
+    V3300mV = 0b11111,
+}
+
+impl VRegVoltage {
+    /// Convert from raw register value to [`VRegVoltage`].
+    pub fn from_vsel_bits(bits: u8) -> Option<Self> {
+        match bits {
+            0b00000 => Some(VRegVoltage::V550mV),
+            0b00001 => Some(VRegVoltage::V600mV),
+            0b00010 => Some(VRegVoltage::V650mV),
+            0b00011 => Some(VRegVoltage::V700mV),
+            0b00100 => Some(VRegVoltage::V750mV),
+            0b00101 => Some(VRegVoltage::V800mV),
+            0b00110 => Some(VRegVoltage::V850mV),
+            0b00111 => Some(VRegVoltage::V900mV),
+            0b01000 => Some(VRegVoltage::V950mV),
+            0b01001 => Some(VRegVoltage::V1000mV),
+            0b01010 => Some(VRegVoltage::V1050mV),
+            0b01011 => Some(VRegVoltage::V1100mV),
+            0b01100 => Some(VRegVoltage::V1150mV),
+            0b01101 => Some(VRegVoltage::V1200mV),
+            0b01110 => Some(VRegVoltage::V1250mV),
+            0b01111 => Some(VRegVoltage::V1300mV),
+            0b10000 => Some(VRegVoltage::V1350mV),
+            0b10001 => Some(VRegVoltage::V1400mV),
+            0b10010 => Some(VRegVoltage::V1500mV),
+            0b10011 => Some(VRegVoltage::V1600mV),
+            0b10100 => Some(VRegVoltage::V1650mV),
+            0b10101 => Some(VRegVoltage::V1700mV),
+            0b10110 => Some(VRegVoltage::V1800mV),
+            0b10111 => Some(VRegVoltage::V1900mV),
+            0b11000 => Some(VRegVoltage::V2000mV),
+            0b11001 => Some(VRegVoltage::V2350mV),
+            0b11010 => Some(VRegVoltage::V2500mV),
+            0b11011 => Some(VRegVoltage::V2650mV),
+            0b11100 => Some(VRegVoltage::V2800mV),
+            0b11101 => Some(VRegVoltage::V3000mV),
+            0b11110 => Some(VRegVoltage::V3150mV),
+            0b11111 => Some(VRegVoltage::V3300mV),
+            _ => None,
+        }
+    }
+}

--- a/rp235x-hal/src/vreg.rs
+++ b/rp235x-hal/src/vreg.rs
@@ -69,43 +69,48 @@ pub enum VRegVoltage {
     V3300mV = 0b11111,
 }
 
-impl VRegVoltage {
+/// Only binary values representable in five bits or less correspond
+/// to possible voltage settings of VSEL on RP235x.
+pub struct InvalidVRegVoltageError;
+
+impl TryFrom<u8> for VRegVoltage {
+    type Error = InvalidVRegVoltageError;
     /// Convert from raw register value to [`VRegVoltage`].
-    pub fn from_vsel_bits(bits: u8) -> Option<Self> {
+    fn try_from(bits: u8) -> Result<Self, InvalidVRegVoltageError> {
         match bits {
-            0b00000 => Some(VRegVoltage::V550mV),
-            0b00001 => Some(VRegVoltage::V600mV),
-            0b00010 => Some(VRegVoltage::V650mV),
-            0b00011 => Some(VRegVoltage::V700mV),
-            0b00100 => Some(VRegVoltage::V750mV),
-            0b00101 => Some(VRegVoltage::V800mV),
-            0b00110 => Some(VRegVoltage::V850mV),
-            0b00111 => Some(VRegVoltage::V900mV),
-            0b01000 => Some(VRegVoltage::V950mV),
-            0b01001 => Some(VRegVoltage::V1000mV),
-            0b01010 => Some(VRegVoltage::V1050mV),
-            0b01011 => Some(VRegVoltage::V1100mV),
-            0b01100 => Some(VRegVoltage::V1150mV),
-            0b01101 => Some(VRegVoltage::V1200mV),
-            0b01110 => Some(VRegVoltage::V1250mV),
-            0b01111 => Some(VRegVoltage::V1300mV),
-            0b10000 => Some(VRegVoltage::V1350mV),
-            0b10001 => Some(VRegVoltage::V1400mV),
-            0b10010 => Some(VRegVoltage::V1500mV),
-            0b10011 => Some(VRegVoltage::V1600mV),
-            0b10100 => Some(VRegVoltage::V1650mV),
-            0b10101 => Some(VRegVoltage::V1700mV),
-            0b10110 => Some(VRegVoltage::V1800mV),
-            0b10111 => Some(VRegVoltage::V1900mV),
-            0b11000 => Some(VRegVoltage::V2000mV),
-            0b11001 => Some(VRegVoltage::V2350mV),
-            0b11010 => Some(VRegVoltage::V2500mV),
-            0b11011 => Some(VRegVoltage::V2650mV),
-            0b11100 => Some(VRegVoltage::V2800mV),
-            0b11101 => Some(VRegVoltage::V3000mV),
-            0b11110 => Some(VRegVoltage::V3150mV),
-            0b11111 => Some(VRegVoltage::V3300mV),
-            _ => None,
+            0b00000 => Ok(VRegVoltage::V550mV),
+            0b00001 => Ok(VRegVoltage::V600mV),
+            0b00010 => Ok(VRegVoltage::V650mV),
+            0b00011 => Ok(VRegVoltage::V700mV),
+            0b00100 => Ok(VRegVoltage::V750mV),
+            0b00101 => Ok(VRegVoltage::V800mV),
+            0b00110 => Ok(VRegVoltage::V850mV),
+            0b00111 => Ok(VRegVoltage::V900mV),
+            0b01000 => Ok(VRegVoltage::V950mV),
+            0b01001 => Ok(VRegVoltage::V1000mV),
+            0b01010 => Ok(VRegVoltage::V1050mV),
+            0b01011 => Ok(VRegVoltage::V1100mV),
+            0b01100 => Ok(VRegVoltage::V1150mV),
+            0b01101 => Ok(VRegVoltage::V1200mV),
+            0b01110 => Ok(VRegVoltage::V1250mV),
+            0b01111 => Ok(VRegVoltage::V1300mV),
+            0b10000 => Ok(VRegVoltage::V1350mV),
+            0b10001 => Ok(VRegVoltage::V1400mV),
+            0b10010 => Ok(VRegVoltage::V1500mV),
+            0b10011 => Ok(VRegVoltage::V1600mV),
+            0b10100 => Ok(VRegVoltage::V1650mV),
+            0b10101 => Ok(VRegVoltage::V1700mV),
+            0b10110 => Ok(VRegVoltage::V1800mV),
+            0b10111 => Ok(VRegVoltage::V1900mV),
+            0b11000 => Ok(VRegVoltage::V2000mV),
+            0b11001 => Ok(VRegVoltage::V2350mV),
+            0b11010 => Ok(VRegVoltage::V2500mV),
+            0b11011 => Ok(VRegVoltage::V2650mV),
+            0b11100 => Ok(VRegVoltage::V2800mV),
+            0b11101 => Ok(VRegVoltage::V3000mV),
+            0b11110 => Ok(VRegVoltage::V3150mV),
+            0b11111 => Ok(VRegVoltage::V3300mV),
+            _ => Err(InvalidVRegVoltageError),
         }
     }
 }


### PR DESCRIPTION
changed: rp235x-hal/src/lib.rs, rp235x-hal/src/powman.rs
added: rp235x-hal/src/vreg.rs

Borrowed from @Altaflux example: https://github.com/Altaflux/gb-rp2350/blob/5c089fc386ad599193e4101f31e2d71d39146cd2/src/main.rs#L144

Tested on RP2350A2.