### PR TITLE
Update pio version to 0.4.0

### DIFF
--- a/rp2040-hal-examples/Cargo.toml
+++ b/rp2040-hal-examples/Cargo.toml
@@ -31,7 +31,7 @@ hd44780-driver = {version = "0.4.0", git = "https://github.com/JohnDoneth/hd4478
 nb = "1.0"
 panic-halt = "0.2.0"
 panic-probe = {version = "0.3.1", features = ["print-defmt"]}
-pio = "0.3.0"
+pio = "0.4.0"
 # We aren't using portable-atomic directly in the examples, but some of our dependencies (like static_cell) require atomic CAS so this is needed.
 portable-atomic = {version = "1.7.0", features = ["critical-section"]}
 rp2040-boot2 = "0.3.0"

--- a/rp2040-hal/Cargo.toml
+++ b/rp2040-hal/Cargo.toml
@@ -33,7 +33,7 @@ fugit = "0.3.6"
 itertools = {version = "0.10.1", default-features = false}
 nb = "1.0"
 paste = "1.0"
-pio-core = "0.3.0"
+pio = "0.4"
 rand_core = "0.9.3"
 rp-binary-info = { version = "0.1.2", path = "../rp-binary-info" }
 rp-hal-common = {version="0.1.0", path="../rp-hal-common"}
@@ -51,7 +51,6 @@ rtic-monotonic = {version = "1.0.0", optional = true}
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-pio = "0.3"
 rand = {version = "0.9.1", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.

--- a/rp2040-hal/src/pio.rs
+++ b/rp2040-hal/src/pio.rs
@@ -2,8 +2,8 @@
 //!
 //! See [Chapter 3 of the datasheet](https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf#section_pio) for more details.
 
+use ::pio::{self, Instruction, InstructionOperands, Program, SideSet, Wrap};
 use core::ops::Deref;
-use pio_core::{self as pio, Instruction, InstructionOperands, Program, SideSet, Wrap};
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},

--- a/rp235x-hal-examples/Cargo.toml
+++ b/rp235x-hal-examples/Cargo.toml
@@ -31,7 +31,7 @@ hd44780-driver = { version = "0.4.0", git = "https://github.com/JohnDoneth/hd447
 heapless = "0.8.0"
 nb = "1.0"
 panic-halt = "0.2.0"
-pio = "0.3.0"
+pio = "0.4.0"
 rp235x-hal = {path = "../rp235x-hal", version = "0.4.0", features = ["binary-info", "critical-section-impl", "rt", "defmt"]}
 usb-device = "0.3.2"
 usbd-serial = "0.2.2"

--- a/rp235x-hal/Cargo.toml
+++ b/rp235x-hal/Cargo.toml
@@ -33,7 +33,7 @@ gcd = ">=2.1,<3.0"
 itertools = {version = "0.13.0", default-features = false}
 nb = "1.0"
 paste = "1.0"
-pio-core = "0.3.0"
+pio = "0.4"
 rand_core = "0.10.0"
 rp-binary-info = {version = "0.1.2", path = "../rp-binary-info"}
 rp-hal-common = {version = "0.1.0", path = "../rp-hal-common"}
@@ -59,7 +59,6 @@ riscv-rt = "0.12"
 
 [dev-dependencies]
 # Non-optional dependencies. Keep these sorted by name.
-pio = "0.3"
 rand = {version = "0.9.1", default-features = false}
 
 # Optional dependencies. Keep these sorted by name.

--- a/rp235x-hal/src/pio.rs
+++ b/rp235x-hal/src/pio.rs
@@ -3,8 +3,8 @@
 //! See [Chapter 11](https://rptl.io/rp2350-datasheet#section_pio) of the RP2350
 //! datasheet for more details.
 
+use ::pio::{self, Instruction, InstructionOperands, Program, SideSet, Wrap};
 use core::ops::Deref;
-use pio_core::{self as pio, Instruction, InstructionOperands, Program, SideSet, Wrap};
 
 use crate::{
     atomic_register_access::{write_bitmask_clear, write_bitmask_set},


### PR DESCRIPTION
Update to pio 0.4.0 since it was just released.
Dropped pio_core as a dependency.
Need to think about if we want to re-export it like embassy-rp does, and what we would call it (since `pio` is already taken by the hal).
I guess we could just do a re-export of the re-export?