### PR TITLE
Add a method to expose the number of transfer remaining during DMA

### DIFF
--- a/rp2040-hal/src/dma/bidirectional.rs
+++ b/rp2040-hal/src/dma/bidirectional.rs
@@ -157,4 +157,10 @@ where
         // TODO: Use a tuple type?
         ((self.ch.0, self.ch.1), self.from, self.bidi, self.to)
     }
+
+    /// Count the number of transfers remaining.
+    pub fn trans_count(&self) -> (usize,usize) {
+        (self.ch.0.ch().ch_trans_count().read().bits() as usize,
+         self.ch.1.ch().ch_trans_count().read().bits() as usize)
+    }
 }

--- a/rp2040-hal/src/dma/bidirectional.rs
+++ b/rp2040-hal/src/dma/bidirectional.rs
@@ -159,8 +159,10 @@ where
     }
 
     /// Count the number of transfers remaining.
-    pub fn trans_count(&self) -> (usize,usize) {
-        (self.ch.0.ch().ch_trans_count().read().bits() as usize,
-         self.ch.1.ch().ch_trans_count().read().bits() as usize)
+    pub fn trans_count(&self) -> (usize, usize) {
+        (
+            self.ch.0.ch().ch_trans_count().read().bits() as usize,
+            self.ch.1.ch().ch_trans_count().read().bits() as usize,
+        )
     }
 }

--- a/rp2040-hal/src/dma/double_buffer.rs
+++ b/rp2040-hal/src/dma/double_buffer.rs
@@ -136,7 +136,6 @@ where
         }
     }
 
-
     /// Count the number of transfers remaining in the active channel
     pub fn trans_count(&self) -> usize {
         if self.second_ch {
@@ -145,7 +144,6 @@ where
             self.ch.0.ch().ch_trans_count().read().bits() as usize
         }
     }
-
 }
 
 impl<CH1, CH2, FROM, TO, WORD> Transfer<CH1, CH2, FROM, TO, ()>

--- a/rp2040-hal/src/dma/double_buffer.rs
+++ b/rp2040-hal/src/dma/double_buffer.rs
@@ -135,6 +135,17 @@ where
             !self.ch.0.ch().ch_ctrl_trig().read().busy().bit_is_set()
         }
     }
+
+
+    /// Count the number of transfers remaining in the active channel
+    pub fn trans_count(&self) -> usize {
+        if self.second_ch {
+            self.ch.1.ch().ch_trans_count().read().bits() as usize
+        } else {
+            self.ch.0.ch().ch_trans_count().read().bits() as usize
+        }
+    }
+
 }
 
 impl<CH1, CH2, FROM, TO, WORD> Transfer<CH1, CH2, FROM, TO, ()>

--- a/rp2040-hal/src/dma/single_buffer.rs
+++ b/rp2040-hal/src/dma/single_buffer.rs
@@ -113,6 +113,11 @@ where
         (self.ch, self.from, self.to)
     }
 
+    /// Count the number of transfers remaining.
+    pub fn trans_count(&self) -> usize {
+        self.ch.ch().ch_trans_count().read().bits() as usize
+    }
+
     /// Aborts the current transfer, returning the channel and targets
     pub fn abort(mut self) -> (CH, FROM, TO) {
         let irq0_was_enabled = self.ch.is_enabled_irq0();

--- a/rp235x-hal/src/dma/bidirectional.rs
+++ b/rp235x-hal/src/dma/bidirectional.rs
@@ -157,4 +157,12 @@ where
         // TODO: Use a tuple type?
         ((self.ch.0, self.ch.1), self.from, self.bidi, self.to)
     }
+
+    /// Count the number of transfers remaining.
+    pub fn trans_count(&self) -> (usize, usize) {
+        (
+            self.ch.0.ch().ch_trans_count().read().bits() as usize,
+            self.ch.1.ch().ch_trans_count().read().bits() as usize,
+        )
+    }
 }

--- a/rp235x-hal/src/dma/double_buffer.rs
+++ b/rp235x-hal/src/dma/double_buffer.rs
@@ -135,6 +135,15 @@ where
             !self.ch.0.ch().ch_ctrl_trig().read().busy().bit_is_set()
         }
     }
+
+    /// Count the number of transfers remaining in the active channel
+    pub fn trans_count(&self) -> usize {
+        if self.second_ch {
+            self.ch.1.ch().ch_trans_count().read().bits() as usize
+        } else {
+            self.ch.0.ch().ch_trans_count().read().bits() as usize
+        }
+    }
 }
 
 impl<CH1, CH2, FROM, TO, WORD> Transfer<CH1, CH2, FROM, TO, ()>

--- a/rp235x-hal/src/dma/single_buffer.rs
+++ b/rp235x-hal/src/dma/single_buffer.rs
@@ -113,6 +113,11 @@ where
         (self.ch, self.from, self.to)
     }
 
+    /// Count the number of transfers remaining.
+    pub fn trans_count(&self) -> usize {
+        self.ch.ch().ch_trans_count().read().bits() as usize
+    }
+
     /// Aborts the current transfer, returning the channel and targets
     pub fn abort(mut self) -> (CH, FROM, TO) {
         let irq0_was_enabled = self.ch.is_enabled_irq0();


### PR DESCRIPTION
With current hal, during DMA transfer, you can only know if a transfer is finished or not with `Transfer::is_done()`.
However, the rp2040 provides a more fine-grained information with the trans_count register.

With those methods, this information is exposed and can be used to estimate remaining time until the end of the transfer.
