### PR TITLE
Add a binary info macro for specifying program description from the user's Cargo.toml package description

### DIFF
--- a/rp-binary-info/src/macros.rs
+++ b/rp-binary-info/src/macros.rs
@@ -146,6 +146,19 @@ macro_rules! rp_program_description {
     };
 }
 
+/// Generate a static item containing the `CARGO_PKG_DESCRIPTION` as the program description,
+/// and return its [`EntryAddr`](super::EntryAddr).
+#[macro_export]
+macro_rules! rp_cargo_description {
+    () => {
+        $crate::env!(
+            $crate::consts::TAG_RASPBERRY_PI,
+            $crate::consts::ID_RP_PROGRAM_DESCRIPTION,
+            "CARGO_PKG_DESCRIPTION"
+        )
+    };
+}
+
 /// Generate a static item containing whether this is a debug or a release
 /// build, and return its [`EntryAddr`](super::EntryAddr).
 #[macro_export]


### PR DESCRIPTION
Similarly to the other `rp_program_xxx` & `rp_cargo_xxx` macros: this macro allows for the specification of picotool binary info entries for the program's description expanded from the `CARGO_PKG_DESCRIPTION` environment variable from the user's `Cargo.toml`.