### PR TITLE
Correct ranges of PLL dividers for both rp2040 and rp235x

### DIFF
--- a/rp2040-hal/src/pll.rs
+++ b/rp2040-hal/src/pll.rs
@@ -143,8 +143,8 @@ impl<D: PhaseLockedLoopDevice> PhaseLockedLoop<Disabled, D> {
         config: PLLConfig,
     ) -> Result<PhaseLockedLoop<Disabled, D>, Error> {
         const VCO_FREQ_RANGE: RangeInclusive<HertzU32> = HertzU32::MHz(750)..=HertzU32::MHz(1_600);
-        const POSTDIV_RANGE: Range<u8> = 1..7;
-        const FBDIV_RANGE: Range<u16> = 16..320;
+        const POSTDIV_RANGE: RangeInclusive<u8> = 1..=7;
+        const FBDIV_RANGE: RangeInclusive<u16> = 16..=320;
 
         let vco_freq = config.vco_freq;
 

--- a/rp235x-hal/src/pll.rs
+++ b/rp235x-hal/src/pll.rs
@@ -146,8 +146,8 @@ impl<D: PhaseLockedLoopDevice> PhaseLockedLoop<Disabled, D> {
         config: PLLConfig,
     ) -> Result<PhaseLockedLoop<Disabled, D>, Error> {
         const VCO_FREQ_RANGE: RangeInclusive<HertzU32> = HertzU32::MHz(400)..=HertzU32::MHz(1_600);
-        const POSTDIV_RANGE: Range<u8> = 1..7;
-        const FBDIV_RANGE: Range<u16> = 16..320;
+        const POSTDIV_RANGE: RangeInclusive<u8> = 1..=7;
+        const FBDIV_RANGE: RangeInclusive<u16> = 16..=320;
 
         let vco_freq = config.vco_freq;
 


### PR DESCRIPTION
Currently in `main` the `POSTDIV` and `FBDIV` divider ranges for both the rp2040 and rp235x PLLs use a noninclusive range. Based on the reference code for calculating these parameters (sections 2.18.2.1 and 8.6.3.2, of their respective datasheets), these should be inclusive ranges on the upper bound.