### PR TITLE
Fix future incompatibility warning regarding float bit masks

### DIFF
--- a/rp2040-hal/src/float/conv.rs
+++ b/rp2040-hal/src/float/conv.rs
@@ -123,11 +123,11 @@ intrinsics! {
         if f.is_not_finite() {
             return f64::from_repr(
                 // Not finite
-                f64::EXPONENT_MASK |
+                <f64 as Float>::EXPONENT_MASK |
                 // Preserve NaN or inf
                 ((f.repr() & f32::SIGNIFICAND_MASK) as u64) |
                 // Preserve sign
-                (((f.repr() & f32::SIGN_MASK) as u64) << (<f64 as Float>::BITS-<f32 as Float>::BITS))
+                (((f.repr() & <f32 as Float>::SIGN_MASK) as u64) << (<f64 as Float>::BITS-<f32 as Float>::BITS))
             );
         }
         rom_data::float_funcs::float_to_double(f)
@@ -140,9 +140,9 @@ intrinsics! {
         if f.is_not_finite() {
             let mut repr: u32 =
                 // Not finite
-                f32::EXPONENT_MASK |
+                <f32 as Float>::EXPONENT_MASK |
                 // Preserve sign
-                ((f.repr() & f64::SIGN_MASK) >> (<f64 as Float>::BITS-<f32 as Float>::BITS)) as u32;
+                ((f.repr() & <f64 as Float>::SIGN_MASK) >> (<f64 as Float>::BITS-<f32 as Float>::BITS)) as u32;
             // Set NaN
             if  (f.repr() & f64::SIGNIFICAND_MASK) != 0 {
                 repr |= 1;

--- a/rp2040-hal/src/float/functions.rs
+++ b/rp2040-hal/src/float/functions.rs
@@ -44,7 +44,7 @@ impl ROMFunctions for f32 {
 
     fn to_trig_range(self) -> Self {
         // -128 < X < 128, logic from the Pico SDK
-        let exponent = (self.repr() & Self::EXPONENT_MASK) >> Self::SIGNIFICAND_BITS;
+        let exponent = (self.repr() & <Self as Float>::EXPONENT_MASK) >> Self::SIGNIFICAND_BITS;
         if exponent < 134 {
             self
         } else {
@@ -83,7 +83,7 @@ impl ROMFunctions for f64 {
 
     fn to_trig_range(self) -> Self {
         // -1024 < X < 1024, logic from the Pico SDK
-        let exponent = (self.repr() & Self::EXPONENT_MASK) >> Self::SIGNIFICAND_BITS;
+        let exponent = (self.repr() & <Self as Float>::EXPONENT_MASK) >> Self::SIGNIFICAND_BITS;
         if exponent < 1033 {
             self
         } else {

--- a/rp2040-hal/src/float/mod.rs
+++ b/rp2040-hal/src/float/mod.rs
@@ -124,8 +124,9 @@ macro_rules! float_impl {
             const SIGNIFICAND_BITS: u32 = $significand_bits;
 
             const SIGN_MASK: Self::Int = 1 << (<Self as Float>::BITS - 1);
-            const SIGNIFICAND_MASK: Self::Int = (1 << Self::SIGNIFICAND_BITS) - 1;
-            const EXPONENT_MASK: Self::Int = !(Self::SIGN_MASK | Self::SIGNIFICAND_MASK);
+            const SIGNIFICAND_MASK: Self::Int = (1 << <Self as Float>::SIGNIFICAND_BITS) - 1;
+            const EXPONENT_MASK: Self::Int =
+                !(<Self as Float>::SIGN_MASK | <Self as Float>::SIGNIFICAND_MASK);
 
             fn repr(self) -> Self::Int {
                 self.to_bits()


### PR DESCRIPTION
Fixes clippy warnings like this in beta:

```
warning: an associated constant with this name may be added to the standard library in the future
   --> src/float/mod.rs:128:48
    |
128 |             const EXPONENT_MASK: Self::Int = !(Self::SIGN_MASK | Self::SIGNIFICAND_MASK);
    |                                                ^^^^^^^^^^^^^^^ help: use the fully qualified path to the associated const: `<f32 as float::Float>::SIGN_MASK`
```

See https://github.com/rust-lang/rust/issues/154064

(Similar change was applied with #992)